### PR TITLE
Implement basic Prosperity card effects

### DIFF
--- a/dominion/cards/prosperity/counting_house.py
+++ b/dominion/cards/prosperity/counting_house.py
@@ -11,5 +11,8 @@ class CountingHouse(Card):
         )
 
     def play_effect(self, game_state):
-        # TODO: draw coppers from discard
-        pass
+        player = game_state.current_player
+        coppers = [c for c in player.discard if c.name == "Copper"]
+        for copper in coppers:
+            player.discard.remove(copper)
+            player.hand.append(copper)

--- a/dominion/cards/prosperity/expand.py
+++ b/dominion/cards/prosperity/expand.py
@@ -11,5 +11,32 @@ class Expand(Card):
         )
 
     def play_effect(self, game_state):
-        # TODO: trash a card to gain one costing up to 3 more
-        pass
+        from ..registry import get_card
+
+        player = game_state.current_player
+        if not player.hand:
+            return
+
+        card_to_trash = player.ai.choose_card_to_trash(game_state, player.hand)
+        if card_to_trash is None:
+            card_to_trash = player.hand[0]
+
+        player.hand.remove(card_to_trash)
+        game_state.trash.append(card_to_trash)
+
+        max_cost = card_to_trash.cost.coins + 3
+        gains = [
+            name
+            for name, count in game_state.supply.items()
+            if count > 0 and get_card(name).cost.coins <= max_cost
+        ]
+        if not gains:
+            return
+
+        gain_card = player.ai.choose_buy(game_state, [get_card(n) for n in gains])
+        if gain_card is None:
+            gain_card = get_card(gains[0])
+
+        game_state.supply[gain_card.name] -= 1
+        player.discard.append(gain_card)
+        gain_card.on_gain(game_state, player)

--- a/dominion/cards/prosperity/grand_market.py
+++ b/dominion/cards/prosperity/grand_market.py
@@ -11,5 +11,7 @@ class GrandMarket(Card):
         )
 
     def may_be_bought(self, game_state) -> bool:
-        # TODO: cannot be bought if player has Copper in play
+        player = game_state.current_player
+        if any(card.name == "Copper" for card in player.in_play):
+            return False
         return super().may_be_bought(game_state)

--- a/dominion/cards/prosperity/hoard.py
+++ b/dominion/cards/prosperity/hoard.py
@@ -11,5 +11,11 @@ class Hoard(Card):
         )
 
     def on_buy(self, game_state):
-        # TODO: gain a Gold when buying a victory card
-        pass
+        from ..registry import get_card
+
+        if game_state.supply.get("Gold", 0) > 0:
+            game_state.supply["Gold"] -= 1
+            gold = get_card("Gold")
+            player = game_state.current_player
+            player.discard.append(gold)
+            gold.on_gain(game_state, player)

--- a/dominion/cards/prosperity/loan.py
+++ b/dominion/cards/prosperity/loan.py
@@ -11,5 +11,14 @@ class Loan(Card):
         )
 
     def play_effect(self, game_state):
-        # TODO: reveal cards until a treasure is revealed and trash it
-        pass
+        player = game_state.current_player
+        revealed = []
+        while player.deck or player.discard:
+            if not player.deck:
+                player.shuffle_discard_into_deck()
+            card = player.deck.pop()
+            if card.is_treasure:
+                game_state.trash.append(card)
+                break
+            revealed.append(card)
+        player.discard.extend(revealed)

--- a/dominion/cards/prosperity/mint.py
+++ b/dominion/cards/prosperity/mint.py
@@ -11,10 +11,26 @@ class Mint(Card):
         )
 
     def play_effect(self, game_state):
-        # TODO: gain a copy of a treasure from hand
-        pass
+        from ..registry import get_card
+
+        player = game_state.current_player
+        treasures = [c for c in player.hand if c.is_treasure]
+        if not treasures:
+            return
+
+        chosen = player.ai.choose_treasure(game_state, treasures)
+        if chosen is None:
+            chosen = treasures[0]
+
+        if game_state.supply.get(chosen.name, 0) > 0:
+            game_state.supply[chosen.name] -= 1
+            gained = get_card(chosen.name)
+            player.discard.append(gained)
+            gained.on_gain(game_state, player)
 
     def on_gain(self, game_state, player):
         super().on_gain(game_state, player)
-        # TODO: trash all treasures you have in play
-        pass
+        treasures = [c for c in player.in_play if c.is_treasure]
+        for t in treasures:
+            player.in_play.remove(t)
+            game_state.trash.append(t)

--- a/dominion/cards/prosperity/monument.py
+++ b/dominion/cards/prosperity/monument.py
@@ -11,5 +11,5 @@ class Monument(Card):
         )
 
     def play_effect(self, game_state):
-        # TODO: gain a victory token
-        pass
+        player = game_state.current_player
+        player.vp_tokens += 1

--- a/dominion/cards/prosperity/mountebank.py
+++ b/dominion/cards/prosperity/mountebank.py
@@ -11,5 +11,23 @@ class Mountebank(Card):
         )
 
     def play_effect(self, game_state):
-        # TODO: give others Curse and Copper unless they discard a Curse
-        pass
+        player = game_state.current_player
+        for other in game_state.players:
+            if other is player:
+                continue
+            curse = next((c for c in other.hand if c.name == "Curse"), None)
+            if curse:
+                other.hand.remove(curse)
+                other.discard.append(curse)
+            else:
+                from ..registry import get_card
+                if game_state.supply.get("Curse", 0) > 0:
+                    game_state.supply["Curse"] -= 1
+                    gained = get_card("Curse")
+                    other.discard.append(gained)
+                    gained.on_gain(game_state, other)
+                if game_state.supply.get("Copper", 0) > 0:
+                    game_state.supply["Copper"] -= 1
+                    copper = get_card("Copper")
+                    other.discard.append(copper)
+                    copper.on_gain(game_state, other)

--- a/dominion/cards/prosperity/peddler.py
+++ b/dominion/cards/prosperity/peddler.py
@@ -11,5 +11,5 @@ class Peddler(Card):
         )
 
     def cost_modifier(self, game_state, player) -> int:
-        # TODO: reduce cost based on actions in play
-        return 0
+        actions_in_play = sum(1 for c in player.in_play if c.is_action)
+        return -2 * actions_in_play

--- a/dominion/cards/prosperity/royal_seal.py
+++ b/dominion/cards/prosperity/royal_seal.py
@@ -12,5 +12,6 @@ class RoyalSeal(Card):
 
     def on_gain(self, game_state, player):
         super().on_gain(game_state, player)
-        # TODO: allow player to place gained card on top of deck
-        pass
+        if self in player.discard:
+            player.discard.remove(self)
+            player.deck.append(self)

--- a/dominion/cards/prosperity/talisman.py
+++ b/dominion/cards/prosperity/talisman.py
@@ -11,5 +11,21 @@ class Talisman(Card):
         )
 
     def on_buy(self, game_state):
-        # TODO: gain a copy of bought card costing 4 or less
-        pass
+        from ..registry import get_card
+
+        player = game_state.current_player
+        affordable = [
+            name
+            for name, count in game_state.supply.items()
+            if count > 0 and get_card(name).cost.coins <= 4
+        ]
+        if not affordable:
+            return
+
+        gain_card = player.ai.choose_buy(game_state, [get_card(n) for n in affordable])
+        if gain_card is None:
+            gain_card = get_card(affordable[0])
+
+        game_state.supply[gain_card.name] -= 1
+        player.discard.append(gain_card)
+        gain_card.on_gain(game_state, player)

--- a/dominion/cards/prosperity/vault.py
+++ b/dominion/cards/prosperity/vault.py
@@ -11,5 +11,18 @@ class Vault(Card):
         )
 
     def play_effect(self, game_state):
-        # TODO: discard for coins, others may discard for card
-        pass
+        player = game_state.current_player
+
+        discard_count = len(player.hand)
+        player.discard.extend(player.hand)
+        player.hand = []
+        player.coins += discard_count
+
+        for other in game_state.players:
+            if other is player or not other.hand:
+                continue
+            discard = other.hand[:1]
+            other.discard.extend(discard)
+            for c in discard:
+                other.hand.remove(c)
+            other.draw_cards(1)

--- a/dominion/cards/prosperity/venture.py
+++ b/dominion/cards/prosperity/venture.py
@@ -11,5 +11,15 @@ class Venture(Card):
         )
 
     def play_effect(self, game_state):
-        # TODO: reveal cards until a treasure is revealed and play it
-        pass
+        player = game_state.current_player
+        revealed = []
+        while player.deck or player.discard:
+            if not player.deck:
+                player.shuffle_discard_into_deck()
+            card = player.deck.pop()
+            if card.is_treasure:
+                player.in_play.append(card)
+                card.on_play(game_state)
+                break
+            revealed.append(card)
+        player.discard.extend(revealed)

--- a/dominion/cards/prosperity/watchtower.py
+++ b/dominion/cards/prosperity/watchtower.py
@@ -11,10 +11,14 @@ class Watchtower(Card):
         )
 
     def play_effect(self, game_state):
-        # TODO: discard cards for coins
-        pass
+        player = game_state.current_player
+        discard_count = len(player.hand)
+        player.discard.extend(player.hand)
+        player.hand = []
+        player.coins += discard_count
 
     def on_gain(self, game_state, player):
         super().on_gain(game_state, player)
-        # TODO: may place gained card on deck or trash it
-        pass
+        if self in player.discard:
+            player.discard.remove(self)
+            player.deck.append(self)


### PR DESCRIPTION
## Summary
- implement victory token gain for Monument
- let Counting House move Coppers from discard to hand
- add trash & gain logic for Expand and Mint
- tweak costs and buying rules for several cards
- implement simplified actions for Mountebank, Loan, Vault and more

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e2bff691c8327aadbae2ee26ec095