### PR TITLE
Add HTML report utilities

### DIFF
--- a/compare_skulk_strategies.py
+++ b/compare_skulk_strategies.py
@@ -1,0 +1,37 @@
+"""Run Skulk Rebuild strategies and produce an HTML report."""
+
+from pathlib import Path
+
+from dominion.reporting.html_report import generate_html_report
+from dominion.simulation.strategy_battle import StrategyBattle
+
+
+def main():
+    kingdom_cards = [
+        "Village",
+        "Smithy",
+        "Market",
+        "Festival",
+        "Laboratory",
+        "Mine",
+        "Witch",
+        "Moat",
+        "Workshop",
+        "Chapel",
+    ]
+
+    battle = StrategyBattle(kingdom_cards)
+
+    # Reduce logging to keep console output clean
+    battle.logger.log_frequency = 1000
+
+    results = battle.run_battle(
+        "Skulk Rebuild", "Skulk Rebuild Improved", num_games=100
+    )
+
+    generate_html_report(results, Path("skulk_report.html"))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/dominion/reporting/__init__.py
+++ b/dominion/reporting/__init__.py
@@ -1,0 +1,5 @@
+"""Reporting utilities for Dominion simulations."""
+
+from .html_report import generate_html_report
+
+__all__ = ["generate_html_report"]

--- a/dominion/reporting/html_report.py
+++ b/dominion/reporting/html_report.py
@@ -1,0 +1,99 @@
+"""Utility functions for generating HTML reports."""
+
+from __future__ import annotations
+
+import base64
+import io
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+
+def fig_to_base64(fig: plt.Figure) -> str:
+    """Convert a matplotlib figure to a base64 encoded PNG."""
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", bbox_inches="tight")
+    buf.seek(0)
+    return base64.b64encode(buf.read()).decode("ascii")
+
+
+def generate_html_report(results: dict, output_path: Path) -> None:
+    """Create an HTML report summarizing battle results."""
+    strat1 = results["strategy1_name"]
+    strat2 = results["strategy2_name"]
+
+    turns1 = [
+        g["turns"]
+        for g in results["detailed_results"]
+        if g["winner"] == strat1
+    ]
+    turns2 = [
+        g["turns"]
+        for g in results["detailed_results"]
+        if g["winner"] == strat2
+    ]
+
+    margin1 = [
+        g["margin"]
+        for g in results["detailed_results"]
+        if g["winner"] == strat1
+    ]
+    margin2 = [
+        g["margin"]
+        for g in results["detailed_results"]
+        if g["winner"] == strat2
+    ]
+
+    # Histogram of turns taken when each strategy wins
+    fig1, ax1 = plt.subplots()
+    bins = range(min(turns1 + turns2), max(turns1 + turns2) + 2)
+    ax1.hist(turns1, bins=bins, alpha=0.5, label=strat1)
+    ax1.hist(turns2, bins=bins, alpha=0.5, label=strat2)
+    ax1.set_xlabel("Turns to finish")
+    ax1.set_ylabel("Games")
+    ax1.set_title("Game length when each strategy wins")
+    ax1.legend()
+    turn_hist = fig_to_base64(fig1)
+    plt.close(fig1)
+
+    # Bar chart of overall wins
+    fig2, ax2 = plt.subplots()
+    ax2.bar([strat1, strat2], [results["strategy1_wins"], results["strategy2_wins"]])
+    ax2.set_ylabel("Wins")
+    ax2.set_title("Total Wins")
+    win_bar = fig_to_base64(fig2)
+    plt.close(fig2)
+
+    # Histogram of victory margin
+    fig3, ax3 = plt.subplots()
+    if margin1 and margin2:
+        margin_bins = range(0, max(margin1 + margin2) + 2)
+    else:
+        margin_bins = range(0, 2)
+    ax3.hist(margin1, bins=margin_bins, alpha=0.5, label=strat1)
+    ax3.hist(margin2, bins=margin_bins, alpha=0.5, label=strat2)
+    ax3.set_xlabel("Victory Margin")
+    ax3.set_ylabel("Games")
+    ax3.set_title("Margin of Victory")
+    ax3.legend()
+    margin_hist = fig_to_base64(fig3)
+    plt.close(fig3)
+
+    html = f"""
+    <html>
+    <head><title>Skulk Strategy Comparison</title></head>
+    <body>
+    <h1>Skulk Strategy Comparison</h1>
+    <p>Games played: {results['games_played']}</p>
+    <h2>Win Counts</h2>
+    <img src="data:image/png;base64,{win_bar}" />
+    <h2>Game Length (Turns)</h2>
+    <img src="data:image/png;base64,{turn_hist}" />
+    <h2>Margin of Victory</h2>
+    <img src="data:image/png;base64,{margin_hist}" />
+    </body>
+    </html>
+    """
+
+    output_path.write_text(html)
+    print(f"Report written to {output_path}")


### PR DESCRIPTION
## Summary
- move report generation to dedicated module `dominion.reporting.html_report`
- keep `compare_skulk_strategies.py` focused on running the battle

## Testing
- `pip install matplotlib`
- `pip install tqdm`
- `python compare_skulk_strategies.py > run_output.txt && tail -n 20 run_output.txt`


------
https://chatgpt.com/codex/tasks/task_e_684dc246c354832798180bd7f01237dc