### PR TITLE
Add Way of the Butterfly implementation

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -32,3 +32,7 @@ class AI(ABC):
     def choose_card_to_trash(self, state: GameState, choices: list[Card]) -> Optional[Card]:
         """Choose a card to trash from available choices."""
         pass
+
+    def choose_way(self, state: GameState, card: Card, ways: list) -> Optional[object]:
+        """Choose a Way to use when playing a card. Default is none."""
+        return None

--- a/dominion/ways/__init__.py
+++ b/dominion/ways/__init__.py
@@ -1,0 +1,4 @@
+from .base_way import Way
+from .butterfly import WayOfTheButterfly
+
+__all__ = ["Way", "WayOfTheButterfly"]

--- a/dominion/ways/base_way.py
+++ b/dominion/ways/base_way.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+@dataclass
+class Way:
+    name: str
+
+    def apply(self, game_state, card) -> None:
+        """Apply this Way's effect when the given card is played."""
+        pass
+
+    @property
+    def is_way(self) -> bool:
+        return True

--- a/dominion/ways/butterfly.py
+++ b/dominion/ways/butterfly.py
@@ -1,0 +1,32 @@
+from dominion.cards.registry import get_card
+from dominion.cards.base_card import Card
+from .base_way import Way
+
+
+class WayOfTheButterfly(Way):
+    """Return the played card to its pile to gain a card costing $1 more."""
+
+    def __init__(self):
+        super().__init__("Way of the Butterfly")
+
+    def apply(self, game_state, card: Card) -> None:
+        player = game_state.current_player
+
+        # Return the card to its supply pile
+        if card in player.in_play:
+            player.in_play.remove(card)
+        game_state.supply[card.name] = game_state.supply.get(card.name, 0) + 1
+
+        target_cost = card.cost.coins + 1
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            candidate = get_card(name)
+            if (
+                candidate.cost.coins == target_cost
+                and candidate.cost.potions == card.cost.potions
+            ):
+                game_state.supply[name] -= 1
+                player.discard.append(candidate)
+                candidate.on_gain(game_state, player)
+                break

--- a/dominion/ways/registry.py
+++ b/dominion/ways/registry.py
@@ -1,0 +1,12 @@
+from typing import Type
+from .base_way import Way
+from .butterfly import WayOfTheButterfly
+
+WAY_TYPES: dict[str, Type[Way]] = {
+    "Way of the Butterfly": WayOfTheButterfly,
+}
+
+
+def get_way(name: str) -> Way:
+    way_class = WAY_TYPES[name]
+    return way_class()

--- a/tests/test_ways.py
+++ b/tests/test_ways.py
@@ -1,0 +1,33 @@
+from dominion.game.game_state import GameState
+from dominion.cards.registry import get_card
+from dominion.ways.butterfly import WayOfTheButterfly
+from tests.utils import DummyAI
+
+
+class ButterflyAI(DummyAI):
+    def choose_action(self, state, choices):
+        for c in choices:
+            if c is not None:
+                return c
+        return None
+
+    def choose_way(self, state, card, ways):
+        for w in ways:
+            if w and w.name == "Way of the Butterfly":
+                return w
+        return None
+
+
+def test_way_of_the_butterfly():
+    ai = ButterflyAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Village"), get_card("Smithy")], ways=[WayOfTheButterfly()])
+    player = state.players[0]
+    player.hand = [get_card("Village")]
+    state.phase = "action"
+    village_supply_before = state.supply["Village"]
+    smithy_supply_before = state.supply["Smithy"]
+    state.handle_action_phase()
+    assert state.supply["Village"] == village_supply_before + 1
+    assert state.supply["Smithy"] == smithy_supply_before - 1
+    assert any(card.name == "Smithy" for card in player.discard)


### PR DESCRIPTION
## Summary
- implement base `Way` type and `WayOfTheButterfly`
- extend `GameState` with support for ways and allow playing actions via a Way
- allow AIs to optionally choose a Way
- add tests for Way of the Butterfly

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e5f0a0c308327ab177345c2ad0c8f