### PR TITLE
Add Wharf Bridge Chapel Village strategy

### DIFF
--- a/dominion/simulation/strategy_registry.py
+++ b/dominion/simulation/strategy_registry.py
@@ -4,6 +4,9 @@ from dominion.strategy.strategies.base_strategy import BaseStrategy
 from dominion.strategy.strategies.big_money import BigMoneyStrategy
 from dominion.strategy.strategies.chapel_witch import ChapelWitchStrategy
 from dominion.strategy.strategies.village_smithy_lab import VillageSmithyLabStrategy
+from dominion.strategy.strategies.wharf_bridge_chapel_village import (
+    WharfBridgeChapelVillageStrategy,
+)
 
 
 class StrategyRegistry:
@@ -18,6 +21,9 @@ class StrategyRegistry:
         self.register_strategy("BigMoney", BigMoneyStrategy)
         self.register_strategy("ChapelWitch", ChapelWitchStrategy)
         self.register_strategy("VillageSmithyLab", VillageSmithyLabStrategy)
+        self.register_strategy(
+            "WharfBridgeChapelVillage", WharfBridgeChapelVillageStrategy
+        )
 
     def register_strategy(self, name: str, strategy_class: Type[BaseStrategy]):
         """Register a new strategy class"""

--- a/dominion/strategy/strategies/wharf_bridge_chapel_village.py
+++ b/dominion/strategy/strategies/wharf_bridge_chapel_village.py
@@ -1,0 +1,52 @@
+from .base_strategy import BaseStrategy, PriorityRule
+
+
+class WharfBridgeChapelVillageStrategy(BaseStrategy):
+    """Wharf/Bridge engine with Chapel thinning and Villages for actions."""
+
+    def __init__(self):
+        super().__init__()
+        self.name = "WharfBridgeChapelVillage"
+        self.description = "Engine using Wharf, Bridge, Chapel and Village"
+        self.version = "1.0"
+
+        # Gain priorities
+        self.gain_priority = [
+            PriorityRule("Province", "my.coins >= 8"),
+            PriorityRule("Chapel", "state.turn_number <= 2 AND my.count(Chapel) == 0"),
+            PriorityRule("Wharf", "my.count(Wharf) < 2"),
+            PriorityRule("Village", "my.count(Bridge) + my.count(Wharf) > my.count(Village)"),
+            PriorityRule("Bridge", "my.coins >= 4"),
+            PriorityRule("Gold", "my.coins >= 6"),
+            PriorityRule("Silver", "my.coins >= 3"),
+            PriorityRule("Copper"),
+        ]
+
+        # Action priorities
+        self.action_priority = [
+            PriorityRule("Chapel", "my.count(Estate) > 0 OR my.count(Copper) > 3"),
+            PriorityRule("Wharf"),
+            PriorityRule("Bridge"),
+            PriorityRule("Village"),
+        ]
+
+        # Trash priorities
+        self.trash_priority = [
+            PriorityRule("Curse"),
+            PriorityRule("Estate", "state.turn_number <= 12"),
+            PriorityRule("Copper", "my.count(Silver) + my.count(Gold) >= 2"),
+        ]
+
+        # Treasure priorities
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+
+from dominion.strategy.enhanced_strategy import EnhancedStrategy
+
+
+def create_wharf_bridge_chapel_village() -> EnhancedStrategy:
+    return WharfBridgeChapelVillageStrategy()


### PR DESCRIPTION
## Summary
- create strategy that buys Wharf, Bridge, Chapel and Village
- register the strategy in `StrategyRegistry`

## Testing
- `pytest -q`
- `python - <<'EOF'
from dominion.simulation.strategy_registry import StrategyRegistry
print(StrategyRegistry().list_strategies())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684dcde85968832794d39243f4329751