### PR TITLE
Implement effects for some Prosperity cards

### DIFF
--- a/dominion/cards/prosperity/bank.py
+++ b/dominion/cards/prosperity/bank.py
@@ -13,5 +13,6 @@ class Bank(Card):
         )
 
     def play_effect(self, game_state):
-        # TODO: add effect based on treasures in play
-        pass
+        player = game_state.current_player
+        treasures_in_play = sum(1 for c in player.in_play if c.is_treasure)
+        player.coins += treasures_in_play

--- a/dominion/cards/prosperity/bishop.py
+++ b/dominion/cards/prosperity/bishop.py
@@ -13,5 +13,14 @@ class Bishop(Card):
         )
 
     def play_effect(self, game_state):
-        # TODO: implement trash for VP tokens
-        pass
+        player = game_state.current_player
+        if not player.hand:
+            return
+
+        card_to_trash = player.ai.choose_card_to_trash(game_state, player.hand)
+        if card_to_trash is None:
+            card_to_trash = player.hand[0]
+
+        player.hand.remove(card_to_trash)
+        game_state.trash.append(card_to_trash)
+        player.vp_tokens += card_to_trash.cost.coins // 2

--- a/dominion/cards/prosperity/city.py
+++ b/dominion/cards/prosperity/city.py
@@ -11,5 +11,13 @@ class City(Card):
         )
 
     def play_effect(self, game_state):
-        # TODO: add bonuses for empty piles
-        pass
+        player = game_state.current_player
+        empty_piles = sum(1 for count in game_state.supply.values() if count == 0)
+
+        if empty_piles >= 1:
+            game_state.draw_cards(player, 1)
+            player.coins += 1
+
+        if empty_piles >= 2:
+            player.buys += 1
+            player.coins += 1


### PR DESCRIPTION
## Summary
- finish Bank treasure effect based on treasures in play
- implement Bishop trashing for VP tokens
- add City bonuses when supply piles are empty

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e2a2c87dc8327b975174fae604f01