### PR TITLE
Add sample strategy battle logs

### DIFF
--- a/battle_logs/game_20250615_013012_566439.log
+++ b/battle_logs/game_20250615_013012_566439.log
@@ -1,0 +1,498 @@
+01:30:12 - INFO - ============================================================
+01:30:12 - INFO - Starting Game 10
+01:30:12 - INFO - Players: Player 3504 (BigMoney), Player 1968 (ChapelWitch)
+01:30:12 - INFO - ============================================================
+01:30:12 - INFO - Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Chapel': 10, 'Witch': 10}
+01:30:12 - INFO - Game initialized with players: Player 3504 (BigMoney), Player 1968 (ChapelWitch)
+01:30:12 - INFO - Kingdom cards: Chapel, Witch
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 1 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Estate, Copper, Estate, Estate, Copper
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Copper (cost: 0; remaining_coins: 2; remaining_buys: 0)
+01:30:12 - INFO - Supply: Copper gained (45 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 1 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Estate, Estate, Copper, Copper
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Chapel (cost: 2; remaining_coins: 1; remaining_buys: 0)
+01:30:12 - INFO - Supply: Chapel gained (9 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 2 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Copper, Copper, Copper, Copper
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Silver (cost: 3; remaining_coins: 2; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (39 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 2 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Copper, Copper, Copper, Estate
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (38 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 3 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Estate, Copper, Copper, Copper, Estate
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Silver (cost: 3; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (37 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 3 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Chapel, Copper, Estate, Copper, Silver
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Chapel (remaining_actions: 0; hand: Copper, Estate, Copper, Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): trashes 1 cards (trashed_cards: Estate; remaining_hand: Copper, Copper, Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (36 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 4 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Estate, Copper, Copper, Copper, Silver
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Silver (cost: 3; remaining_coins: 2; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (35 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 4 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Copper, Estate, Estate, Copper
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Silver (cost: 3; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (34 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 5 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Copper, Copper, Copper, Silver
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Gold (cost: 6; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Gold gained (29 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 5 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Copper, Estate, Copper, Chapel
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Chapel (remaining_actions: 0; hand: Copper, Copper, Estate, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): trashes 4 cards (trashed_cards: Estate, Copper, Copper, Copper; remaining_hand: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Copper (cost: 0; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Copper gained (44 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 6 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Estate, Copper, Copper, Estate, Silver
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (33 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 6 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Silver, Copper, Estate, Silver
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Copper, Copper, Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Witch (cost: 5; remaining_coins: 1; remaining_buys: 0)
+01:30:12 - INFO - Supply: Witch gained (9 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 7 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Estate, Copper, Silver, Copper
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Silver (cost: 3; remaining_coins: 2; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (32 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 7 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Copper, Silver, Copper, Copper
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Gold (cost: 6; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Gold gained (28 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 8 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Estate, Gold, Silver, Copper, Copper
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Gold (coins_before: 0; coins_added: 3; coins_after: 3; remaining_treasures: Silver, Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Gold (cost: 6; remaining_coins: 1; remaining_buys: 0)
+01:30:12 - INFO - Supply: Gold gained (27 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 8 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Chapel, Silver, Silver, Witch
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Chapel (remaining_actions: 0; hand: Copper, Silver, Silver, Witch)
+01:30:12 - INFO - Player 1968 (ChapelWitch): trashes 1 cards (trashed_cards: Copper; remaining_hand: Silver, Silver, Witch)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (31 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 9 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Silver, Copper, Estate, Copper, Silver
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Copper, Copper, Silver)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Gold (cost: 6; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Gold gained (26 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 9 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Estate, Chapel, Silver, Silver, Copper
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Chapel (remaining_actions: 0; hand: Estate, Silver, Silver, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): trashes 2 cards (trashed_cards: Estate, Copper; remaining_hand: Silver, Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (30 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 10 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Silver, Copper, Gold, Gold
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Gold (coins_before: 0; coins_added: 3; coins_after: 3; remaining_treasures: Copper, Silver, Copper, Gold)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Gold (coins_before: 3; coins_added: 3; coins_after: 6; remaining_treasures: Copper, Silver, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 6; coins_added: 2; coins_after: 8; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 8; coins_added: 1; coins_after: 9; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 9; coins_added: 1; coins_after: 10; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Province (cost: 8; remaining_coins: 2; remaining_buys: 0)
+01:30:12 - INFO - Supply: Province gained (7 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 10 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Witch, Copper, Copper, Silver, Copper
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Witch (remaining_actions: 0; hand: Copper, Copper, Silver, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): draws 2 cards (drawn_cards: Silver, Gold; new_hand: Copper, Copper, Silver, Copper, Silver, Gold)
+01:30:12 - INFO - Player 1968 (ChapelWitch): gives curse to GeneticAI-139789023403504 (curses_remaining: 9)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Gold (coins_before: 0; coins_added: 3; coins_after: 3; remaining_treasures: Copper, Copper, Silver, Copper, Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: Copper, Copper, Copper, Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 5; coins_added: 2; coins_after: 7; remaining_treasures: Copper, Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 7; coins_added: 1; coins_after: 8; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 8; coins_added: 1; coins_after: 9; remaining_treasures: Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 9; coins_added: 1; coins_after: 10; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Province (cost: 8; remaining_coins: 2; remaining_buys: 0)
+01:30:12 - INFO - Supply: Province gained (6 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 11 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Gold, Copper, Copper, Estate, Silver
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Gold (coins_before: 0; coins_added: 3; coins_after: 3; remaining_treasures: Copper, Copper, Silver)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Gold (cost: 6; remaining_coins: 1; remaining_buys: 0)
+01:30:12 - INFO - Supply: Gold gained (25 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 11 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Copper, Silver, Silver, Silver
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Copper, Copper, Silver, Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: Copper, Copper, Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 4; coins_added: 2; coins_after: 6; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 7; coins_added: 1; coins_after: 8; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Province (cost: 8; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Province gained (5 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 12 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Estate, Estate, Copper, Silver
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (29 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 12 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Silver, Gold, Silver, Copper, Chapel
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Gold (coins_before: 0; coins_added: 3; coins_after: 3; remaining_treasures: Silver, Silver, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: Silver, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 5; coins_added: 2; coins_after: 7; remaining_treasures: Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 7; coins_added: 1; coins_after: 8; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Province (cost: 8; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Province gained (4 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 13 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Copper, Silver, Silver, Estate
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Copper, Copper, Silver)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Gold (cost: 6; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Gold gained (24 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 13 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Province, Witch, Silver, Silver, Copper
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Witch (remaining_actions: 0; hand: Province, Silver, Silver, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): draws 2 cards (drawn_cards: Silver, Silver; new_hand: Province, Silver, Silver, Copper, Silver, Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): gives curse to GeneticAI-139789023403504 (curses_remaining: 8)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Silver, Copper, Silver, Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: Copper, Silver, Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 4; coins_added: 2; coins_after: 6; remaining_treasures: Copper, Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 6; coins_added: 2; coins_after: 8; remaining_treasures: Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 8; coins_added: 1; coins_after: 9; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Province (cost: 8; remaining_coins: 1; remaining_buys: 0)
+01:30:12 - INFO - Supply: Province gained (3 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 14 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Copper, Estate, Copper, Estate
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Silver (cost: 3; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (28 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 14 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Province, Province, Copper, Silver, Chapel
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Silver (cost: 3; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (27 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 15 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Gold, Silver, Province, Copper, Curse
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Gold (coins_before: 0; coins_added: 3; coins_after: 3; remaining_treasures: Silver, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Gold (cost: 6; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Gold gained (23 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 15 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Gold, Copper, Silver, Copper, Chapel
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Gold (coins_before: 0; coins_added: 3; coins_after: 3; remaining_treasures: Copper, Silver, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Gold (cost: 6; remaining_coins: 1; remaining_buys: 0)
+01:30:12 - INFO - Supply: Gold gained (22 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 16 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Gold, Gold, Silver, Gold, Silver
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Gold (coins_before: 0; coins_added: 3; coins_after: 3; remaining_treasures: Gold, Silver, Gold, Silver)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Gold (coins_before: 3; coins_added: 3; coins_after: 6; remaining_treasures: Silver, Gold, Silver)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Gold (coins_before: 6; coins_added: 3; coins_after: 9; remaining_treasures: Silver, Silver)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 9; coins_added: 2; coins_after: 11; remaining_treasures: Silver)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 11; coins_added: 2; coins_after: 13; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Province (cost: 8; remaining_coins: 5; remaining_buys: 0)
+01:30:12 - INFO - Supply: Province gained (2 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 16 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Silver, Province, Province, Silver, Province
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (26 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 17 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Silver, Copper, Copper, Curse, Silver
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Copper, Copper, Silver)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Gold (cost: 6; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Gold gained (21 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 17 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Province, Witch, Silver, Silver, Silver
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Witch (remaining_actions: 0; hand: Province, Silver, Silver, Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Province, Silver, Silver, Silver, Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): gives curse to GeneticAI-139789023403504 (curses_remaining: 7)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Silver, Silver, Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: Silver, Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 4; coins_added: 2; coins_after: 6; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 7; coins_added: 1; coins_after: 8; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Province (cost: 8; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Province gained (1 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 18 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Silver, Estate, Curse, Copper, Estate
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Silver (cost: 3; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Silver gained (25 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 18 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Province, Silver, Province, Copper, Gold
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Gold (coins_before: 0; coins_added: 3; coins_after: 3; remaining_treasures: Silver, Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: Copper)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Gold (cost: 6; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Gold gained (20 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 19 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Gold, Silver, Copper, Estate, Province
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Gold (coins_before: 0; coins_added: 3; coins_after: 3; remaining_treasures: Silver, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Gold (cost: 6; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Gold gained (19 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 19 - Player 1968 (ChapelWitch)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Silver, Silver, Chapel, Silver, Province
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 0; coins_added: 2; coins_after: 2; remaining_treasures: Silver, Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: Silver)
+01:30:12 - INFO - Player 1968 (ChapelWitch): plays Silver (coins_before: 4; coins_added: 2; coins_after: 6; remaining_treasures: )
+01:30:12 - INFO - Player 1968 (ChapelWitch): buys Gold (cost: 6; remaining_coins: 0; remaining_buys: 0)
+01:30:12 - INFO - Supply: Gold gained (18 remaining)
+01:30:12 - INFO - 
+========================================
+01:30:12 - INFO - Turn 20 - Player 3504 (BigMoney)
+01:30:12 - INFO - Resources: 1 actions, 1 buys, 0 coins
+01:30:12 - INFO - Hand: Copper, Copper, Silver, Gold, Gold
+01:30:12 - INFO - ----------------------------------------
+01:30:12 - INFO - Player 3504 (BigMoney): plays Gold (coins_before: 0; coins_added: 3; coins_after: 3; remaining_treasures: Copper, Copper, Silver, Gold)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Gold (coins_before: 3; coins_added: 3; coins_after: 6; remaining_treasures: Copper, Copper, Silver)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Silver (coins_before: 6; coins_added: 2; coins_after: 8; remaining_treasures: Copper, Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 8; coins_added: 1; coins_after: 9; remaining_treasures: Copper)
+01:30:12 - INFO - Player 3504 (BigMoney): plays Copper (coins_before: 9; coins_added: 1; coins_after: 10; remaining_treasures: )
+01:30:12 - INFO - Player 3504 (BigMoney): buys Province (cost: 8; remaining_coins: 2; remaining_buys: 0)
+01:30:12 - INFO - Supply: Province gained (0 remaining)
+01:30:12 - INFO - Game over: Provinces depleted
+01:30:12 - INFO - 
+============================================================
+01:30:12 - INFO - Game Over!
+01:30:12 - INFO - Winner: Player 1968 (ChapelWitch)
+01:30:12 - INFO - 
+Final Scores:
+01:30:12 - INFO -   Player 3504 (BigMoney): 18
+01:30:12 - INFO -   Player 1968 (ChapelWitch): 30
+01:30:12 - INFO - 
+Final Supply State:
+01:30:12 - INFO -   Copper: 44 remaining
+01:30:12 - INFO -   Silver: 25 remaining
+01:30:12 - INFO -   Gold: 18 remaining
+01:30:12 - INFO -   Estate: 8 remaining
+01:30:12 - INFO -   Duchy: 8 remaining
+01:30:12 - INFO -   Province: Empty
+01:30:12 - INFO -   Curse: 7 remaining
+01:30:12 - INFO -   Chapel: 9 remaining
+01:30:12 - INFO -   Witch: 9 remaining
+01:30:12 - INFO - ============================================================
+

--- a/battle_logs/metrics/game_20250615_013012_566439_metrics.json
+++ b/battle_logs/metrics/game_20250615_013012_566439_metrics.json
@@ -1,0 +1,25 @@
+{
+  "turn_count": 20,
+  "cards_played": {
+    "Copper": 75,
+    "Chapel": 4,
+    "Silver": 50,
+    "Gold": 15,
+    "Witch": 3
+  },
+  "victory_points": {
+    "GeneticAI-139789023403504": 18,
+    "GeneticAI-139789023401968": 30
+  },
+  "actions_played": {
+    "GeneticAI-139789023401968": 7
+  },
+  "cards_bought": {
+    "Copper": 2,
+    "Chapel": 1,
+    "Silver": 15,
+    "Gold": 12,
+    "Witch": 1,
+    "Province": 8
+  }
+}

--- a/run_output.txt
+++ b/run_output.txt
@@ -1,0 +1,146 @@
+
+Initializing battle between Chapel Witch and Big Money...
+Registered strategy: Skulk Rebuild Improved
+Registered strategy: Wharf Bridge Chapel Village
+Registered strategy: Skulk Rebuild
+Registered strategy: Chapel Witch
+Registered strategy: Big Money
+Registered strategy: Village Smithy Lab
+Registered strategy: Ultimate Dominion
+Registered strategy: Collection Patrician Rebuild
+Registered strategy: Rats Modify Rebuild
+
+Available strategies: Big Money, Chapel Witch, Collection Patrician Rebuild, Rats Modify Rebuild, Skulk Rebuild, Skulk Rebuild Improved, Ultimate Dominion, Village Smithy Lab, Wharf Bridge Chapel Village
+
+Running 10 games...
+
+Running 10 games between:
+Strategy 1: Chapel Witch
+Strategy 2: Big Money
+
+Using kingdom cards: Chapel, Witch
+Playing game 1/10...
+Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Chapel': 10, 'Witch': 10}
+Game initialized with players: Player 0576 (ChapelWitch), Player 1008 (BigMoney)
+Kingdom cards: Chapel, Witch
+Game over: Provinces depleted
+Playing game 2/10...
+Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Chapel': 10, 'Witch': 10}
+Game initialized with players: Player 6128 (BigMoney), Player 5696 (ChapelWitch)
+Kingdom cards: Chapel, Witch
+Game over: Provinces depleted
+Playing game 3/10...
+Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Chapel': 10, 'Witch': 10}
+Game initialized with players: Player 3120 (ChapelWitch), Player 3024 (BigMoney)
+Kingdom cards: Chapel, Witch
+Game over: Provinces depleted
+Playing game 4/10...
+Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Chapel': 10, 'Witch': 10}
+Game initialized with players: Player 7072 (BigMoney), Player 5584 (ChapelWitch)
+Kingdom cards: Chapel, Witch
+Game over: Provinces depleted
+Playing game 5/10...
+Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Chapel': 10, 'Witch': 10}
+Game initialized with players: Player 8784 (ChapelWitch), Player 9600 (BigMoney)
+Kingdom cards: Chapel, Witch
+Game over: Provinces depleted
+Playing game 6/10...
+Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Chapel': 10, 'Witch': 10}
+Game initialized with players: Player 2880 (BigMoney), Player 0272 (ChapelWitch)
+Kingdom cards: Chapel, Witch
+Game over: Provinces depleted
+Playing game 7/10...
+Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Chapel': 10, 'Witch': 10}
+Game initialized with players: Player 3984 (ChapelWitch), Player 7600 (BigMoney)
+Kingdom cards: Chapel, Witch
+Game over: Provinces depleted
+Playing game 8/10...
+Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Chapel': 10, 'Witch': 10}
+Game initialized with players: Player 6352 (BigMoney), Player 1856 (ChapelWitch)
+Kingdom cards: Chapel, Witch
+Game over: Provinces depleted
+Playing game 9/10...
+Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Chapel': 10, 'Witch': 10}
+Game initialized with players: Player 5584 (ChapelWitch), Player 5680 (BigMoney)
+Kingdom cards: Chapel, Witch
+Game over: Provinces depleted
+Playing game 10/10...
+Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Chapel': 10, 'Witch': 10}
+Game initialized with players: Player 3504 (BigMoney), Player 1968 (ChapelWitch)
+Kingdom cards: Chapel, Witch
+Game over: Provinces depleted
+
+=== Strategy Battle Results ===
+
+Games played: 10
+
+Chapel Witch:
+  Wins: 8 (80.0%)
+  Average Score: 29.0
+
+Big Money:
+  Wins: 2 (20.0%)
+  Average Score: 19.4
+
+Detailed game results:
+
+Game 1:
+  Winner: Big Money
+  Scores: Chapel Witch=19, Big Money=32
+  Margin: 13
+  Turns: 0
+
+Game 2:
+  Winner: Chapel Witch
+  Scores: Chapel Witch=37, Big Money=11
+  Margin: 26
+  Turns: 0
+
+Game 3:
+  Winner: Chapel Witch
+  Scores: Chapel Witch=30, Big Money=17
+  Margin: 13
+  Turns: 0
+
+Game 4:
+  Winner: Chapel Witch
+  Scores: Chapel Witch=26, Big Money=22
+  Margin: 4
+  Turns: 0
+
+Game 5:
+  Winner: Chapel Witch
+  Scores: Chapel Witch=31, Big Money=18
+  Margin: 13
+  Turns: 0
+
+Game 6:
+  Winner: Chapel Witch
+  Scores: Chapel Witch=26, Big Money=23
+  Margin: 3
+  Turns: 0
+
+Game 7:
+  Winner: Chapel Witch
+  Scores: Chapel Witch=36, Big Money=9
+  Margin: 27
+  Turns: 0
+
+Game 8:
+  Winner: Chapel Witch
+  Scores: Chapel Witch=31, Big Money=19
+  Margin: 12
+  Turns: 0
+
+Game 9:
+  Winner: Big Money
+  Scores: Chapel Witch=24, Big Money=25
+  Margin: 1
+  Turns: 0
+
+Game 10:
+  Winner: Chapel Witch
+  Scores: Chapel Witch=30, Big Money=18
+  Margin: 12
+  Turns: 0
+  Log: battle_logs/game_20250615_013012_566439.log


### PR DESCRIPTION
## Summary
- run a sample battle between Chapel Witch and Big Money
- include resulting run output and log/metrics files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e21c640348327b925c55652817a64