### PR TITLE
Add Looting event and Sewers project

### DIFF
--- a/dominion/cards/allies/modify.py
+++ b/dominion/cards/allies/modify.py
@@ -20,7 +20,7 @@ class Modify(Card):
         if not to_trash:
             return
         player.hand.remove(to_trash)
-        game_state.trash.append(to_trash)
+        game_state.trash_card(player, to_trash)
         max_cost = to_trash.cost.coins + 2
         choices = [
             name

--- a/dominion/cards/base_set/chapel.py
+++ b/dominion/cards/base_set/chapel.py
@@ -27,7 +27,7 @@ class Chapel(Card):
 
             if card_to_trash:
                 player.hand.remove(card_to_trash)
-                game_state.trash.append(card_to_trash)
+                game_state.trash_card(player, card_to_trash)
                 cards_to_trash.append(card_to_trash)
             else:
                 # AI chose to stop trashing

--- a/dominion/cards/base_set/mine.py
+++ b/dominion/cards/base_set/mine.py
@@ -26,7 +26,7 @@ class Mine(Card):
         if treasure_to_trash:
             # Remove from hand and add to trash
             player.hand.remove(treasure_to_trash)
-            game_state.trash.append(treasure_to_trash)
+            game_state.trash_card(player, treasure_to_trash)
 
             # Find treasures that can be gained
             possible_gains = [

--- a/dominion/cards/dark_ages/forager.py
+++ b/dominion/cards/dark_ages/forager.py
@@ -18,7 +18,7 @@ class Forager(Card):
         if card_to_trash is None:
             card_to_trash = player.hand[0]
         player.hand.remove(card_to_trash)
-        game_state.trash.append(card_to_trash)
+        game_state.trash_card(player, card_to_trash)
 
         # Count different treasures in trash
         treasure_names = {c.name for c in game_state.trash if c.is_treasure}

--- a/dominion/cards/dark_ages/rats.py
+++ b/dominion/cards/dark_ages/rats.py
@@ -24,7 +24,7 @@ class Rats(Card):
             trash_choice = player.ai.choose_card_to_trash(game_state, choices)
             if trash_choice:
                 player.hand.remove(trash_choice)
-                game_state.trash.append(trash_choice)
+                game_state.trash_card(player, trash_choice)
 
     def on_trash(self, game_state, player):
         player.draw_cards(1)

--- a/dominion/cards/dark_ages/rebuild.py
+++ b/dominion/cards/dark_ages/rebuild.py
@@ -19,7 +19,7 @@ class Rebuild(Card):
             estate = next((c for c in pile if c.name == "Estate"), None)
             if estate:
                 pile.remove(estate)
-                game_state.trash.append(estate)
+                game_state.trash_card(player, estate)
                 if game_state.supply.get("Duchy", 0) > 0:
                     game_state.supply["Duchy"] -= 1
                     duchy = get_card("Duchy")

--- a/dominion/cards/prosperity/bishop.py
+++ b/dominion/cards/prosperity/bishop.py
@@ -22,5 +22,5 @@ class Bishop(Card):
             card_to_trash = player.hand[0]
 
         player.hand.remove(card_to_trash)
-        game_state.trash.append(card_to_trash)
+        game_state.trash_card(player, card_to_trash)
         player.vp_tokens += card_to_trash.cost.coins // 2

--- a/dominion/events/__init__.py
+++ b/dominion/events/__init__.py
@@ -1,4 +1,5 @@
 from .base_event import Event
 from .gain_silver import GainSilver
+from .looting import Looting
 
-__all__ = ["Event", "GainSilver"]
+__all__ = ["Event", "GainSilver", "Looting"]

--- a/dominion/events/looting.py
+++ b/dominion/events/looting.py
@@ -1,0 +1,15 @@
+from dominion.cards.base_card import CardCost
+from dominion.cards.registry import get_card
+from .base_event import Event
+
+
+class Looting(Event):
+    """Event that gains a Gold when bought."""
+
+    def __init__(self):
+        super().__init__("Looting", CardCost(coins=5))
+
+    def on_buy(self, game_state, player) -> None:
+        gold = get_card("Gold")
+        player.discard.append(gold)
+        gold.on_gain(game_state, player)

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -484,6 +484,16 @@ class GameState:
             return True
         return False
 
+    def trash_card(self, player: PlayerState, card: Card) -> None:
+        """Move a card to the trash and trigger related effects."""
+        self.trash.append(card)
+        card.on_trash(self, player)
+
+        # Resolve project triggers for trashing
+        for project in player.projects:
+            if hasattr(project, "on_trash"):
+                project.on_trash(self, player, card)
+
     def _update_final_metrics(self):
         """Update final game metrics including victory points."""
         if not self.logger:

--- a/dominion/projects/__init__.py
+++ b/dominion/projects/__init__.py
@@ -1,4 +1,5 @@
 from .base_project import Project
 from .card_draw import CardDraw
+from .sewers import Sewers
 
-__all__ = ["Project", "CardDraw"]
+__all__ = ["Project", "CardDraw", "Sewers"]

--- a/dominion/projects/base_project.py
+++ b/dominion/projects/base_project.py
@@ -15,6 +15,9 @@ class Project:
     def on_turn_start(self, game_state, player) -> None:
         pass
 
+    def on_trash(self, game_state, player, card) -> None:
+        pass
+
     @property
     def is_project(self) -> bool:
         return True

--- a/dominion/projects/sewers.py
+++ b/dominion/projects/sewers.py
@@ -1,0 +1,17 @@
+from dominion.cards.base_card import CardCost
+from .base_project import Project
+
+
+class Sewers(Project):
+    """When you trash a card, you may trash a card from your hand."""
+
+    def __init__(self):
+        super().__init__("Sewers", CardCost(coins=3))
+
+    def on_trash(self, game_state, player, card) -> None:
+        if not player.hand:
+            return
+        choice = player.ai.choose_card_to_trash(game_state, player.hand + [None])
+        if choice:
+            player.hand.remove(choice)
+            game_state.trash_card(player, choice)

--- a/tests/test_events_projects.py
+++ b/tests/test_events_projects.py
@@ -1,8 +1,8 @@
 from dominion.game.game_state import GameState
 from dominion.cards.registry import get_card
-from dominion.events import GainSilver
-from dominion.projects import CardDraw
-from tests.utils import BuyEventAI
+from dominion.events import GainSilver, Looting
+from dominion.projects import CardDraw, Sewers
+from tests.utils import BuyEventAI, TrashFirstAI
 
 
 def test_event_gain_silver():
@@ -28,3 +28,31 @@ def test_project_card_draw():
     state.handle_cleanup_phase()
     state.handle_start_phase()
     assert len(player.hand) == 6
+
+
+def test_event_looting_gain_gold():
+    ai = BuyEventAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Village")], events=[Looting()])
+    player = state.players[0]
+    player.coins = 5
+    state.phase = "buy"
+    state.handle_buy_phase()
+    assert any(card.name == "Gold" for card in player.discard)
+
+
+def test_project_sewers_trash_extra():
+    ai = TrashFirstAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Village")], projects=[Sewers()])
+    player = state.players[0]
+    player.coins = 3
+    state.phase = "buy"
+    state.handle_buy_phase()
+    assert len(player.projects) == 1
+
+    # Prepare hand with two cards to trash
+    player.hand = [get_card("Estate"), get_card("Copper")]
+    first = player.hand.pop(0)
+    state.trash_card(player, first)
+    assert len(state.trash) == 2

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,3 +32,10 @@ class BuyEventAI(DummyAI):
             if getattr(choice, "is_event", False) or getattr(choice, "is_project", False):
                 return choice
         return None
+
+
+class TrashFirstAI(BuyEventAI):
+    """AI that always trashes the first available card."""
+
+    def choose_card_to_trash(self, state: GameState, choices: list[Card]) -> Optional[Card]:
+        return choices[0] if choices else None


### PR DESCRIPTION
## Summary
- add new `Looting` event and `Sewers` project
- support project triggers on trashing with `GameState.trash_card`
- update existing cards to use new trash helper
- extend project base with `on_trash`
- add tests for new features

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e2c6e3fb48327ab0f793229d76178