### PR TITLE
Fix Patrician/Emporium split pile rules

### DIFF
--- a/dominion/cards/empires/emporium.py
+++ b/dominion/cards/empires/emporium.py
@@ -1,7 +1,10 @@
 from ..base_card import Card, CardCost, CardStats, CardType
+from ..split_pile import SplitPileMixin
 
 
-class Emporium(Card):
+class Emporium(SplitPileMixin, Card):
+    partner_card_name = "Patrician"
+    bottom = True
     def __init__(self):
         super().__init__(
             name="Emporium",
@@ -9,6 +12,7 @@ class Emporium(Card):
             stats=CardStats(actions=2, cards=2, vp=2),
             types=[CardType.ACTION, CardType.VICTORY],
         )
+
 
     def on_gain(self, game_state, player):
         super().on_gain(game_state, player)

--- a/dominion/cards/empires/patrician.py
+++ b/dominion/cards/empires/patrician.py
@@ -1,7 +1,10 @@
 from ..base_card import Card, CardCost, CardStats, CardType
+from ..split_pile import SplitPileMixin
 
 
-class Patrician(Card):
+class Patrician(SplitPileMixin, Card):
+    partner_card_name = "Emporium"
+    bottom = False
     def __init__(self):
         super().__init__(
             name="Patrician",
@@ -9,6 +12,7 @@ class Patrician(Card):
             stats=CardStats(cards=1, actions=1),
             types=[CardType.ACTION],
         )
+
 
     def play_effect(self, game_state):
         player = game_state.current_player

--- a/dominion/cards/split_pile.py
+++ b/dominion/cards/split_pile.py
@@ -1,0 +1,17 @@
+from .base_card import Card
+
+
+class SplitPileMixin(Card):
+    """Mixin for cards that share a split pile."""
+
+    partner_card_name: str = ""
+    bottom: bool = False
+
+    def starting_supply(self, game_state) -> int:
+        # Each half of the split pile starts with five or eight copies
+        return 5 if len(game_state.players) <= 2 else 8
+
+    def may_be_bought(self, game_state) -> bool:
+        if self.bottom and game_state.supply.get(self.partner_card_name, 0) > 0:
+            return False
+        return super().may_be_bought(game_state)

--- a/tests/test_split_piles.py
+++ b/tests/test_split_piles.py
@@ -1,0 +1,22 @@
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from dominion.cards.registry import get_card
+from tests.utils import DummyAI
+
+
+def test_patrician_emporium_supply_and_buy_rule():
+    players = [PlayerState(DummyAI()) for _ in range(2)]
+    state = GameState(players)
+    state.setup_supply([get_card("Patrician"), get_card("Emporium")])
+
+    # Split pile should start with five of each card
+    assert state.supply["Patrician"] == 5
+    assert state.supply["Emporium"] == 5
+
+    emp = get_card("Emporium")
+    # Cannot buy Emporium while Patricians remain
+    assert not emp.may_be_bought(state)
+
+    state.supply["Patrician"] = 0
+    # Once Patricians are gone Emporium becomes available
+    assert emp.may_be_bought(state)


### PR DESCRIPTION
## Summary
- adjust Patrician and Emporium starting supply to behave as a split pile
- restrict Emporium purchases until Patricians are gone
- add regression test covering the split pile behaviour
- factor out shared logic into a `SplitPileMixin`

## Testing
- `pytest -q tests/test_split_piles.py`
- `pytest -q` *(8 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_684e6601a7c08327855a72f32a7df28b