### PR TITLE
Add Dark Ages shelter starting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 To battle strategies:
 
 python -m dominion.simulation.strategy_battle ChapelWitch BigMoney --games 2
+
+Pass `--use-shelters` to start each player with Necropolis, Hovel and
+Overgrown Estate instead of three Estates.

--- a/dominion/cards/expansions/__init__.py
+++ b/dominion/cards/expansions/__init__.py
@@ -10,6 +10,7 @@ from .beggar import Beggar
 from .modify import Modify
 from .rebuild import Rebuild
 from .crypt import Crypt
+from .shelters import Hovel, Necropolis, OvergrownEstate
 
 __all__ = [
     'Patrician',
@@ -24,4 +25,7 @@ __all__ = [
     'Modify',
     'Rebuild',
     'Crypt',
+    'Hovel',
+    'Necropolis',
+    'OvergrownEstate',
 ]

--- a/dominion/cards/expansions/shelters.py
+++ b/dominion/cards/expansions/shelters.py
@@ -1,0 +1,46 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+class Necropolis(Card):
+    """Simple implementation of the Necropolis shelter."""
+
+    def __init__(self):
+        super().__init__(
+            name="Necropolis",
+            cost=CardCost(coins=0),
+            stats=CardStats(actions=2),
+            types=[CardType.ACTION],
+        )
+
+    def starting_supply(self, game_state) -> int:
+        # Shelters are not part of the normal supply
+        return 0
+
+
+class Hovel(Card):
+    """Simple implementation of the Hovel shelter."""
+
+    def __init__(self):
+        super().__init__(
+            name="Hovel",
+            cost=CardCost(coins=0),
+            stats=CardStats(),
+            types=[CardType.REACTION],
+        )
+
+    def starting_supply(self, game_state) -> int:
+        return 0
+
+
+class OvergrownEstate(Card):
+    """Simple implementation of the Overgrown Estate shelter."""
+
+    def __init__(self):
+        super().__init__(
+            name="Overgrown Estate",
+            cost=CardCost(coins=0),
+            stats=CardStats(vp=1),
+            types=[CardType.VICTORY],
+        )
+
+    def starting_supply(self, game_state) -> int:
+        return 0

--- a/dominion/cards/registry.py
+++ b/dominion/cards/registry.py
@@ -26,6 +26,9 @@ from dominion.cards.expansions import (
     Crypt,
     Skulk,
     SnowyVillage,
+    Hovel,
+    Necropolis,
+    OvergrownEstate,
 )
 from dominion.cards.treasures import Copper, Gold, Silver
 from dominion.cards.victory import Curse, Duchy, Estate, Province
@@ -65,6 +68,9 @@ CARD_TYPES: dict[str, Type[Card]] = {
     "Modify": Modify,
     "Rebuild": Rebuild,
     "Crypt": Crypt,
+    "Hovel": Hovel,
+    "Necropolis": Necropolis,
+    "Overgrown Estate": OvergrownEstate,
 }
 
 

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -56,7 +56,9 @@ class GameState:
     def current_player(self) -> PlayerState:
         return self.players[self.current_player_index]
 
-    def initialize_game(self, ais: list, kingdom_cards: list[Card]):
+    def initialize_game(
+        self, ais: list, kingdom_cards: list[Card], use_shelters: bool = False
+    ):
         """Set up the game with given AIs and kingdom cards."""
         # Create PlayerState objects for each AI
         self.players = [PlayerState(ai) for ai in ais]
@@ -64,7 +66,7 @@ class GameState:
 
         # Initialize players
         for player in self.players:
-            player.initialize()
+            player.initialize(use_shelters)
 
         # Create a more readable player list for logging
         player_descriptions = []

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -33,11 +33,23 @@ class PlayerState:
     turns_taken: int = 0
     actions_played: int = 0
 
-    def initialize(self):
-        """Set up starting deck (7 Coppers, 3 Estates) and draw initial hand."""
+    def initialize(self, use_shelters: bool = False):
+        """Set up starting deck and draw initial hand.
 
-        # Create starting deck: 7 Coppers and 3 Estates
-        self.deck = [get_card("Copper") for _ in range(7)] + [get_card("Estate") for _ in range(3)]
+        If ``use_shelters`` is ``True``, start with Necropolis, Hovel and
+        Overgrown Estate instead of three Estates as in the Dark Ages expansion.
+        """
+
+        # Create starting deck
+        self.deck = [get_card("Copper") for _ in range(7)]
+        if use_shelters:
+            self.deck += [
+                get_card("Necropolis"),
+                get_card("Hovel"),
+                get_card("Overgrown Estate"),
+            ]
+        else:
+            self.deck += [get_card("Estate") for _ in range(3)]
 
         # Shuffle the deck
         random.shuffle(self.deck)

--- a/dominion/simulation/strategy_battle.py
+++ b/dominion/simulation/strategy_battle.py
@@ -12,10 +12,13 @@ from dominion.strategy.strategy_loader import StrategyLoader
 class StrategyBattle:
     """System for running battles between strategies."""
 
-    def __init__(self, kingdom_cards: list[str], log_folder: str = "battle_logs"):
+    def __init__(
+        self, kingdom_cards: list[str], log_folder: str = "battle_logs", use_shelters: bool = False
+    ):
         self.kingdom_cards = kingdom_cards
         self.logger = GameLogger(log_folder=log_folder)
         self.strategy_loader = StrategyLoader()  # Now automatically loads all strategies
+        self.use_shelters = use_shelters
 
     def run_battle(self, strategy1_name: str, strategy2_name: str, num_games: int = 100) -> dict[str, Any]:
         """Run multiple games between two strategies"""
@@ -96,7 +99,7 @@ class StrategyBattle:
 
         # Initialize game
         kingdom_cards = [get_card(name) for name in self.kingdom_cards]
-        game_state.initialize_game([ai1, ai2], kingdom_cards)
+        game_state.initialize_game([ai1, ai2], kingdom_cards, use_shelters=self.use_shelters)
 
         # Run game
         while not game_state.is_game_over():
@@ -117,6 +120,11 @@ def main():
     parser.add_argument("strategy1_name", help="Name of first strategy")
     parser.add_argument("strategy2_name", help="Name of second strategy")
     parser.add_argument("--games", type=int, default=100, help="Number of games to play")
+    parser.add_argument(
+        "--use-shelters",
+        action="store_true",
+        help="Start games with Shelters instead of Estates",
+    )
     args = parser.parse_args()
 
     # Default kingdom cards
@@ -135,7 +143,7 @@ def main():
 
     print(f"\nInitializing battle between {args.strategy1_name} and {args.strategy2_name}...")
 
-    battle = StrategyBattle(kingdom_cards)
+    battle = StrategyBattle(kingdom_cards, use_shelters=args.use_shelters)
 
     # Print available strategies
     print("\nAvailable strategies:", ", ".join(battle.strategy_loader.list_strategies()))


### PR DESCRIPTION
## Summary
- add Necropolis, Hovel and Overgrown Estate shelter cards
- allow PlayerState.initialize to optionally use Shelters
- pass `use_shelters` through GameState and StrategyBattle
- support `--use-shelters` CLI flag
- document the flag in README

## Testing
- `pip install -e .`
- `pip install tqdm`
- `pytest -q`
- `python - <<'PY'
from dominion.cards.registry import get_card
print(get_card('Necropolis'))
print(get_card('Hovel'))
print(get_card('Overgrown Estate'))
PY
`
- `python - <<'PY'
from dominion.game.game_state import GameState
from dominion.cards.registry import get_card
class DummyAI:
    def __init__(self):
        self.name='AI-1'
        self.strategy=None
state=GameState(players=[], supply={})
state.initialize_game([DummyAI()], [get_card('Village')], use_shelters=True)
p=state.players[0]
print(sorted([c.name for c in p.hand+p.deck+p.discard]))
PY
`

------
https://chatgpt.com/codex/tasks/task_e_684dcc43ba44832792973a922a3b5d3f