### PR TITLE
Add UltimateDominion strategy

### DIFF
--- a/dominion/strategy/strategies/ultimate_dominion.py
+++ b/dominion/strategy/strategies/ultimate_dominion.py
@@ -1,0 +1,61 @@
+from .base_strategy import BaseStrategy, PriorityRule
+from dominion.strategy.enhanced_strategy import EnhancedStrategy
+
+
+class UltimateDominionStrategy(BaseStrategy):
+    """Comprehensive engine strategy combining trashing, draw, and payload."""
+
+    def __init__(self):
+        super().__init__()
+        self.name = "UltimateDominion"
+        self.description = "Strong engine approach with Chapel trashing and powerful payload"
+        self.version = "1.0"
+
+        # Gain priorities
+        self.gain_priority = [
+            # Victory points
+            PriorityRule("Province", PriorityRule.can_afford(8)),
+            # Early trashing
+            PriorityRule(
+                "Chapel",
+                PriorityRule.and_(PriorityRule.turn_number("<=", 2), "my.count(Chapel) == 0"),
+            ),
+            # Draw and actions
+            PriorityRule("Laboratory", PriorityRule.can_afford(5)),
+            PriorityRule("Village", PriorityRule.resources("actions", "<", 2)),
+            PriorityRule("Market", PriorityRule.can_afford(5)),
+            PriorityRule("Festival", PriorityRule.can_afford(5)),
+            PriorityRule("Witch", PriorityRule.and_(PriorityRule.turn_number("<=", 10), "my.count(Witch) < 2")),
+            # Economy
+            PriorityRule("Gold", PriorityRule.can_afford(6)),
+            PriorityRule("Silver", PriorityRule.can_afford(3)),
+            PriorityRule("Copper"),
+        ]
+
+        # Action priorities
+        self.action_priority = [
+            PriorityRule("Chapel", "my.count(Estate) > 0 or my.count(Copper) > 2"),
+            PriorityRule("Witch"),
+            PriorityRule("Village"),
+            PriorityRule("Market"),
+            PriorityRule("Festival"),
+            PriorityRule("Laboratory"),
+        ]
+
+        # Trash priorities
+        self.trash_priority = [
+            PriorityRule("Curse"),
+            PriorityRule("Estate", PriorityRule.provinces_left(">", 4)),
+            PriorityRule("Copper", "my.count(Silver) + my.count(Gold) >= 3"),
+        ]
+
+        # Treasure play order
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+
+def create_ultimate_dominion() -> EnhancedStrategy:
+    return UltimateDominionStrategy()


### PR DESCRIPTION
## Summary
- implement an ultimate Dominion engine strategy
- auto-register via create function

## Testing
- `python -m dominion.simulation.strategy_battle "Ultimate Dominion" "Big Money" --games 1`
- `python - <<'EOF'
from dominion.strategy.strategy_loader import StrategyLoader
loader = StrategyLoader()
print(loader.list_strategies())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684dcdba72088327a310bf687bf603ed