### PR TITLE
Improve log player names

### DIFF
--- a/dominion/simulation/game_logger.py
+++ b/dominion/simulation/game_logger.py
@@ -4,7 +4,9 @@ import os
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, auto
-from typing import Any, Optional
+from typing import Any, Optional, List
+
+from dominion.ai.genetic_ai import GeneticAI
 
 from tqdm import tqdm
 
@@ -62,7 +64,7 @@ class GameLogger:
         self.file_logger = logging.getLogger("DominionGameFile")
         self.file_logger.setLevel(logging.DEBUG)
 
-    def start_game(self, players: list[str]):
+    def start_game(self, players: List[GeneticAI]):
         """Start tracking a new game with enhanced initial state logging."""
         self.game_count += 1
         self.should_log_to_file = self.game_count % self.log_frequency == 0
@@ -81,10 +83,18 @@ class GameLogger:
             file_handler.setFormatter(formatter)
             self.file_logger.addHandler(file_handler)
 
+            # Create readable player descriptions
+            descriptions = []
+            for ai in players:
+                ai_id = ai.name.split("-")[1]
+                short_id = ai_id[-4:]
+                strategy_name = getattr(ai.strategy, "name", "Unknown Strategy")
+                descriptions.append(f"Player {short_id} ({strategy_name})")
+
             # Enhanced game start logging
             self.file_logger.info("=" * 60)
             self.file_logger.info(f"Starting Game {self.game_count}")
-            self.file_logger.info(f"Players: {', '.join(players)}")
+            self.file_logger.info(f"Players: {', '.join(descriptions)}")
             self.file_logger.info("=" * 60)
 
     def format_player_name(self, name: str) -> str:

--- a/dominion/simulation/strategy_battle.py
+++ b/dominion/simulation/strategy_battle.py
@@ -107,8 +107,8 @@ class StrategyBattle:
 
     def _run_game(self, ai1: GeneticAI, ai2: GeneticAI) -> tuple[GeneticAI, dict[str, int], Optional[str]]:
         """Run a single game between two AIs."""
-        # Start game logging
-        self.logger.start_game([ai1.name, ai2.name])
+        # Start game logging with actual AI objects for better descriptions
+        self.logger.start_game([ai1, ai2])
 
         # Set up game state
         game_state = GameState(players=[], supply={})

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib
 seaborn
 scipy
 tqdm
+lark


### PR DESCRIPTION
## Summary
- make GameLogger know about GeneticAI so we can log readable player names
- describe players by short id and strategy at game start
- update StrategyBattle to pass AI objects to the logger
- add lark requirement for tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1bd46b088327a2903a4f95948c0b