### PR TITLE
Add Skulk/Rebuild strategy

### DIFF
--- a/dominion/strategy/strategies/skulk_rebuild.py
+++ b/dominion/strategy/strategies/skulk_rebuild.py
@@ -1,0 +1,47 @@
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+class SkulkRebuildStrategy(EnhancedStrategy):
+    """Strategy for Forager/Skulk/Rebuild board."""
+
+    def __init__(self):
+        super().__init__()
+        self.name = "SkulkRebuild"
+        self.description = "Trash with Forager, gain Gold via Skulk, and score with Rebuild"
+        self.version = "1.0"
+
+        # Gain priorities
+        self.gain_priority = [
+            PriorityRule("Province", PriorityRule.can_afford(8)),
+            PriorityRule("Rebuild", "my.count(Rebuild) < 3"),
+            PriorityRule("Duchy", ""),
+            PriorityRule("Skulk", PriorityRule.can_afford(4)),
+            PriorityRule("Forager", "my.count(Forager) < 1"),
+            PriorityRule("Gold", PriorityRule.can_afford(6)),
+            PriorityRule("Silver", PriorityRule.can_afford(3)),
+            PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),
+            PriorityRule("Copper"),
+        ]
+
+        # Action priorities
+        self.action_priority = [
+            PriorityRule("Rebuild"),
+            PriorityRule("Forager"),
+            PriorityRule("Skulk"),
+        ]
+
+        # Trash priorities
+        self.trash_priority = [
+            PriorityRule("Curse"),
+            PriorityRule("Estate"),
+            PriorityRule("Copper"),
+        ]
+
+        # Treasure play order
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+def create_skulk_rebuild() -> EnhancedStrategy:
+    return SkulkRebuildStrategy()

--- a/dominion/strategy/strategies/skulk_rebuild.yaml
+++ b/dominion/strategy/strategies/skulk_rebuild.yaml
@@ -1,0 +1,34 @@
+metadata:
+  name: SkulkRebuild
+  description: Forager + Skulk opening, gain Rebuilds for Duchy rush
+  version: "1.0"
+actionPriority:
+  - card: Rebuild
+  - card: Forager
+  - card: Skulk
+gainPriority:
+  - card: Province
+    condition: my.coins >= 8
+  - card: Rebuild
+    condition: my.count(Rebuild) < 3
+  - card: Duchy
+  - card: Skulk
+    condition: my.coins >= 4
+  - card: Forager
+    condition: my.count(Forager) < 1
+  - card: Gold
+    condition: my.coins >= 6
+  - card: Silver
+    condition: my.coins >= 3
+  - card: Estate
+    condition: state.provinces_left <= 2
+  - card: Copper
+
+treasurePriority:
+  - card: Gold
+  - card: Silver
+  - card: Copper
+trashPriority:
+  - card: Curse
+  - card: Estate
+  - card: Copper


### PR DESCRIPTION
## Summary
- add SkulkRebuild strategy in Python
- provide matching YAML strategy file

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dbc6bd32c8327ae167e255be4cc5c