### PR TITLE
Add Menagerie event stubs

### DIFF
--- a/dominion/events/__init__.py
+++ b/dominion/events/__init__.py
@@ -1,5 +1,25 @@
 from .base_event import Event
 from .gain_silver import GainSilver
 from .looting import Looting
+from .menagerie_events import (
+    Desperation,
+    Gamble,
+    March,
+    Toil,
+    Enhance,
+    Delay,
+    SeizeTheDay,
+)
 
-__all__ = ["Event", "GainSilver", "Looting"]
+__all__ = [
+    "Event",
+    "GainSilver",
+    "Looting",
+    "Desperation",
+    "Gamble",
+    "March",
+    "Toil",
+    "Enhance",
+    "Delay",
+    "SeizeTheDay",
+]

--- a/dominion/events/menagerie_events.py
+++ b/dominion/events/menagerie_events.py
@@ -1,0 +1,121 @@
+from dominion.cards.base_card import CardCost
+from dominion.cards.registry import get_card
+from .base_event import Event
+
+
+class Desperation(Event):
+    """+1 Buy, gain a Curse."""
+
+    def __init__(self):
+        super().__init__("Desperation", CardCost(coins=0))
+
+    def on_buy(self, game_state, player) -> None:
+        player.buys += 1
+        game_state.give_curse_to_player(player)
+
+
+class Gamble(Event):
+    """Reveal the top card of your deck and play it if possible."""
+
+    def __init__(self):
+        super().__init__("Gamble", CardCost(coins=2))
+
+    def on_buy(self, game_state, player) -> None:
+        if not player.deck and player.discard:
+            player.shuffle_discard_into_deck()
+        if player.deck:
+            card = player.deck.pop()
+            player.in_play.append(card)
+            card.on_play(game_state)
+        else:
+            pass
+
+
+class March(Event):
+    """Play an Action from your discard pile."""
+
+    def __init__(self):
+        super().__init__("March", CardCost(coins=3))
+
+    def on_buy(self, game_state, player) -> None:
+        actions = [c for c in player.discard if c.is_action]
+        if not actions:
+            return
+        choice = player.ai.choose_action(game_state, actions + [None])
+        if choice:
+            player.discard.remove(choice)
+            player.in_play.append(choice)
+            choice.on_play(game_state)
+
+
+class Toil(Event):
+    """Play an Action from your hand."""
+
+    def __init__(self):
+        super().__init__("Toil", CardCost(coins=4))
+
+    def on_buy(self, game_state, player) -> None:
+        actions = [c for c in player.hand if c.is_action]
+        if not actions:
+            return
+        choice = player.ai.choose_action(game_state, actions + [None])
+        if choice:
+            player.hand.remove(choice)
+            player.in_play.append(choice)
+            choice.on_play(game_state)
+
+
+class Enhance(Event):
+    """Trash a card to gain one costing up to 3 more."""
+
+    def __init__(self):
+        super().__init__("Enhance", CardCost(coins=3))
+
+    def on_buy(self, game_state, player) -> None:
+        if not player.hand:
+            return
+        card = player.ai.choose_card_to_trash(game_state, player.hand + [None])
+        if not card:
+            return
+        player.hand.remove(card)
+        game_state.trash_card(player, card)
+        max_cost = card.cost.coins + 3
+        affordable = [
+            name
+            for name, count in game_state.supply.items()
+            if count > 0 and get_card(name).cost.coins <= max_cost
+        ]
+        if affordable:
+            gain = get_card(affordable[0])
+            game_state.supply[gain.name] -= 1
+            player.discard.append(gain)
+            gain.on_gain(game_state, player)
+
+
+class Delay(Event):
+    """Set aside a card to take next turn."""
+
+    def __init__(self):
+        super().__init__("Delay", CardCost(coins=2))
+
+    def on_buy(self, game_state, player) -> None:
+        if not player.hand:
+            return
+        choice = player.ai.choose_action(game_state, player.hand + [None])
+        if choice:
+            player.hand.remove(choice)
+            player.delayed_cards.append(choice)
+
+
+class SeizeTheDay(Event):
+    """Take an extra turn (once per game)."""
+
+    def __init__(self):
+        super().__init__("Seize the Day", CardCost(coins=4))
+
+    def may_be_bought(self, game_state, player) -> bool:
+        return not player.seize_the_day_used
+
+    def on_buy(self, game_state, player) -> None:
+        player.seize_the_day_used = True
+        game_state.extra_turn = True

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -125,6 +125,11 @@ class GameState:
         self.current_player.bought_this_turn = []
         self.current_player.banned_buys = []
 
+        # Return any cards delayed by the Delay event
+        if self.current_player.delayed_cards:
+            self.current_player.hand.extend(self.current_player.delayed_cards)
+            self.current_player.delayed_cards = []
+
         # Resolve project effects that occur at the start of the turn
         for project in self.current_player.projects:
             project.on_turn_start(self, self.current_player)

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -36,6 +36,8 @@ class PlayerState:
     actions_this_turn: int = 0
     bought_this_turn: list[str] = field(default_factory=list)
     banned_buys: list[str] = field(default_factory=list)
+    delayed_cards: list[Card] = field(default_factory=list)
+    seize_the_day_used: bool = False
 
     def initialize(self, use_shelters: bool = False):
         """Set up starting deck and draw initial hand.
@@ -80,6 +82,8 @@ class PlayerState:
         self.actions_this_turn = 0
         self.bought_this_turn = []
         self.banned_buys = []
+        self.delayed_cards = []
+        self.seize_the_day_used = False
 
         # Draw initial hand of 5 cards
         self.draw_cards(5)

--- a/tests/test_events_projects.py
+++ b/tests/test_events_projects.py
@@ -1,6 +1,12 @@
 from dominion.game.game_state import GameState
 from dominion.cards.registry import get_card
-from dominion.events import GainSilver, Looting
+from dominion.events import (
+    GainSilver,
+    Looting,
+    Desperation,
+    Delay,
+    SeizeTheDay,
+)
 from dominion.projects import CardDraw, Sewers
 from tests.utils import BuyEventAI, TrashFirstAI
 
@@ -59,3 +65,53 @@ def test_project_sewers_trash_extra():
     first = player.hand.pop(0)
     state.trash_card(player, first)
     assert len(state.trash) == 2
+
+class ChooseFirstActionAI(BuyEventAI):
+    def choose_action(self, state, choices):
+        for ch in choices:
+            if ch is not None:
+                return ch
+        return None
+
+
+def test_event_desperation():
+    ai = BuyEventAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Village")], events=[Desperation()])
+    player = state.players[0]
+    player.coins = 0
+    state.phase = "buy"
+    curses_before = state.supply["Curse"]
+    state.handle_buy_phase()
+    assert state.supply["Curse"] == curses_before - 1
+    assert any(c.name == "Curse" for c in player.discard)
+
+
+def test_event_seize_the_day_extra_turn():
+    ai = BuyEventAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Village")], events=[SeizeTheDay()])
+    player = state.players[0]
+    player.coins = 4
+    state.phase = "buy"
+    state.handle_buy_phase()
+    assert state.extra_turn
+    state.handle_cleanup_phase()
+    assert state.current_player is player
+    state.handle_start_phase()
+    assert player.turns_taken == 2
+
+
+def test_event_delay_returns_card():
+    ai = ChooseFirstActionAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Village")], events=[Delay()])
+    player = state.players[0]
+    player.coins = 2
+    state.phase = "buy"
+    first = player.hand[0]
+    state.handle_buy_phase()
+    assert first not in player.hand
+    state.handle_cleanup_phase()
+    state.handle_start_phase()
+    assert first in player.hand


### PR DESCRIPTION
## Summary
- implement several simple Menagerie events
- track delayed cards and Seize the Day usage in `PlayerState`
- return delayed cards at start of turn
- test new events

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e5f2ea1a08327adde1e312c7d3bfe