### PR TITLE
Implement Contraband effect

### DIFF
--- a/dominion/cards/prosperity/contraband.py
+++ b/dominion/cards/prosperity/contraband.py
@@ -11,5 +11,30 @@ class Contraband(Card):
         )
 
     def play_effect(self, game_state):
-        # TODO: implement buy restriction effect
-        pass
+        """Next player names a card the current player cannot buy this turn."""
+        from ..registry import get_card  # Avoid circular import
+
+        if not game_state.players:
+            return
+
+        current_index = game_state.current_player_index
+        next_index = (current_index + 1) % len(game_state.players)
+        next_player = game_state.players[next_index]
+
+        choices = [get_card(name) for name, count in game_state.supply.items() if count > 0]
+        if not choices:
+            return
+
+        banned = next_player.ai.choose_buy(game_state, choices)
+        if banned is None:
+            banned = choices[0]
+
+        game_state.current_player.banned_buys.append(banned.name)
+        game_state.log_callback(
+            (
+                "action",
+                next_player.ai.name,
+                f"bans {banned.name} with Contraband",
+                {},
+            )
+        )

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -114,6 +114,7 @@ class GameState:
         self.current_player.collection_played = 0
         self.current_player.actions_this_turn = 0
         self.current_player.bought_this_turn = []
+        self.current_player.banned_buys = []
 
         # Log turn header with complete state
         resources = {
@@ -289,7 +290,12 @@ class GameState:
         for card_name, count in self.supply.items():
             if count > 0:
                 card = get_card(card_name)
-                if card.cost.coins <= player.coins and card.cost.potions <= player.potions and card.may_be_bought(self):
+                if (
+                    card.cost.coins <= player.coins
+                    and card.cost.potions <= player.potions
+                    and card.may_be_bought(self)
+                    and card_name not in player.banned_buys
+                ):
                     affordable.append(card)
         return affordable
 

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -34,6 +34,7 @@ class PlayerState:
     actions_played: int = 0
     actions_this_turn: int = 0
     bought_this_turn: list[str] = field(default_factory=list)
+    banned_buys: list[str] = field(default_factory=list)
 
     def initialize(self, use_shelters: bool = False):
         """Set up starting deck and draw initial hand.
@@ -76,6 +77,7 @@ class PlayerState:
         self.actions_played = 0
         self.actions_this_turn = 0
         self.bought_this_turn = []
+        self.banned_buys = []
 
         # Draw initial hand of 5 cards
         self.draw_cards(5)


### PR DESCRIPTION
## Summary
- implement Contraband's effect so the next player bans a buy
- track `banned_buys` on each `PlayerState`
- reset banned buys each turn and ignore banned cards when listing purchases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e2832b7e88327a446daa1f2acbaf2