### PR TITLE
Add RatsModifyRebuild strategy

### DIFF
--- a/dominion/strategy/strategies/rats_modify_rebuild.py
+++ b/dominion/strategy/strategies/rats_modify_rebuild.py
@@ -1,0 +1,57 @@
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class RatsModifyRebuildStrategy(EnhancedStrategy):
+    """Strategy utilizing Rats, Modify, Rebuild, Forager, Skulk and Patrician/Emporium."""
+
+    def __init__(self):
+        super().__init__()
+        self.name = "RatsModifyRebuild"
+        self.description = "Use Rats and Forager to thin, Modify for upgrades, Skulk for Gold, and Rebuild for points"
+        self.version = "1.0"
+
+        # Gain priorities
+        self.gain_priority = [
+            PriorityRule("Province", PriorityRule.can_afford(8)),
+            PriorityRule("Rebuild", "my.count(Rebuild) < 3"),
+            PriorityRule("Emporium", PriorityRule.can_afford(5)),
+            PriorityRule("Duchy"),
+            PriorityRule("Patrician", "my.count(Patrician) < 2"),
+            PriorityRule("Modify", "my.count(Modify) < 2"),
+            PriorityRule("Skulk", PriorityRule.can_afford(4)),
+            PriorityRule("Rats", PriorityRule.can_afford(4)),
+            PriorityRule("Forager", "my.count(Forager) < 1"),
+            PriorityRule("Gold", PriorityRule.can_afford(6)),
+            PriorityRule("Silver", PriorityRule.can_afford(3)),
+            PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),
+            PriorityRule("Copper"),
+        ]
+
+        # Action priorities
+        self.action_priority = [
+            PriorityRule("Forager"),
+            PriorityRule("Modify"),
+            PriorityRule("Rebuild"),
+            PriorityRule("Rats"),
+            PriorityRule("Patrician"),
+            PriorityRule("Skulk"),
+        ]
+
+        # Trash priorities
+        self.trash_priority = [
+            PriorityRule("Curse"),
+            PriorityRule("Estate"),
+            PriorityRule("Copper"),
+            PriorityRule("Rats"),
+        ]
+
+        # Treasure priorities
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+
+def create_rats_modify_rebuild() -> EnhancedStrategy:
+    return RatsModifyRebuildStrategy()


### PR DESCRIPTION
## Summary
- add a new strategy `RatsModifyRebuild` that uses Rats, Modify, Rebuild, Forager, Skulk, Patrician/Eporium

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dcd8d6f0c83279f7b8f2d9f7bcd9d