### PR TITLE
Fix trash handling and add tests

### DIFF
--- a/dominion/cards/base_set/mine.py
+++ b/dominion/cards/base_set/mine.py
@@ -13,6 +13,7 @@ class Mine(Card):
     def play_effect(self, game_state):
         """Trash a treasure from hand and gain a treasure costing up to 3 coins more."""
         player = game_state.current_player
+        from ..registry import get_card
 
         # Find treasures in hand
         treasure_cards = [card for card in player.hand if card.is_treasure]
@@ -34,13 +35,13 @@ class Mine(Card):
                 for card in game_state.supply.keys()
                 if card in ["Copper", "Silver", "Gold"]
                 and game_state.supply[card] > 0
-                and Card.get_card(card).cost.coins <= treasure_to_trash.cost.coins + 3
+                and get_card(card).cost.coins <= treasure_to_trash.cost.coins + 3
             ]
 
             # Let AI choose what to gain
             if possible_gains:
                 chosen_card = player.ai.choose_buy(
-                    game_state, [Card.get_card(name) for name in possible_gains]
+                    game_state, [get_card(name) for name in possible_gains]
                 )
 
                 if chosen_card:

--- a/dominion/cards/prosperity/expand.py
+++ b/dominion/cards/prosperity/expand.py
@@ -22,7 +22,7 @@ class Expand(Card):
             card_to_trash = player.hand[0]
 
         player.hand.remove(card_to_trash)
-        game_state.trash.append(card_to_trash)
+        game_state.trash_card(player, card_to_trash)
 
         max_cost = card_to_trash.cost.coins + 3
         gains = [

--- a/dominion/cards/prosperity/loan.py
+++ b/dominion/cards/prosperity/loan.py
@@ -18,7 +18,7 @@ class Loan(Card):
                 player.shuffle_discard_into_deck()
             card = player.deck.pop()
             if card.is_treasure:
-                game_state.trash.append(card)
+                game_state.trash_card(player, card)
                 break
             revealed.append(card)
         player.discard.extend(revealed)

--- a/dominion/cards/prosperity/mint.py
+++ b/dominion/cards/prosperity/mint.py
@@ -33,4 +33,4 @@ class Mint(Card):
         treasures = [c for c in player.in_play if c.is_treasure]
         for t in treasures:
             player.in_play.remove(t)
-            game_state.trash.append(t)
+            game_state.trash_card(player, t)

--- a/dominion/events/menagerie_events.py
+++ b/dominion/events/menagerie_events.py
@@ -118,4 +118,5 @@ class SeizeTheDay(Event):
 
     def on_buy(self, game_state, player) -> None:
         player.seize_the_day_used = True
+        player.turns_taken += 1
         game_state.extra_turn = True

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -106,7 +106,7 @@ class GameState:
             "Estate": 12 if len(self.players) > 2 else 8,
             "Duchy": 12 if len(self.players) > 2 else 8,
             "Province": 12 if len(self.players) > 2 else 8,
-            "Curse": 10 * (len(self.players) - 1),
+            "Curse": 10 * (len(self.players) - 1) if len(self.players) > 1 else 10,
         }
 
         self.supply = dict(basic_cards)
@@ -118,8 +118,7 @@ class GameState:
 
     def handle_start_phase(self):
         """Handle the start of turn phase."""
-        if not self.extra_turn:
-            self.current_player.turns_taken += 1
+        self.current_player.turns_taken += 1
 
         # Reset per-turn flags
         self.current_player.ignore_action_bonuses = False

--- a/tests/test_trashing_cards.py
+++ b/tests/test_trashing_cards.py
@@ -1,0 +1,76 @@
+import pytest
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from dominion.cards.registry import get_card
+from tests.utils import TrashFirstAI
+
+
+def play_action(state, player, card):
+    """Helper to play an action card from hand."""
+    player.hand.remove(card)
+    player.in_play.append(card)
+    card.on_play(state)
+
+
+def test_expand_trashes_card_and_triggers_on_trash():
+    ai = TrashFirstAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([get_card("Expand"), get_card("Village")])
+
+    # Ensure deck has a card to draw when Rats is trashed
+    player.deck = [get_card("Copper")]
+    player.hand = [get_card("Expand"), get_card("Rats")]
+
+    expand = player.hand[0]
+    play_action(state, player, expand)
+
+    # Rats should be trashed and its on_trash draws a card
+    assert any(c.name == "Rats" for c in state.trash)
+    assert len(player.hand) == 1  # drew back up to one card
+
+
+def test_mint_on_gain_trashes_treasures_in_play():
+    ai = TrashFirstAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([get_card("Mint")])
+
+    player.in_play = [get_card("Copper"), get_card("Silver")]
+    mint = get_card("Mint")
+    mint.on_gain(state, player)
+
+    assert len(state.trash) == 2
+    assert not player.in_play
+
+
+def test_loan_trashes_first_treasure():
+    ai = TrashFirstAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([])
+
+    player.deck = [get_card("Silver"), get_card("Estate")]
+    loan = get_card("Loan")
+    player.hand = [loan]
+    play_action(state, player, loan)
+
+    assert any(c.name == "Silver" for c in state.trash)
+    assert all(c.name != "Silver" for c in player.discard)
+
+
+
+def test_forager_trashes_card():
+    ai = TrashFirstAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([get_card("Forager")])
+
+    player.deck = [get_card("Copper")]
+    player.hand = [get_card("Forager"), get_card("Rats")]
+
+    forager = player.hand[0]
+    play_action(state, player, forager)
+
+    assert any(c.name == "Rats" for c in state.trash)
+    assert len(player.hand) == 1  # Rats drew a card on trash

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,7 +29,9 @@ class BuyEventAI(DummyAI):
 
     def choose_buy(self, state: GameState, choices: list[Optional[Card]]):
         for choice in choices:
-            if getattr(choice, "is_event", False) or getattr(choice, "is_project", False):
+            if (
+                getattr(choice, "is_event", False) or getattr(choice, "is_project", False)
+            ) and choice.name not in state.current_player.bought_this_turn:
                 return choice
         return None
 


### PR DESCRIPTION
## Summary
- ensure trashing cards call `trash_card`
- import `get_card` lazily in Mine
- update `BuyEventAI` to avoid infinite loops
- always provide some curses in games with one player
- increment turn counter for extra turns
- add coverage tests for trashing cards
- add Forager trashing test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e667210c483279e0d8add5bf5e0e0