### PR TITLE
Fix logging for single game

### DIFF
--- a/dominion/simulation/game_logger.py
+++ b/dominion/simulation/game_logger.py
@@ -68,7 +68,10 @@ class GameLogger:
     def start_game(self, players: List[GeneticAI]):
         """Start tracking a new game with enhanced initial state logging."""
         self.game_count += 1
-        self.should_log_to_file = self.game_count % self.log_frequency == 0
+        # Log the first game, then every ``log_frequency`` games thereafter
+        # ``game_count`` starts at 1 for the first game, so subtract 1 when
+        # computing the modulus to ensure game 1 is logged.
+        self.should_log_to_file = (self.game_count - 1) % self.log_frequency == 0
 
         if self.should_log_to_file:
             # Include microseconds to avoid filename collisions when multiple


### PR DESCRIPTION
## Summary
- log game 1 rather than waiting for game 10

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e2324ad648327b77880fa4c24f476