### PR TITLE
Improve player names in logs

### DIFF
--- a/dominion/simulation/game_logger.py
+++ b/dominion/simulation/game_logger.py
@@ -51,6 +51,7 @@ class GameLogger:
         self.game_count = 0
         self.should_log_to_file = False
         self.training_progress: Optional[tqdm] = None
+        self.name_map: dict[str, str] = {}
 
         # Create log directories
         os.makedirs(log_folder, exist_ok=True)
@@ -83,13 +84,16 @@ class GameLogger:
             file_handler.setFormatter(formatter)
             self.file_logger.addHandler(file_handler)
 
-            # Create readable player descriptions
+            # Create readable player descriptions and map them for later use
             descriptions = []
+            self.name_map = {}
             for ai in players:
                 ai_id = ai.name.split("-")[1]
                 short_id = ai_id[-4:]
                 strategy_name = getattr(ai.strategy, "name", "Unknown Strategy")
-                descriptions.append(f"Player {short_id} ({strategy_name})")
+                friendly = f"Player {short_id} ({strategy_name})"
+                self.name_map[ai.name] = friendly
+                descriptions.append(friendly)
 
             # Enhanced game start logging
             self.file_logger.info("=" * 60)
@@ -99,8 +103,10 @@ class GameLogger:
 
     def format_player_name(self, name: str) -> str:
         """Format player name to be more readable."""
+        if name in self.name_map:
+            return self.name_map[name]
         if "GeneticAI-" in name:
-            return f"AI-{name.split('-')[1][:4]}"  # Show only first 4 digits of id
+            return f"AI-{name.split('-')[1][:4]}"
         return name
 
     def log_turn_header(self, player_name: str, turn_number: int, resources: dict[str, int]):

--- a/dominion/simulation/strategy_battle.py
+++ b/dominion/simulation/strategy_battle.py
@@ -165,11 +165,9 @@ class StrategyBattle:
         # Start game logging with actual AI objects for better descriptions
         self.logger.start_game([ai1, ai2])
 
-        # Set up game state
+        # Set up game state and attach logger for structured logging
         game_state = GameState(players=[], supply={})
-        game_state.log_callback = lambda msg: (
-            self.logger.file_logger.info(msg) if self.logger.should_log_to_file else print(msg)
-        )
+        game_state.set_logger(self.logger)
 
         # Initialize game
         kingdom_cards = [get_card(name) for name in kingdom_card_names]


### PR DESCRIPTION
## Summary
- keep a friendly name map for AIs in `GameLogger`
- format names using the map
- attach logger to `GameState` in `StrategyBattle` for structured logs

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1f5d7a308327ad9fb82490107771