### PR TITLE
Add battle logs for CustomBoard3 vs CustomBoard2

### DIFF
--- a/battle_logs/game_20250615_070005_843795.log
+++ b/battle_logs/game_20250615_070005_843795.log
@@ -1,0 +1,3250 @@
+07:00:05 - INFO - ============================================================
+07:00:05 - INFO - Starting Game 1
+07:00:05 - INFO - Players: Player 1 (CustomBoard3), Player 2 (CustomBoard2)
+07:00:05 - INFO - ============================================================
+07:00:05 - INFO - Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Collection': 10, 'Emporium': 10, 'Forager': 10, 'Miser': 10, 'Modify': 10, 'Patrician': 10, 'Rats': 10, 'Rebuild': 10, 'Skulk': 10, 'Snowy Village': 10}
+07:00:05 - INFO - Game initialized with players: Player 1 (CustomBoard3), Player 2 (CustomBoard2)
+07:00:05 - INFO - Kingdom cards: Collection, Emporium, Forager, Miser, Modify, Patrician, Rats, Rebuild, Skulk, Snowy Village
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 1 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Estate, Copper, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (9 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 0 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 1 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Estate, Copper, Copper, Estate, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (8 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 0 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 2 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Estate, Copper, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (7 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 0 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 2 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Estate, Copper, Copper, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (6 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 0 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 3 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Estate, Copper, Patrician, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Estate, Copper, Copper, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (5 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 1 action and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 3 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Estate, Copper, Copper, Patrician, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (4 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 4 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Estate, Copper, Copper, Copper, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (3 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 1 action and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 4 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Copper, Patrician, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Copper, Estate, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (2 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 5 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Copper, Patrician, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Copper, Patrician, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Estate, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (1 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 2 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 5 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Patrician, Estate, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Patrician, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (0 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 2 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 6 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Patrician, Patrician, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Patrician, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Patrician, Estate, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Estate, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:05 - INFO - Supply: Snowy Village gained (9 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 2 actions and bought Snowy Village
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 6 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Copper, Estate, Estate, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Estate, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Estate, Patrician, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Estate, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Estate, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:05 - INFO - Supply: Forager gained (9 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 2 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 7 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Estate, Copper, Copper, Copper, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Copper, Copper, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Copper, Copper, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Snowy Village gained (8 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 3 actions and bought Snowy Village
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 7 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Patrician, Patrician, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Patrician, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Patrician, Estate, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Estate, Estate, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Estate, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:05 - INFO - Supply: Forager gained (8 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 3 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 8 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Estate, Copper, Patrician, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Estate, Copper, Copper, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:05 - INFO - Supply: Snowy Village gained (7 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 1 action and bought Snowy Village
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 8 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager, Copper, Estate, Copper, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Estate, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 1)
+07:00:05 - INFO - Supply: Forager gained (7 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 9 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Snowy Village, Patrician, Estate, Copper, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Estate, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Estate, Copper, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Estate, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Estate, Copper, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Estate, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Estate, Copper, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Estate, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Estate, Copper, Patrician, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Estate, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Estate, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Estate, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Estate, Copper, Copper, Copper, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Estate, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Forager gained (6 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 7 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 9 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Copper, Forager, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Patrician, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Patrician, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Patrician, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 1)
+07:00:05 - INFO - Supply: Forager gained (5 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 3 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 10 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Estate, Copper, Snowy Village, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Estate, Copper, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Copper, Estate, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:05 - INFO - Supply: Forager gained (4 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 1 action and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 10 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Copper, Estate, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Copper, Copper, Copper, Estate, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 1)
+07:00:05 - INFO - Supply: Forager gained (3 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 2 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 11 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Patrician, Copper, Patrician, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Patrician, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Patrician, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 0; remaining_buys: 0)
+07:00:05 - INFO - Supply: Emporium gained (9 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 2 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 11 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Copper, Patrician, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Copper, Patrician, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: )
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: )
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 5 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 12 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Snowy Village, Forager, Estate, Estate, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Snowy Village, Estate, Estate, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Estate, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Estate, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Estate, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Estate, Estate, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Estate, Estate)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 4 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 12 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Copper, Copper, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Copper, Copper, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Copper, Copper, Copper, Copper, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 1)
+07:00:05 - INFO - Supply: Forager gained (2 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 3 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 13 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Copper, Copper, Patrician, Snowy Village
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Patrician, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Copper, Copper, Patrician, Snowy Village, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Snowy Village, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Snowy Village, Snowy Village, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Snowy Village, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Snowy Village, Snowy Village, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Snowy Village, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Snowy Village, Snowy Village, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Copper, Snowy Village, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Copper, Copper, Snowy Village, Copper, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Copper, Copper, Snowy Village, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 2; hand: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 1)
+07:00:05 - INFO - Supply: Silver gained (39 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 7 actions and bought Silver
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 13 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Estate, Forager, Patrician, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Estate, Patrician, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: )
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 2)
+07:00:05 - INFO - Supply: Forager gained (1 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 3 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 14 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Estate, Copper, Copper, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Copper, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Estate, Copper, Copper, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Estate, Copper, Copper, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Copper; new_hand: Estate, Copper, Copper, Forager, Snowy Village, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 1; hand: Estate, Copper, Copper, Snowy Village, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Copper, Copper, Copper, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 4; coins_added: 2; coins_after: 6; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 1)
+07:00:05 - INFO - Supply: Emporium gained (8 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 4 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 14 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Forager, Forager, Patrician, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Forager, Patrician, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 3 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 15 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Snowy Village, Copper, Copper, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Snowy Village, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Snowy Village, Copper, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Snowy Village, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Copper, Snowy Village, Copper, Copper, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Copper, Copper, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Copper, Snowy Village, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Copper, Copper, Copper, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Copper, Copper, Copper, Snowy Village, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Copper, Copper, Copper, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Copper, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 0; remaining_buys: 1)
+07:00:05 - INFO - Supply: Silver gained (38 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 7 actions and bought Silver
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 15 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Copper, Patrician, Forager, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Copper, Patrician, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Patrician, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Patrician, Copper, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: )
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 5 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 16 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Snowy Village, Copper, Copper, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Copper, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Snowy Village, Copper, Copper, Forager, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Snowy Village, Copper, Copper, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Silver, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Silver, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 0; remaining_buys: 1)
+07:00:05 - INFO - Supply: Emporium gained (7 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 3 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 16 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Forager, Forager, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Forager, Forager, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 3 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 17 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Snowy Village, Snowy Village, Silver, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Snowy Village, Silver, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Copper, Snowy Village, Silver, Copper, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Copper, Snowy Village, Silver, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 2; hand: Silver, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Silver, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Silver, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Silver, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Silver, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 0; remaining_buys: 1)
+07:00:05 - INFO - Supply: Emporium gained (6 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 4 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 17 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Forager, Forager, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Forager, Forager, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 3 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 18 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Forager, Snowy Village
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Forager, Snowy Village, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Snowy Village, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Emporium, Forager, Snowy Village, Patrician, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Snowy Village, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Emporium, Forager, Snowy Village, Copper, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Snowy Village, Copper, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Forager, Snowy Village, Copper, Silver, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Snowy Village, Copper, Silver, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Snowy Village, Copper, Silver, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Snowy Village, Copper, Silver, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Forager; new_hand: Forager, Snowy Village, Copper, Silver, Emporium, Copper, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Snowy Village, Copper, Silver, Copper, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Patrician; new_hand: Forager, Snowy Village, Copper, Silver, Copper, Forager, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Forager, Snowy Village, Copper, Silver, Copper, Forager, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Forager, Snowy Village, Copper, Silver, Copper, Forager, Copper, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Snowy Village, Copper, Silver, Copper, Forager, Copper, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Silver; new_hand: Forager, Snowy Village, Copper, Silver, Copper, Forager, Copper, Snowy Village, Snowy Village, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 4; hand: Snowy Village, Copper, Silver, Copper, Forager, Copper, Snowy Village, Snowy Village, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 4; hand: Snowy Village, Silver, Copper, Copper, Snowy Village, Snowy Village, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 4; hand: Silver, Copper, Snowy Village, Snowy Village, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 7; hand: Silver, Copper, Snowy Village, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: Silver, Copper, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Silver, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 5; coins_added: 2; coins_after: 7; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 2; remaining_buys: 2)
+07:00:05 - INFO - Supply: Emporium gained (5 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 14 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 18 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Forager, Forager, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Forager, Forager, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 3 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 19 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Forager, Emporium, Snowy Village
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Forager, Emporium, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Forager, Emporium, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Snowy Village, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Forager, Emporium, Snowy Village, Emporium, Emporium, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Snowy Village, Emporium, Emporium, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Forager; new_hand: Forager, Snowy Village, Emporium, Emporium, Snowy Village, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Snowy Village, Emporium, Emporium, Snowy Village, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Forager, Snowy Village, Emporium, Emporium, Snowy Village, Forager, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Snowy Village, Emporium, Snowy Village, Forager, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Silver; new_hand: Forager, Snowy Village, Emporium, Snowy Village, Forager, Silver, Copper, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Snowy Village, Snowy Village, Forager, Silver, Copper, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Emporium; new_hand: Forager, Snowy Village, Snowy Village, Forager, Silver, Copper, Silver, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Snowy Village, Snowy Village, Forager, Silver, Copper, Silver, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Forager, Snowy Village, Snowy Village, Forager, Silver, Copper, Silver, Snowy Village, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 4; hand: Forager, Snowy Village, Snowy Village, Forager, Silver, Copper, Silver, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Snowy Village, Snowy Village, Forager, Silver, Copper, Silver, Snowy Village, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 4; hand: Forager, Snowy Village, Snowy Village, Forager, Silver, Copper, Silver, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Snowy Village, Snowy Village, Forager, Silver, Copper, Silver, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 5; hand: Snowy Village, Snowy Village, Forager, Silver, Copper, Silver, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 5; hand: Snowy Village, Snowy Village, Silver, Silver, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 5; hand: Snowy Village, Silver, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 8; hand: Silver, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 7; hand: Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 0; remaining_buys: 2)
+07:00:05 - INFO - Supply: Emporium gained (4 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 15 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 19 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager, Forager, Forager, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 2)
+07:00:05 - INFO - Supply: Forager gained (0 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 2 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 20 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Forager, Snowy Village, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Forager, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Forager, Snowy Village, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Snowy Village, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Forager, Snowy Village, Emporium, Emporium, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Snowy Village, Emporium, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Forager, Patrician; new_hand: Forager, Snowy Village, Emporium, Snowy Village, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Snowy Village, Emporium, Snowy Village, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Snowy Village, Emporium, Snowy Village, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Snowy Village, Emporium, Snowy Village, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Snowy Village, Emporium, Snowy Village, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Snowy Village, Emporium, Snowy Village, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Forager, Snowy Village, Emporium, Snowy Village, Forager, Emporium, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Snowy Village, Snowy Village, Forager, Emporium, Silver, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Emporium, Snowy Village; new_hand: Forager, Snowy Village, Snowy Village, Forager, Emporium, Silver, Emporium, Emporium, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Snowy Village, Snowy Village, Forager, Silver, Emporium, Emporium, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Snowy Village, Snowy Village, Forager, Silver, Emporium, Emporium, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Snowy Village, Snowy Village, Forager, Silver, Emporium, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Snowy Village, Snowy Village, Forager, Silver, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager, Snowy Village, Snowy Village, Forager, Silver, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: Snowy Village, Snowy Village, Forager, Silver, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: Snowy Village, Snowy Village, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 9; hand: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 2)
+07:00:05 - INFO - Supply: Snowy Village gained (6 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 15 actions and bought Snowy Village
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 20 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager, Forager, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 2 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 21 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Emporium, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Forager, Emporium, Patrician, Emporium, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Forager, Emporium, Emporium, Snowy Village, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Snowy Village, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Forager, Emporium, Snowy Village, Forager, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Snowy Village, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Snowy Village, Forager, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Snowy Village, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Snowy Village, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Snowy Village, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Snowy Village; new_hand: Forager, Snowy Village, Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Forager, Snowy Village, Forager, Emporium, Emporium, Emporium, Emporium, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Forager, Snowy Village, Forager, Emporium, Emporium, Emporium, Emporium, Snowy Village, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Snowy Village, Forager, Emporium, Emporium, Emporium, Snowy Village, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Snowy Village, Forager, Emporium, Emporium, Snowy Village, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Snowy Village, Forager, Emporium, Snowy Village, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager, Snowy Village, Forager, Snowy Village, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: Snowy Village, Forager, Snowy Village, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: Snowy Village, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 2)
+07:00:05 - INFO - Supply: Snowy Village gained (5 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 14 actions and bought Snowy Village
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 21 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 22 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Emporium, Patrician, Emporium, Emporium, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Snowy Village, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Snowy Village, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Snowy Village, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Snowy Village, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Snowy Village; new_hand: Emporium, Emporium, Snowy Village, Emporium, Forager, Patrician, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Snowy Village, Emporium, Forager, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Snowy Village, Emporium, Forager, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Snowy Village, Emporium, Forager, Snowy Village, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Snowy Village, Emporium, Forager, Snowy Village, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Snowy Village, Emporium, Forager, Snowy Village, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Snowy Village, Forager, Snowy Village, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Snowy Village, Forager, Snowy Village, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Snowy Village, Forager, Snowy Village, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: Snowy Village, Snowy Village, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 2)
+07:00:05 - INFO - Supply: Snowy Village gained (4 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 13 actions and bought Snowy Village
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 22 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 23 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Forager, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Forager, Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Forager, Emporium, Emporium, Emporium, Emporium, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Forager, Emporium, Emporium, Emporium, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Forager, Emporium, Emporium, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Forager, Emporium, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Forager, Snowy Village, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager, Forager, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: Forager, Snowy Village)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 13 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 23 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 24 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Emporium, Snowy Village, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Snowy Village, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Snowy Village, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Snowy Village, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Emporium, Snowy Village, Forager, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Snowy Village, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Snowy Village, Forager, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Snowy Village, Forager, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Snowy Village, Forager, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Snowy Village, Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Snowy Village, Forager, Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Snowy Village, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Snowy Village, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Snowy Village, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Snowy Village, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Snowy Village, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Snowy Village, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: Snowy Village)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 24 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 25 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager, Emporium, Emporium, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 25 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 26 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Emporium, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Forager, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 26 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 27 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Emporium, Patrician, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 27 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 28 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Patrician, Emporium, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 28 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 29 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Patrician, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Patrician, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Emporium, Patrician, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Patrician, Patrician, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 29 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 30 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Forager, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 30 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 31 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Patrician, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 31 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 32 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Forager, Patrician, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Forager, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Forager, Patrician, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Patrician, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Patrician, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 32 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 33 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Emporium, Emporium, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 33 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 34 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Patrician, Emporium, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 34 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 35 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Emporium, Emporium, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 35 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 36 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 36 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 37 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Forager, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 37 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 38 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager, Emporium, Patrician, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 38 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 39 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Emporium, Forager, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 39 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 40 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Emporium, Emporium, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 40 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 41 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Emporium, Patrician, Patrician, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 41 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 42 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Emporium, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 42 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 43 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Emporium, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 43 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 44 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Emporium, Patrician, Emporium, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 44 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 45 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Emporium, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 45 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 46 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Patrician, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 46 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 47 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Emporium, Patrician, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 47 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 48 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Forager, Patrician, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 48 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 49 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Emporium, Patrician, Patrician, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Patrician, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 49 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 50 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Patrician, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 50 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 51 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Patrician, Patrician, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Patrician, Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 51 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 52 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 52 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 53 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Emporium, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 53 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 54 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Patrician, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 54 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 55 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Forager, Patrician, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Patrician, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Patrician, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Patrician, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 55 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 56 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager, Emporium, Patrician, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 56 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 57 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Emporium, Emporium, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 57 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 58 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Patrician, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Patrician, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Emporium, Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Patrician, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 58 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 59 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Emporium, Emporium, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 59 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 60 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Emporium, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 60 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 61 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Emporium, Patrician, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 61 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 62 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Emporium, Emporium, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 62 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 63 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Forager, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 63 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 64 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Patrician, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Patrician, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Patrician, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 64 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 65 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Forager, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 65 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 66 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Forager, Patrician, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 66 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 67 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Forager, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Forager, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 67 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 68 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Emporium, Patrician, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 68 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 69 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Forager, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 69 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 70 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Emporium, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Emporium, Emporium, Emporium, Forager, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 70 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 71 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Emporium, Patrician, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 71 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 72 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Patrician, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Patrician, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 72 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 73 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Patrician, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 73 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 74 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Emporium, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 74 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 75 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Patrician, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Patrician, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Emporium, Patrician, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Patrician, Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 75 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 76 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Emporium, Patrician, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Emporium, Patrician, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 76 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 77 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Emporium, Forager, Patrician, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Forager, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 77 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 78 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Emporium, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 78 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 79 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Patrician, Patrician, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Patrician, Patrician, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Forager, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 79 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 80 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 80 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 81 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Forager, Emporium, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 81 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 82 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Patrician, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 82 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 83 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Emporium, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 83 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 84 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Emporium, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Patrician, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 84 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 85 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Forager, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Forager, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 85 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 86 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Forager, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 86 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 87 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Patrician, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Patrician, Patrician, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Patrician, Forager, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Forager, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Patrician, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 87 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 88 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Emporium, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Patrician, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 88 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 89 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Emporium, Emporium, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 89 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 90 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Emporium, Emporium, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 90 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 91 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Emporium, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 91 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 92 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Emporium, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 92 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 93 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Emporium, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Forager, Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 93 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 94 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Patrician, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Patrician, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 94 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 95 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Emporium, Emporium, Patrician, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 95 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 96 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Patrician, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 96 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 97 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Emporium, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 97 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 98 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Forager, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 98 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 99 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Emporium, Patrician, Patrician, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Patrician, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Emporium, Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 99 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 100 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Patrician, Emporium, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Emporium, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Forager, Emporium)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Forager)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 6; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 100 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:05 - INFO - Game over: Maximum turns reached
+07:00:05 - INFO - 
+============================================================
+07:00:05 - INFO - Game Over!
+07:00:05 - INFO - Winner: Player 1 (CustomBoard3)
+07:00:05 - INFO - 
+Final Scores:
+07:00:05 - INFO -   Player 1 (CustomBoard3): 24
+07:00:05 - INFO -     Emporium x6 -> 12 VP
+07:00:05 - INFO -     VP Tokens: 12
+07:00:05 - INFO -   Player 2 (CustomBoard2): 0
+07:00:05 - INFO - 
+Final Supply State:
+07:00:05 - INFO -   Copper: 46 remaining
+07:00:05 - INFO -   Silver: 38 remaining
+07:00:05 - INFO -   Gold: 30 remaining
+07:00:05 - INFO -   Estate: 8 remaining
+07:00:05 - INFO -   Duchy: 8 remaining
+07:00:05 - INFO -   Province: 8 remaining
+07:00:05 - INFO -   Curse: 10 remaining
+07:00:05 - INFO -   Collection: 10 remaining
+07:00:05 - INFO -   Emporium: 4 remaining
+07:00:05 - INFO -   Forager: Empty
+07:00:05 - INFO -   Miser: 10 remaining
+07:00:05 - INFO -   Modify: 10 remaining
+07:00:05 - INFO -   Patrician: Empty
+07:00:05 - INFO -   Rats: 10 remaining
+07:00:05 - INFO -   Rebuild: 10 remaining
+07:00:05 - INFO -   Skulk: 10 remaining
+07:00:05 - INFO -   Snowy Village: 4 remaining
+07:00:05 - INFO - ============================================================
+

--- a/battle_logs/game_20250615_070005_960829.log
+++ b/battle_logs/game_20250615_070005_960829.log
@@ -1,0 +1,844 @@
+07:00:05 - INFO - ============================================================
+07:00:05 - INFO - Starting Game 2
+07:00:05 - INFO - Players: Player 1 (CustomBoard2), Player 2 (CustomBoard3)
+07:00:05 - INFO - ============================================================
+07:00:05 - INFO - Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Collection': 10, 'Emporium': 10, 'Forager': 10, 'Miser': 10, 'Modify': 10, 'Patrician': 10, 'Rats': 10, 'Rebuild': 10, 'Skulk': 10, 'Snowy Village': 10}
+07:00:05 - INFO - Game initialized with players: Player 1 (CustomBoard2), Player 2 (CustomBoard3)
+07:00:05 - INFO - Kingdom cards: Collection, Emporium, Forager, Miser, Modify, Patrician, Rats, Rebuild, Skulk, Snowy Village
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 1 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Estate, Copper, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (9 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 0 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 1 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Estate, Estate, Copper, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 0; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (8 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 0 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 2 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Estate, Estate, Copper, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (7 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 0 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 2 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Copper, Copper, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 3; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (6 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 0 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 3 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Copper, Copper, Copper, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Copper, Estate, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (5 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 3 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Copper, Copper, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 3; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (4 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 0 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 4 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Estate, Copper, Copper, Patrician, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (3 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 4 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Estate, Estate, Copper, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Estate, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Estate, Estate, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 0; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (2 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 1 action and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 5 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Estate, Copper, Copper, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (1 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 0 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 5 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Copper, Copper, Copper, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Copper, Estate, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Estate, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (0 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 2 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 6 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Patrician, Copper, Patrician, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Patrician, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Patrician, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Copper, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Copper, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Forager gained (9 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 4 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 6 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Copper, Copper, Estate, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Estate, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:05 - INFO - Supply: Snowy Village gained (9 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 1 action and bought Snowy Village
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 7 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Copper, Copper, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Forager gained (8 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 7 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Copper, Copper, Estate, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Estate, Copper, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Estate, Copper, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Estate, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:05 - INFO - Supply: Snowy Village gained (8 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 3 actions and bought Snowy Village
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 8 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Estate, Patrician, Copper, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Estate, Copper, Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Copper, Estate, Copper, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Estate, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 5 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 8 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Snowy Village, Patrician, Estate, Copper, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Estate, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Estate, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Estate, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Snowy Village gained (7 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 2 actions and bought Snowy Village
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 9 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Patrician, Patrician, Copper, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Patrician, Copper, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Patrician, Copper, Estate, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Copper, Copper, Estate, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Copper, Estate, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 4 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 9 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Snowy Village, Estate, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Snowy Village, Estate, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Snowy Village, Estate, Patrician, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Estate, Patrician, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Snowy Village, Estate, Patrician, Patrician, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Estate, Patrician, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Estate, Patrician, Snowy Village, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Estate, Snowy Village, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Estate, Snowy Village, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Estate, Snowy Village, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Snowy Village, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Estate, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Estate, Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:05 - INFO - Supply: Forager gained (7 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 6 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 10 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Copper, Forager, Copper, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Copper, Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Patrician, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 1)
+07:00:05 - INFO - Supply: Forager gained (6 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 10 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Snowy Village, Estate, Copper, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Estate, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Forager gained (5 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 1 action and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 11 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Forager, Patrician, Patrician, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Patrician, Patrician, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Patrician, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Patrician, Copper, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: )
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 2)
+07:00:05 - INFO - Supply: Forager gained (4 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 4 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 11 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Copper, Snowy Village, Copper, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Snowy Village, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Copper, Snowy Village, Copper, Copper, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Copper, Snowy Village, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 0; remaining_buys: 1)
+07:00:05 - INFO - Supply: Silver gained (39 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 3 actions and bought Silver
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 12 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Copper, Forager, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Patrician, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Patrician, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Patrician, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 1)
+07:00:05 - INFO - Supply: Forager gained (3 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 12 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Copper, Estate, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Copper, Estate, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Copper, Copper, Copper, Estate, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 1)
+07:00:05 - INFO - Supply: Silver gained (38 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 3 actions and bought Silver
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 13 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Patrician, Copper, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Patrician, Copper, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: )
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Estate)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 13 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Snowy Village, Snowy Village, Copper, Estate, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Snowy Village, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Snowy Village, Copper, Estate, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Snowy Village, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Snowy Village, Copper, Estate, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Snowy Village, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Snowy Village, Copper, Estate, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Snowy Village, Copper, Estate, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Copper, Estate, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Copper, Estate, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Copper, Estate, Copper, Copper, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Copper, Estate, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 1)
+07:00:05 - INFO - Supply: Silver gained (37 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 6 actions and bought Silver
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 14 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager, Copper, Patrician, Patrician, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Patrician, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: )
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 2)
+07:00:05 - INFO - Supply: Forager gained (2 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 14 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Silver, Patrician, Patrician, Copper, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Silver, Patrician, Copper, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Silver, Patrician, Copper, Forager, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Silver, Copper, Forager, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Silver, Copper, Forager, Silver, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Silver, Copper, Silver, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Silver, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 4; coins_added: 2; coins_after: 6; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 1)
+07:00:05 - INFO - Supply: Emporium gained (9 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 3 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 15 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Forager, Forager, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Forager, Forager, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 15 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Estate, Snowy Village, Patrician, Silver
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Snowy Village, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Copper, Estate, Snowy Village, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Estate, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Copper, Estate, Silver, Snowy Village, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Copper, Estate, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 2; hand: Copper, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Silver, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Copper, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Silver, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Silver, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 0; remaining_buys: 1)
+07:00:05 - INFO - Supply: Emporium gained (8 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 5 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 16 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Forager, Estate, Patrician, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Estate, Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Patrician)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: )
+07:00:05 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 2)
+07:00:05 - INFO - Supply: Forager gained (1 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 16 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Patrician, Silver, Forager, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Silver, Forager, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Patrician, Silver, Forager, Emporium, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Silver, Forager, Emporium, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Silver, Forager, Emporium, Copper, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Silver, Forager, Copper, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Patrician; new_hand: Silver, Forager, Copper, Silver, Snowy Village, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Silver, Forager, Copper, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Silver, Forager, Copper, Silver, Snowy Village, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 1; hand: Silver, Copper, Silver, Snowy Village, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Silver, Silver, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Silver, Silver, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Silver, Silver, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Silver, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 5; coins_added: 2; coins_after: 7; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 2; remaining_buys: 1)
+07:00:05 - INFO - Supply: Emporium gained (7 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 6 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 17 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager, Forager, Forager, Forager, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager, Forager, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought nothing
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 17 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Silver, Snowy Village, Silver, Patrician, Snowy Village
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Silver, Snowy Village, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Silver, Snowy Village, Silver, Snowy Village, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Silver, Snowy Village, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Silver, Snowy Village, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Silver, Snowy Village, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Silver, Snowy Village, Patrician, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Silver, Snowy Village, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Silver, Snowy Village, Patrician, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Silver, Snowy Village, Forager, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Silver, Snowy Village, Forager, Emporium, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 1)
+07:00:05 - INFO - Supply: Silver gained (36 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 7 actions and bought Silver
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 18 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Patrician, Forager, Forager, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Patrician, Forager, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 3)
+07:00:05 - INFO - Supply: Forager gained (0 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought Forager
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 18 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Emporium, Silver, Snowy Village, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Copper, Silver, Snowy Village, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Copper, Silver, Snowy Village, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Copper, Silver, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Copper, Silver, Copper, Copper, Copper, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 4; hand: Copper, Silver, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Silver, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Silver, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 5; coins_added: 2; coins_after: 7; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 2; remaining_buys: 1)
+07:00:05 - INFO - Supply: Emporium gained (6 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 3 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 19 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager, Forager, Forager, Forager, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager, Forager, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Skulk (cost: 4; remaining_coins: 0; remaining_buys: 3)
+07:00:05 - INFO - Supply: Skulk gained (9 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought Skulk
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 19 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Snowy Village, Silver, Patrician, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Snowy Village, Silver, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Emporium, Snowy Village, Silver, Patrician, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Snowy Village, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Snowy Village, Silver, Snowy Village, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Snowy Village, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Emporium, Snowy Village, Silver, Snowy Village, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Snowy Village, Silver, Snowy Village, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Snowy Village, Silver, Snowy Village, Silver, Patrician, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Snowy Village, Silver, Snowy Village, Silver, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Snowy Village, Silver, Snowy Village, Silver, Patrician, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Snowy Village, Silver, Snowy Village, Silver, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Snowy Village, Silver, Snowy Village, Silver, Emporium, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Snowy Village, Silver, Snowy Village, Silver, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Snowy Village; new_hand: Snowy Village, Silver, Snowy Village, Silver, Forager, Copper, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Snowy Village, Silver, Snowy Village, Silver, Copper, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 2; hand: Silver, Snowy Village, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Silver, Snowy Village, Silver, Snowy Village, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 5; hand: Silver, Silver, Snowy Village, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Silver, Silver, Snowy Village, Copper, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Silver, Silver, Snowy Village, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Emporium, Copper; new_hand: Silver, Silver, Snowy Village, Copper, Emporium, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Silver, Silver, Snowy Village, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Silver, Forager; new_hand: Silver, Silver, Snowy Village, Copper, Copper, Silver, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Silver, Silver, Snowy Village, Copper, Copper, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Silver, Silver, Copper, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Silver, Silver, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 5; coins_added: 2; coins_after: 7; remaining_treasures: Silver, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 7; coins_added: 2; coins_after: 9; remaining_treasures: Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 9; coins_added: 2; coins_after: 11; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Province (cost: 8; remaining_coins: 3; remaining_buys: 2)
+07:00:05 - INFO - Supply: Province gained (7 remaining)
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 0; remaining_buys: 1)
+07:00:05 - INFO - Supply: Silver gained (35 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 14 actions and bought Province, Silver
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 20 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager, Skulk, Forager, Forager, Gold
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Skulk, Forager, Forager, Gold)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Gold)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Gold (coins_before: 4; coins_added: 3; coins_after: 7; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 2; remaining_buys: 2)
+07:00:05 - INFO - Supply: Emporium gained (5 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 2 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 20 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager, Silver, Emporium, Patrician, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Silver, Emporium, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Silver, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Silver, Emporium, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Silver, Snowy Village; new_hand: Forager, Silver, Emporium, Emporium, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Silver, Emporium, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Province, Snowy Village; new_hand: Forager, Silver, Emporium, Silver, Snowy Village, Province, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Silver, Silver, Snowy Village, Province, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Forager, Silver, Silver, Snowy Village, Province, Snowy Village, Emporium, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Forager, Silver, Silver, Snowy Village, Province, Snowy Village, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Silver, Silver, Snowy Village, Province, Snowy Village, Emporium, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Forager, Silver, Silver, Snowy Village, Province, Snowy Village, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Silver, Silver, Snowy Village, Province, Snowy Village, Emporium, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Forager, Silver, Silver, Snowy Village, Province, Snowy Village, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Forager, Silver, Silver, Snowy Village, Province, Snowy Village, Emporium, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Silver, Silver, Snowy Village, Province, Snowy Village, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Silver, Snowy Village; new_hand: Forager, Silver, Silver, Snowy Village, Province, Snowy Village, Forager, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 4; hand: Silver, Silver, Snowy Village, Province, Snowy Village, Forager, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 4; hand: Silver, Snowy Village, Province, Snowy Village, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 4; hand: Province, Snowy Village, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Province, Snowy Village, Silver, Snowy Village, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 7; hand: Province, Snowy Village, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Province, Snowy Village, Silver, Snowy Village, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: Province, Silver, Snowy Village, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Province, Silver, Snowy Village, Copper, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 5; hand: Province, Silver, Copper, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Silver, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 5; coins_added: 2; coins_after: 7; remaining_treasures: Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 7; coins_added: 2; coins_after: 9; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Province (cost: 8; remaining_coins: 1; remaining_buys: 2)
+07:00:05 - INFO - Supply: Province gained (6 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 14 actions and bought Province
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 21 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Forager, Forager, Gold
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Emporium, Forager, Gold)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Gold)
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 0; remaining_buys: 2)
+07:00:05 - INFO - Supply: Emporium gained (4 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 2 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 21 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager, Snowy Village, Emporium, Province, Province
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Snowy Village, Province, Province)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Emporium, Snowy Village; new_hand: Forager, Snowy Village, Province, Province, Emporium, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Snowy Village, Province, Province, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Silver, Patrician; new_hand: Forager, Snowy Village, Province, Province, Snowy Village, Silver, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Forager, Snowy Village, Province, Province, Snowy Village, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Snowy Village, Province, Province, Snowy Village, Silver, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Forager, Snowy Village, Province, Province, Snowy Village, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Forager, Snowy Village, Province, Province, Snowy Village, Silver, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Snowy Village, Province, Province, Snowy Village, Silver, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 2; hand: Province, Province, Snowy Village, Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Province, Province, Snowy Village, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 5; hand: Province, Province, Silver, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Province, Province, Silver, Snowy Village, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 4; hand: Province, Province, Silver, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Province, Province, Silver, Copper, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Province, Province, Silver, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Province, Province, Silver, Copper, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Province, Province, Silver, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Province, Province, Silver, Copper, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Province, Province, Silver, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Province, Province, Silver, Copper, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Province, Province, Silver, Copper, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Province, Province, Silver, Copper, Forager, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Silver)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 4; coins_added: 2; coins_after: 6; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 1)
+07:00:05 - INFO - Supply: Emporium gained (3 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 12 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 22 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Forager, Forager
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Emporium, Forager)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Silver (cost: 3; remaining_coins: 0; remaining_buys: 2)
+07:00:05 - INFO - Supply: Silver gained (34 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 2 actions and bought Silver
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 22 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Patrician, Silver, Snowy Village, Emporium
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Silver, Snowy Village, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Silver, Snowy Village, Emporium, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Silver, Snowy Village, Emporium, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Patrician; new_hand: Silver, Snowy Village, Emporium, Forager, Snowy Village, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Silver, Snowy Village, Emporium, Forager, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Silver, Snowy Village, Emporium, Forager, Snowy Village, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Silver, Snowy Village, Forager, Snowy Village, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Copper; new_hand: Silver, Snowy Village, Forager, Snowy Village, Emporium, Snowy Village, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Silver, Snowy Village, Forager, Snowy Village, Snowy Village, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Province; new_hand: Silver, Snowy Village, Forager, Snowy Village, Snowy Village, Copper, Patrician, Province)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Silver, Snowy Village, Forager, Snowy Village, Snowy Village, Copper, Province)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Silver, Snowy Village, Forager, Snowy Village, Snowy Village, Copper, Province, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Silver, Snowy Village, Forager, Snowy Village, Snowy Village, Copper, Province, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Province, Patrician; new_hand: Silver, Snowy Village, Forager, Snowy Village, Snowy Village, Copper, Province, Emporium, Province, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 4; hand: Silver, Snowy Village, Forager, Snowy Village, Snowy Village, Copper, Province, Emporium, Province)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Silver, Snowy Village, Forager, Snowy Village, Snowy Village, Copper, Province, Emporium, Province, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 4; hand: Silver, Snowy Village, Forager, Snowy Village, Snowy Village, Copper, Province, Emporium, Province)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Silver, Snowy Village, Forager, Snowy Village, Snowy Village, Copper, Province, Emporium, Province, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Silver, Snowy Village, Forager, Snowy Village, Snowy Village, Copper, Province, Province, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 5; hand: Silver, Snowy Village, Snowy Village, Snowy Village, Copper, Province, Province, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 5; hand: Silver, Snowy Village, Snowy Village, Snowy Village, Province, Province)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 5; hand: Snowy Village, Snowy Village, Province, Province)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 8; hand: Snowy Village, Province, Province)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 7; hand: Province, Province)
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 2)
+07:00:05 - INFO - Supply: Emporium gained (2 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard3) played 15 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 23 - Player 1 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Forager, Forager, Silver
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Silver)
+07:00:05 - INFO - Player 1 (CustomBoard2): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 0; remaining_buys: 1)
+07:00:05 - INFO - Supply: Emporium gained (1 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 23 - Player 2 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Emporium, Emporium, Patrician, Emporium, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Emporium, Emporium, Emporium, Emporium, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Snowy Village, Emporium)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Patrician; new_hand: Emporium, Emporium, Emporium, Snowy Village, Emporium, Snowy Village, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Snowy Village, Emporium, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Snowy Village, Emporium, Snowy Village, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Snowy Village, Emporium, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Snowy Village, Emporium, Snowy Village, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Emporium, Snowy Village, Emporium, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Emporium, Emporium, Emporium, Snowy Village, Emporium, Snowy Village, Snowy Village)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Snowy Village, Emporium, Snowy Village, Snowy Village, Province)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Province, Forager; new_hand: Emporium, Emporium, Snowy Village, Emporium, Snowy Village, Snowy Village, Province, Province, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Emporium, Snowy Village, Emporium, Snowy Village, Snowy Village, Province, Province, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Emporium, Forager; new_hand: Emporium, Snowy Village, Emporium, Snowy Village, Snowy Village, Province, Province, Forager, Emporium, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Snowy Village, Emporium, Snowy Village, Snowy Village, Province, Province, Forager, Emporium, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Snowy Village, Snowy Village, Snowy Village, Province, Province, Forager, Emporium, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Snowy Village, Snowy Village, Snowy Village, Province, Province, Forager, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 6; hand: Snowy Village, Snowy Village, Snowy Village, Province, Province, Forager)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 6; hand: Snowy Village, Snowy Village, Province, Province)
+07:00:05 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: Province, Province)
+07:00:05 - INFO - Player 2 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 2)
+07:00:05 - INFO - Supply: Emporium gained (0 remaining)
+07:00:05 - INFO - Game over: Three piles depleted
+07:00:05 - INFO - 
+============================================================
+07:00:05 - INFO - Game Over!
+07:00:05 - INFO - Winner: Player 2 (CustomBoard3)
+07:00:05 - INFO - 
+Final Scores:
+07:00:05 - INFO -   Player 1 (CustomBoard2): 2
+07:00:05 - INFO -     Emporium x1 -> 2 VP
+07:00:05 - INFO -   Player 2 (CustomBoard3): 38
+07:00:05 - INFO -     Province x2 -> 12 VP
+07:00:05 - INFO -     Emporium x7 -> 14 VP
+07:00:05 - INFO -     VP Tokens: 12
+07:00:05 - INFO - 
+Final Supply State:
+07:00:05 - INFO -   Copper: 46 remaining
+07:00:05 - INFO -   Silver: 34 remaining
+07:00:05 - INFO -   Gold: 29 remaining
+07:00:05 - INFO -   Estate: 8 remaining
+07:00:05 - INFO -   Duchy: 8 remaining
+07:00:05 - INFO -   Province: 6 remaining
+07:00:05 - INFO -   Curse: 10 remaining
+07:00:05 - INFO -   Collection: 10 remaining
+07:00:05 - INFO -   Emporium: Empty
+07:00:05 - INFO -   Forager: Empty
+07:00:05 - INFO -   Miser: 10 remaining
+07:00:05 - INFO -   Modify: 10 remaining
+07:00:05 - INFO -   Patrician: Empty
+07:00:05 - INFO -   Rats: 10 remaining
+07:00:05 - INFO -   Rebuild: 10 remaining
+07:00:05 - INFO -   Skulk: 9 remaining
+07:00:05 - INFO -   Snowy Village: 7 remaining
+07:00:05 - INFO - ============================================================
+

--- a/battle_logs/game_20250615_070005_994950.log
+++ b/battle_logs/game_20250615_070005_994950.log
@@ -1,0 +1,1322 @@
+07:00:05 - INFO - ============================================================
+07:00:05 - INFO - Starting Game 3
+07:00:05 - INFO - Players: Player 1 (CustomBoard3), Player 2 (CustomBoard2)
+07:00:05 - INFO - ============================================================
+07:00:05 - INFO - Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Collection': 10, 'Emporium': 10, 'Forager': 10, 'Miser': 10, 'Modify': 10, 'Patrician': 10, 'Rats': 10, 'Rebuild': 10, 'Skulk': 10, 'Snowy Village': 10}
+07:00:05 - INFO - Game initialized with players: Player 1 (CustomBoard3), Player 2 (CustomBoard2)
+07:00:05 - INFO - Kingdom cards: Collection, Emporium, Forager, Miser, Modify, Patrician, Rats, Rebuild, Skulk, Snowy Village
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 1 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Copper, Copper, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 3; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (9 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 0 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 1 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Copper, Copper, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 0; remaining_buys: 0)
+07:00:05 - INFO - Supply: Emporium gained (9 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 0 actions and bought Emporium
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 2 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Estate, Copper, Copper, Estate, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 0; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (8 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 0 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 2 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Estate, Estate, Copper, Copper, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 0; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (7 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 0 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 3 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Estate, Copper, Copper, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (6 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 1 action and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 3 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Copper, Copper, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (5 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 0 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 4 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Patrician, Copper, Copper, Copper, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Copper, Estate, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (4 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 1 action and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 4 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Estate, Copper, Estate, Patrician, Copper
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Estate, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Estate, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Estate, Copper, Estate, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Estate; new_hand: Estate, Copper, Estate, Copper, Copper, Copper, Estate)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:05 - INFO - Player 2 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (3 remaining)
+07:00:05 - INFO - Summary: Player 2 (CustomBoard2) played 2 actions and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 5 - Player 1 (CustomBoard3)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Estate, Copper, Copper, Patrician, Estate
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Copper, Estate)
+07:00:05 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Copper, Estate, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:05 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:05 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:05 - INFO - Supply: Patrician gained (2 remaining)
+07:00:05 - INFO - Summary: Player 1 (CustomBoard3) played 1 action and bought Patrician
+07:00:05 - INFO - 
+========================================
+07:00:05 - INFO - Turn 5 - Player 2 (CustomBoard2)
+07:00:05 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:05 - INFO - Hand: Copper, Copper, Patrician, Copper, Patrician
+07:00:05 - INFO - ----------------------------------------
+07:00:05 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Patrician)
+07:00:05 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Estate; new_hand: Copper, Copper, Copper, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (8 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 3 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 6 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Patrician, Copper, Copper, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (1 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 2 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 6 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Patrician, Estate, Estate, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Estate, Estate, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (0 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 7 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Copper, Copper, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Copper, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Copper, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Snowy Village gained (9 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 4 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 7 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Emporium, Copper, Patrician, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Emporium, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Copper, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Copper; new_hand: Copper, Copper, Copper, Copper, Emporium, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Copper, Copper, Copper, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Copper, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Copper, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Copper; new_hand: Copper, Copper, Copper, Copper, Copper, Copper, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Copper, Copper, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Copper, Copper, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (7 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 5 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 8 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Estate, Estate, Copper, Estate
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Estate, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Estate, Copper, Estate, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Estate, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Estate, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 2 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 8 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Estate, Patrician, Copper, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Estate, Estate, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Estate, Estate, Copper, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Estate, Estate, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Estate, Estate, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Estate, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Patrician; new_hand: Estate, Estate, Copper, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Estate, Estate, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Estate, Estate, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Forager gained (9 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 4 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 9 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Patrician, Estate, Estate, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Estate, Estate, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 9 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Patrician, Emporium, Copper, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Emporium, Copper, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Copper, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Copper, Copper, Emporium, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Copper, Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Forager, Estate; new_hand: Copper, Copper, Estate, Copper, Copper, Forager, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 2; hand: Copper, Copper, Estate, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 1)
+07:00:06 - INFO - Supply: Forager gained (8 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 4 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 10 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Snowy Village, Patrician, Patrician, Copper, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Patrician, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Patrician, Copper, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Copper, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Copper, Patrician, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Copper, Patrician, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (6 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 6 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 10 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Copper, Emporium, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Patrician, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Copper, Emporium, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Emporium, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Emporium, Copper, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Emporium, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Forager, Patrician; new_hand: Copper, Copper, Copper, Estate, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 1; hand: Copper, Copper, Copper, Estate, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 1)
+07:00:06 - INFO - Supply: Forager gained (7 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 6 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 11 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Copper, Estate, Snowy Village
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Copper, Estate, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Copper, Estate, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Snowy Village gained (8 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 2 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 11 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Emporium, Copper, Forager, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Estate; new_hand: Copper, Copper, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Forager; new_hand: Copper, Copper, Estate, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 2; hand: Copper, Copper, Estate, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Copper; new_hand: Copper, Copper, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 3; hand: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 2)
+07:00:06 - INFO - Supply: Emporium gained (5 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 7 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 12 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Copper, Patrician, Patrician, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Copper, Patrician, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Copper, Patrician, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Copper, Copper, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Copper, Emporium, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Copper, Emporium, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Copper, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Estate, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Copper; new_hand: Estate, Copper, Copper, Copper, Copper, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Estate, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (4 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 6 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 12 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Patrician, Copper, Patrician, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Copper, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Forager, Copper; new_hand: Copper, Copper, Copper, Forager, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 1; hand: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 0; remaining_buys: 2)
+07:00:06 - INFO - Supply: Emporium gained (3 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 6 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 13 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Estate, Copper, Snowy Village, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Estate, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Estate, Estate, Copper, Snowy Village, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Estate, Estate, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Estate, Copper, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Estate, Estate, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Estate, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Snowy Village gained (7 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 3 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 13 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Copper, Emporium, Emporium, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Emporium, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Emporium, Emporium, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Emporium, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Emporium, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Emporium, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Emporium; new_hand: Emporium, Copper, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Copper, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Forager, Forager; new_hand: Copper, Copper, Copper, Emporium, Forager, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 3; hand: Copper, Copper, Copper, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 3; hand: Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 3; hand: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Copper, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 4; hand: Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 4; hand: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 3)
+07:00:06 - INFO - Supply: Forager gained (6 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 12 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 14 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Patrician, Emporium, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Emporium, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Emporium, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Emporium, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Estate; new_hand: Copper, Copper, Copper, Copper, Patrician, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Copper, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Copper, Copper, Copper, Estate, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Copper, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Copper, Copper, Copper, Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (2 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 7 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 14 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Forager, Forager, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: )
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Patrician; new_hand: Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Copper, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 1; hand: Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: )
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 2; hand: Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 4)
+07:00:06 - INFO - Supply: Forager gained (5 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 10 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 15 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Copper, Snowy Village, Patrician, Snowy Village
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Snowy Village, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Estate, Copper, Snowy Village, Snowy Village, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Estate, Copper, Snowy Village, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Estate, Copper, Snowy Village, Estate, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Estate, Copper, Estate, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Estate, Copper, Estate, Snowy Village, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Estate, Copper, Estate, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Copper; new_hand: Estate, Copper, Estate, Snowy Village, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Estate, Copper, Estate, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Copper, Estate, Snowy Village, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Estate, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Copper, Estate, Snowy Village, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 6 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 15 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Forager, Patrician, Forager, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Emporium, Patrician, Forager, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 3 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 16 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Copper, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Copper, Patrician, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Estate, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Estate, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Copper, Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Copper, Copper, Copper, Estate, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (1 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 3 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 16 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Forager, Emporium, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: )
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 5 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 17 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Snowy Village, Patrician, Estate, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Patrician, Estate, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Snowy Village, Patrician, Estate, Patrician, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Estate, Patrician, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Snowy Village, Estate, Patrician, Emporium, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Estate, Emporium, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Estate, Emporium, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Snowy Village, Estate, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Estate, Snowy Village; new_hand: Snowy Village, Estate, Snowy Village, Copper, Estate, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Estate, Snowy Village, Copper, Estate, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Estate, Snowy Village, Copper, Estate, Snowy Village, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Estate, Snowy Village, Copper, Estate, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Estate, Snowy Village, Copper, Estate, Snowy Village, Patrician, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Estate, Snowy Village, Copper, Estate, Snowy Village, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Snowy Village, Copper, Estate, Snowy Village, Emporium, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Estate, Snowy Village, Copper, Estate, Snowy Village, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Snowy Village, Copper, Estate, Snowy Village, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Estate, Snowy Village, Copper, Estate, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Estate, Snowy Village, Copper, Estate, Snowy Village, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Estate, Copper, Estate, Snowy Village, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Copper, Estate, Snowy Village, Copper, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Forager gained (4 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 10 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 17 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Forager, Patrician, Forager, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Patrician, Forager, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 3 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 18 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Emporium, Estate, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Snowy Village; new_hand: Copper, Copper, Estate, Copper, Patrician, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Copper, Copper, Estate, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Estate, Copper, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Copper, Copper, Estate, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Estate, Copper, Snowy Village, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Copper, Copper, Estate, Copper, Snowy Village, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Snowy Village; new_hand: Copper, Copper, Estate, Copper, Snowy Village, Estate, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 2; hand: Copper, Copper, Estate, Copper, Estate, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Copper, Estate, Copper, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 5; hand: Copper, Copper, Estate, Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Estate, Copper, Estate, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 4; hand: Copper, Copper, Estate, Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Copper, Copper, Estate, Copper, Estate, Copper, Copper, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Copper, Copper, Estate, Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 1)
+07:00:06 - INFO - Supply: Emporium gained (0 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 8 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 18 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Patrician, Forager, Forager, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Forager, Forager, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 3 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 19 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Emporium, Snowy Village, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Emporium, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Emporium, Snowy Village, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Emporium, Snowy Village, Patrician, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Emporium, Snowy Village, Patrician, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Emporium, Snowy Village, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Emporium, Snowy Village, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Estate, Snowy Village, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Estate, Snowy Village, Emporium, Copper, Copper, Patrician, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Estate, Snowy Village, Emporium, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Estate, Snowy Village, Emporium, Copper, Copper, Emporium, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Estate, Snowy Village, Copper, Copper, Emporium, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Copper; new_hand: Estate, Snowy Village, Copper, Copper, Emporium, Snowy Village, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Estate, Snowy Village, Copper, Copper, Emporium, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Snowy Village, Copper, Copper, Emporium, Snowy Village, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Estate, Snowy Village, Copper, Copper, Emporium, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Snowy Village, Copper, Copper, Emporium, Snowy Village, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Estate, Snowy Village, Copper, Copper, Snowy Village, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Estate, Snowy Village, Copper, Copper, Snowy Village, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Estate, Copper, Copper, Snowy Village, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Estate, Copper, Copper, Snowy Village, Copper, Copper, Copper, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: Estate, Copper, Copper, Copper, Copper, Copper, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Estate, Copper, Copper, Copper, Copper, Copper, Copper, Snowy Village, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 5; hand: Estate, Copper, Copper, Copper, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Copper, Copper, Copper, Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Gold (cost: 6; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Gold gained (29 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought Gold
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 19 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Forager, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 2 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 20 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Emporium, Emporium, Snowy Village, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Forager, Emporium, Emporium, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Snowy Village; new_hand: Forager, Emporium, Snowy Village, Copper, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Snowy Village, Copper, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Forager, Snowy Village, Copper, Copper, Snowy Village, Emporium, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Forager, Snowy Village, Copper, Copper, Snowy Village, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Forager, Snowy Village, Copper, Copper, Snowy Village, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Snowy Village, Copper, Copper, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Estate; new_hand: Forager, Snowy Village, Copper, Copper, Snowy Village, Copper, Patrician, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Forager, Snowy Village, Copper, Copper, Snowy Village, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Gold; new_hand: Forager, Snowy Village, Copper, Copper, Snowy Village, Copper, Estate, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Snowy Village, Copper, Copper, Snowy Village, Copper, Estate, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Copper, Copper, Snowy Village, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Snowy Village, Copper, Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: Copper, Copper, Copper, Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Copper, Gold, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 5; hand: Copper, Copper, Copper, Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Copper, Copper, Gold, Copper, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Copper, Copper, Copper, Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Copper, Copper, Copper, Gold, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Gold, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Gold, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Gold, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Gold, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 7; coins_added: 3; coins_after: 10; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Province (cost: 8; remaining_coins: 2; remaining_buys: 1)
+07:00:06 - INFO - Supply: Province gained (7 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 12 actions and bought Province
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 20 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 21 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Estate, Patrician, Snowy Village, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Snowy Village, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Estate, Snowy Village, Emporium, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Snowy Village, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Snowy Village, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Copper, Estate, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Province; new_hand: Copper, Estate, Snowy Village, Copper, Patrician, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Copper, Estate, Snowy Village, Copper, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Gold; new_hand: Copper, Estate, Snowy Village, Copper, Province, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Copper, Estate, Copper, Province, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Copper, Estate, Copper, Province, Gold, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 4; hand: Copper, Estate, Copper, Province, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Copper, Province, Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 3; coins_added: 3; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Gold (cost: 6; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Gold gained (28 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 6 actions and bought Gold
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 21 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 22 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Emporium, Forager, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Emporium, Emporium, Forager, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Emporium, Forager, Emporium, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Emporium; new_hand: Forager, Emporium, Copper, Copper, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Copper, Copper, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Copper; new_hand: Forager, Copper, Copper, Copper, Copper, Emporium, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Copper, Copper, Copper, Copper, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Estate, Copper; new_hand: Forager, Copper, Copper, Copper, Copper, Snowy Village, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 4; hand: Copper, Copper, Copper, Copper, Snowy Village, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 4; hand: Copper, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Gold; new_hand: Copper, Copper, Copper, Copper, Copper, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 7; coins_added: 3; coins_after: 10; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Province (cost: 8; remaining_coins: 2; remaining_buys: 1)
+07:00:06 - INFO - Supply: Province gained (6 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 9 actions and bought Province
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 22 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 23 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Province, Snowy Village, Gold, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Province, Snowy Village, Gold, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Province, Snowy Village, Gold, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Province, Snowy Village, Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Patrician; new_hand: Province, Snowy Village, Gold, Copper, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Province, Snowy Village, Gold, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Province, Snowy Village, Gold, Copper, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Province, Snowy Village, Gold, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Province, Snowy Village, Gold, Copper, Snowy Village, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Province, Snowy Village, Gold, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Forager, Patrician; new_hand: Province, Snowy Village, Gold, Copper, Snowy Village, Forager, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Province, Snowy Village, Gold, Copper, Snowy Village, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Province, Snowy Village, Gold, Copper, Snowy Village, Forager, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Province, Snowy Village, Gold, Copper, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 2; hand: Province, Gold, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Province, Gold, Snowy Village, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 5; hand: Province, Gold, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Province, Gold, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Province, Gold, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Emporium; new_hand: Province, Gold, Copper, Copper, Snowy Village, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Province, Gold, Copper, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Province, Gold, Copper, Copper, Snowy Village, Emporium, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Province, Gold, Copper, Copper, Snowy Village, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Province, Gold, Copper, Copper, Snowy Village, Emporium, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Province, Gold, Copper, Copper, Snowy Village, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Province, Gold, Copper, Copper, Snowy Village, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Province, Gold, Copper, Copper, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Province, Gold, Copper, Copper, Snowy Village, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Gold, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Gold, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Gold, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 6; coins_added: 3; coins_after: 9; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Province (cost: 8; remaining_coins: 1; remaining_buys: 1)
+07:00:06 - INFO - Supply: Province gained (5 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 14 actions and bought Province
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 23 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 24 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Gold, Copper, Province, Gold, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Gold, Copper, Province, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Gold, Copper, Province, Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Gold, Copper, Province, Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Gold, Copper, Province, Gold, Copper, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Gold, Copper, Province, Gold, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Gold, Copper, Province, Gold, Copper, Patrician, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Gold, Copper, Province, Gold, Copper, Snowy Village, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Province; new_hand: Gold, Copper, Province, Gold, Copper, Snowy Village, Emporium, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Gold, Copper, Province, Gold, Copper, Snowy Village, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Forager, Copper; new_hand: Gold, Copper, Province, Gold, Copper, Snowy Village, Province, Forager, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Gold, Copper, Province, Gold, Copper, Snowy Village, Province, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 2; hand: Gold, Province, Gold, Copper, Province, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Gold, Province, Gold, Copper, Province, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Gold, Gold, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Gold, Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Gold, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 4; coins_added: 3; coins_after: 7; remaining_treasures: Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 7; coins_added: 3; coins_after: 10; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Province (cost: 8; remaining_coins: 2; remaining_buys: 1)
+07:00:06 - INFO - Supply: Province gained (4 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 7 actions and bought Province
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 24 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 25 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Snowy Village, Emporium, Emporium, Copper, Snowy Village
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Snowy Village, Emporium, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Snowy Village, Emporium, Copper, Snowy Village, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Snowy Village, Emporium, Copper, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Snowy Village, Emporium, Copper, Snowy Village, Patrician, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Snowy Village, Emporium, Copper, Snowy Village, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Emporium, Copper, Snowy Village, Emporium, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Snowy Village, Emporium, Copper, Snowy Village, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Emporium, Copper, Snowy Village, Emporium, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Snowy Village, Copper, Snowy Village, Emporium, Copper, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Province, Snowy Village; new_hand: Snowy Village, Copper, Snowy Village, Emporium, Copper, Province, Province, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Snowy Village, Copper, Snowy Village, Copper, Province, Province, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Province; new_hand: Snowy Village, Copper, Snowy Village, Copper, Province, Province, Snowy Village, Copper, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Copper, Snowy Village, Copper, Province, Province, Snowy Village, Copper, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Snowy Village, Copper, Province, Province, Snowy Village, Copper, Province, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 6; hand: Copper, Snowy Village, Copper, Province, Province, Snowy Village, Copper, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Snowy Village, Copper, Province, Province, Snowy Village, Copper, Province, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Copper, Snowy Village, Copper, Province, Province, Snowy Village, Copper, Province, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Gold, Gold; new_hand: Copper, Snowy Village, Copper, Province, Province, Snowy Village, Copper, Province, Emporium, Gold, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Copper, Snowy Village, Copper, Province, Province, Snowy Village, Copper, Province, Gold, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Forager, Patrician; new_hand: Copper, Snowy Village, Copper, Province, Province, Snowy Village, Copper, Province, Gold, Gold, Forager, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Copper, Snowy Village, Copper, Province, Province, Snowy Village, Copper, Province, Gold, Gold, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Snowy Village, Copper, Province, Province, Snowy Village, Copper, Province, Gold, Gold, Forager, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Copper, Snowy Village, Copper, Province, Province, Snowy Village, Copper, Province, Gold, Gold, Copper, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Copper, Province, Province, Snowy Village, Copper, Province, Gold, Gold, Copper, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Province, Province, Snowy Village, Copper, Province, Gold, Gold, Copper, Province, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Province, Province, Copper, Province, Gold, Gold, Copper, Province, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Province, Province, Copper, Province, Gold, Gold, Copper, Province, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Gold, Gold, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Gold, Gold, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Gold, Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Gold, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 5; coins_added: 3; coins_after: 8; remaining_treasures: Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 8; coins_added: 3; coins_after: 11; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Province (cost: 8; remaining_coins: 3; remaining_buys: 1)
+07:00:06 - INFO - Supply: Province gained (3 remaining)
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Forager gained (3 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 14 actions and bought Province, Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 25 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 26 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Emporium, Emporium, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Emporium, Emporium, Emporium, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Province; new_hand: Copper, Emporium, Emporium, Emporium, Province, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Copper, Emporium, Emporium, Province, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Province; new_hand: Copper, Emporium, Emporium, Province, Province, Patrician, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Copper, Emporium, Emporium, Province, Province, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Emporium, Emporium, Province, Province, Province, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Copper, Emporium, Province, Province, Province, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Gold; new_hand: Copper, Emporium, Province, Province, Province, Copper, Snowy Village, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Copper, Province, Province, Province, Copper, Snowy Village, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Province; new_hand: Copper, Province, Province, Province, Copper, Snowy Village, Gold, Patrician, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Copper, Province, Province, Province, Copper, Snowy Village, Gold, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Province, Province, Province, Copper, Snowy Village, Gold, Province, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Copper, Province, Province, Province, Copper, Snowy Village, Gold, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Province, Province, Province, Copper, Snowy Village, Gold, Province, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Copper, Province, Province, Province, Copper, Gold, Province, Copper, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Copper, Province, Province, Province, Copper, Gold, Province, Copper, Province, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: Copper, Province, Province, Province, Copper, Gold, Province, Copper, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Copper, Province, Province, Province, Copper, Gold, Province, Copper, Province, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 5; hand: Copper, Province, Province, Province, Copper, Gold, Province, Copper, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Province, Province, Province, Copper, Gold, Province, Copper, Province, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Gold, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Gold, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 4; coins_added: 3; coins_after: 7; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Gold (cost: 6; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Gold gained (27 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 11 actions and bought Gold
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 26 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 27 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Gold, Patrician, Forager, Emporium, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Gold, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Gold, Forager, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Gold, Forager, Emporium, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Gold, Forager, Emporium, Forager, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Gold, Forager, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Province; new_hand: Gold, Forager, Emporium, Forager, Patrician, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Gold, Forager, Emporium, Forager, Province, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Province; new_hand: Gold, Forager, Emporium, Forager, Province, Province, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Gold, Forager, Forager, Province, Province, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Gold, Forager, Forager, Province, Province, Province, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Gold, Forager, Province, Province, Province, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Gold, Province, Province, Province, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 2; coins_added: 3; coins_after: 5; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Modify (cost: 5; remaining_coins: 0; remaining_buys: 2)
+07:00:06 - INFO - Supply: Modify gained (9 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 7 actions and bought Modify
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 27 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 28 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Province, Copper, Gold, Copper, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Province, Copper, Gold, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Gold; new_hand: Province, Copper, Gold, Copper, Snowy Village, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Province, Copper, Gold, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Province, Copper, Gold, Copper, Gold, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 4; hand: Province, Copper, Gold, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Province, Copper, Gold, Copper, Gold, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Province, Copper, Gold, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Province, Copper, Gold, Copper, Gold, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Province, Copper, Gold, Copper, Gold, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Province; new_hand: Province, Copper, Gold, Copper, Gold, Snowy Village, Patrician, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Province, Copper, Gold, Copper, Gold, Snowy Village, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Province, Copper, Gold, Copper, Gold, Snowy Village, Province, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Province, Copper, Gold, Copper, Gold, Snowy Village, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Province; new_hand: Province, Copper, Gold, Copper, Gold, Snowy Village, Province, Patrician, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Gold, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Gold, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 2; coins_added: 3; coins_after: 5; remaining_treasures: Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 5; coins_added: 3; coins_after: 8; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Province (cost: 8; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Province gained (2 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 7 actions and bought Province
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 28 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 29 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Gold, Forager, Province
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Gold, Forager, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Modify; new_hand: Patrician, Gold, Forager, Province, Modify)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Gold, Forager, Province, Modify)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Gold, Forager, Province, Modify, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Gold, Forager, Province, Modify, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Gold, Forager, Province, Modify, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Gold, Forager, Province, Modify, Forager, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Province; new_hand: Gold, Forager, Province, Modify, Forager, Emporium, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Gold, Forager, Province, Modify, Forager, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Patrician; new_hand: Gold, Forager, Province, Modify, Forager, Province, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Gold, Forager, Province, Modify, Forager, Province, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Gold, Forager, Province, Modify, Forager, Province, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Gold, Forager, Province, Modify, Forager, Province, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Gold, Forager, Province, Modify, Forager, Province, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Gold, Province, Modify, Forager, Province, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Gold, Province, Modify, Province, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Modify (remaining_actions: 2; hand: Province, Province, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 2; hand: Province, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Province, Province, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Estate (cost: 2; remaining_coins: 2; remaining_buys: 2)
+07:00:06 - INFO - Supply: Estate gained (7 remaining)
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Estate (cost: 2; remaining_coins: 0; remaining_buys: 1)
+07:00:06 - INFO - Supply: Estate gained (6 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 11 actions and bought Estate, Estate
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 29 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 30 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Gold, Emporium, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Gold, Emporium, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Province; new_hand: Emporium, Gold, Emporium, Emporium, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Gold, Emporium, Emporium, Province, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Province; new_hand: Gold, Emporium, Emporium, Province, Province, Snowy Village, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Gold, Emporium, Province, Province, Snowy Village, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Gold, Province; new_hand: Gold, Emporium, Province, Province, Snowy Village, Province, Gold, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Gold, Province, Province, Snowy Village, Province, Gold, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Patrician; new_hand: Gold, Province, Province, Snowy Village, Province, Gold, Province, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Gold, Province, Province, Snowy Village, Province, Gold, Province, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Gold, Province, Province, Snowy Village, Province, Gold, Province, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Gold, Province, Province, Snowy Village, Province, Gold, Province, Snowy Village, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Gold, Province, Province, Snowy Village, Province, Gold, Province, Snowy Village, Province, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Gold, Province, Province, Province, Gold, Province, Snowy Village, Province, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Gold, Province, Province, Province, Gold, Province, Snowy Village, Province, Estate, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: Gold, Province, Province, Province, Gold, Province, Province, Estate, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Province; new_hand: Gold, Province, Province, Province, Gold, Province, Province, Estate, Estate, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 0; coins_added: 3; coins_after: 3; remaining_treasures: Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 3; coins_added: 3; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Gold (cost: 6; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Gold gained (26 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 8 actions and bought Gold
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 30 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 31 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Forager, Patrician, Emporium, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Forager, Emporium, Forager, Emporium, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Forager, Emporium, Snowy Village, Modify)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Gold; new_hand: Forager, Forager, Emporium, Snowy Village, Modify, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Forager, Snowy Village, Modify, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Forager, Forager, Snowy Village, Modify, Copper, Gold, Patrician, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Forager, Forager, Snowy Village, Modify, Copper, Gold, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Forager, Forager, Snowy Village, Modify, Copper, Gold, Emporium, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Forager, Snowy Village, Modify, Copper, Gold, Snowy Village, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Emporium, Gold; new_hand: Forager, Forager, Snowy Village, Modify, Copper, Gold, Snowy Village, Province, Emporium, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 3; hand: Forager, Forager, Snowy Village, Modify, Copper, Gold, Snowy Village, Province, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Gold, Snowy Village; new_hand: Forager, Forager, Snowy Village, Modify, Copper, Gold, Snowy Village, Province, Gold, Gold, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 4; hand: Forager, Snowy Village, Modify, Copper, Gold, Snowy Village, Province, Gold, Gold, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 4; hand: Snowy Village, Modify, Gold, Snowy Village, Province, Gold, Gold, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Modify (remaining_actions: 4; hand: Gold, Snowy Village, Province, Gold, Gold, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 4; hand: Gold, Province, Gold, Gold, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Gold, Province, Gold, Gold, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 7; hand: Gold, Province, Gold, Gold, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Gold, Province, Gold, Gold, Snowy Village, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: Gold, Province, Gold, Gold, Estate, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Gold, Province, Gold, Gold, Estate, Province, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 5; hand: Gold, Province, Gold, Gold, Estate, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Province; new_hand: Gold, Province, Gold, Gold, Estate, Province, Patrician, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 4; hand: Gold, Province, Gold, Gold, Estate, Province, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Province; new_hand: Gold, Province, Gold, Gold, Estate, Province, Province, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 4; coins_added: 3; coins_after: 7; remaining_treasures: Gold, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 7; coins_added: 3; coins_after: 10; remaining_treasures: Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 10; coins_added: 3; coins_after: 13; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Province (cost: 8; remaining_coins: 5; remaining_buys: 2)
+07:00:06 - INFO - Supply: Province gained (1 remaining)
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 2; remaining_buys: 1)
+07:00:06 - INFO - Supply: Snowy Village gained (6 remaining)
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Estate (cost: 2; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Estate gained (5 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 16 actions and bought Province, Snowy Village, Estate
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 31 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 32 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Province, Patrician, Snowy Village, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Province, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Province, Snowy Village, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Province, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Estate, Province, Snowy Village, Patrician, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Province, Snowy Village, Forager, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Estate, Province, Snowy Village, Forager, Province, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Estate, Province, Snowy Village, Forager, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Province; new_hand: Estate, Province, Snowy Village, Forager, Province, Snowy Village, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 1; hand: Estate, Province, Snowy Village, Province, Snowy Village, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Province, Province, Snowy Village, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Province; new_hand: Province, Province, Snowy Village, Province, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 4; hand: Province, Province, Province, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Province; new_hand: Province, Province, Province, Province, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Estate (cost: 2; remaining_coins: 0; remaining_buys: 1)
+07:00:06 - INFO - Supply: Estate gained (4 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 7 actions and bought Estate
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 32 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 33 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Snowy Village, Province, Emporium, Gold, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Province, Emporium, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Snowy Village, Province, Emporium, Gold, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Snowy Village, Province, Gold, Emporium, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Forager, Gold; new_hand: Snowy Village, Province, Gold, Emporium, Province, Forager, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Snowy Village, Province, Gold, Province, Forager, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Estate, Estate; new_hand: Snowy Village, Province, Gold, Province, Forager, Gold, Estate, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Snowy Village, Province, Gold, Province, Gold, Estate, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 2; hand: Province, Gold, Province, Gold, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Province, Gold, Province, Gold, Estate, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 5; hand: Province, Gold, Province, Gold, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Gold; new_hand: Province, Gold, Province, Gold, Estate, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Province, Gold, Province, Gold, Estate, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Modify, Patrician; new_hand: Province, Gold, Province, Gold, Estate, Gold, Modify, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Province, Gold, Province, Gold, Estate, Gold, Modify)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Province, Gold, Province, Gold, Estate, Gold, Modify, Emporium)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Province, Gold, Province, Gold, Estate, Gold, Modify)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 2 cards (drawn_cards: Forager, Province; new_hand: Province, Gold, Province, Gold, Estate, Gold, Modify, Forager, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 1; hand: Province, Gold, Province, Gold, Estate, Gold, Modify, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Modify (remaining_actions: 0; hand: Province, Gold, Province, Gold, Gold, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 4; coins_added: 3; coins_after: 7; remaining_treasures: Gold, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 7; coins_added: 3; coins_after: 10; remaining_treasures: Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 10; coins_added: 3; coins_after: 13; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Province (cost: 8; remaining_coins: 5; remaining_buys: 2)
+07:00:06 - INFO - Supply: Province gained (0 remaining)
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Modify (cost: 5; remaining_coins: 0; remaining_buys: 1)
+07:00:06 - INFO - Supply: Modify gained (8 remaining)
+07:00:06 - INFO - Game over: Provinces depleted
+07:00:06 - INFO - 
+============================================================
+07:00:06 - INFO - Game Over!
+07:00:06 - INFO - Winner: Player 1 (CustomBoard3)
+07:00:06 - INFO - 
+Final Scores:
+07:00:06 - INFO -   Player 1 (CustomBoard3): 69
+07:00:06 - INFO -     Province x8 -> 48 VP
+07:00:06 - INFO -     Estate x1 -> 1 VP
+07:00:06 - INFO -     Emporium x5 -> 10 VP
+07:00:06 - INFO -     VP Tokens: 10
+07:00:06 - INFO -   Player 2 (CustomBoard2): 8
+07:00:06 - INFO -     VP Tokens: 8
+07:00:06 - INFO - 
+Final Supply State:
+07:00:06 - INFO -   Copper: 46 remaining
+07:00:06 - INFO -   Silver: 40 remaining
+07:00:06 - INFO -   Gold: 26 remaining
+07:00:06 - INFO -   Estate: 4 remaining
+07:00:06 - INFO -   Duchy: 8 remaining
+07:00:06 - INFO -   Province: Empty
+07:00:06 - INFO -   Curse: 10 remaining
+07:00:06 - INFO -   Collection: 10 remaining
+07:00:06 - INFO -   Emporium: Empty
+07:00:06 - INFO -   Forager: 3 remaining
+07:00:06 - INFO -   Miser: 10 remaining
+07:00:06 - INFO -   Modify: 8 remaining
+07:00:06 - INFO -   Patrician: Empty
+07:00:06 - INFO -   Rats: 10 remaining
+07:00:06 - INFO -   Rebuild: 10 remaining
+07:00:06 - INFO -   Skulk: 10 remaining
+07:00:06 - INFO -   Snowy Village: 6 remaining
+07:00:06 - INFO - ============================================================
+

--- a/battle_logs/game_20250615_070006_044965.log
+++ b/battle_logs/game_20250615_070006_044965.log
@@ -1,0 +1,2916 @@
+07:00:06 - INFO - ============================================================
+07:00:06 - INFO - Starting Game 4
+07:00:06 - INFO - Players: Player 1 (CustomBoard2), Player 2 (CustomBoard3)
+07:00:06 - INFO - ============================================================
+07:00:06 - INFO - Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Collection': 10, 'Emporium': 10, 'Forager': 10, 'Miser': 10, 'Modify': 10, 'Patrician': 10, 'Rats': 10, 'Rebuild': 10, 'Skulk': 10, 'Snowy Village': 10}
+07:00:06 - INFO - Game initialized with players: Player 1 (CustomBoard2), Player 2 (CustomBoard3)
+07:00:06 - INFO - Kingdom cards: Collection, Emporium, Forager, Miser, Modify, Patrician, Rats, Rebuild, Skulk, Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 1 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Copper, Copper, Copper, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (9 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 0 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 1 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Estate, Estate, Copper, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (8 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 0 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 2 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Estate, Estate, Copper, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (7 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 0 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 2 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Copper, Copper, Estate
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (6 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 0 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 3 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Patrician, Estate, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Estate, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (5 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 3 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Estate, Estate, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (4 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 1 action and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 4 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Copper, Copper, Estate, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (3 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 4 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Estate, Copper, Patrician, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (2 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 1 action and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 5 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Copper, Copper, Copper, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (1 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 0 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 5 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Copper, Copper, Estate, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (0 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 1 action and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 6 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Estate, Patrician, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Patrician, Estate, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Patrician, Estate, Patrician, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Estate, Patrician, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Estate, Patrician, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Estate, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Forager gained (9 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 6 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Patrician, Estate, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Estate, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Estate, Patrician, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Estate, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Estate, Patrician, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Estate, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Snowy Village gained (9 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 3 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 7 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Patrician, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Patrician, Patrician, Patrician, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Patrician, Patrician, Patrician, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Patrician, Patrician, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Patrician, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Patrician, Copper, Copper, Estate, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 1)
+07:00:06 - INFO - Supply: Forager gained (8 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 6 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 7 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Snowy Village, Copper, Estate, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Snowy Village, Copper, Estate, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Estate, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Copper, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Snowy Village gained (8 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 2 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 8 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Estate, Estate, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Forager gained (7 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 0 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 8 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Copper, Estate, Copper, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Estate, Copper, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Copper, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Snowy Village gained (7 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 3 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 9 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Copper, Patrician, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 1)
+07:00:06 - INFO - Supply: Forager gained (6 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 9 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Snowy Village, Patrician, Patrician, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Patrician, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Patrician, Patrician, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Patrician, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Patrician, Copper, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Copper, Patrician, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Snowy Village, Copper, Patrician, Copper, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Copper, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Snowy Village, Copper, Copper, Snowy Village, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Copper, Snowy Village, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Snowy Village, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Forager gained (5 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 7 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 10 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Estate, Copper, Copper, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Estate, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 1)
+07:00:06 - INFO - Supply: Forager gained (4 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 10 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Estate, Copper, Snowy Village, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Estate, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Forager gained (3 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 1 action and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 11 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Patrician, Copper, Forager, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Copper, Forager, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 11 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Snowy Village, Snowy Village, Estate
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Copper, Snowy Village, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Snowy Village, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Estate, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Copper, Copper, Estate, Copper, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Silver gained (39 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 4 actions and bought Silver
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 12 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Patrician, Copper, Forager, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Patrician, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Copper, Patrician, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: )
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Estate)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 5 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 12 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Patrician, Patrician, Copper, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Patrician, Copper, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Patrician, Copper, Forager, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Forager, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Copper, Copper, Forager, Estate, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Copper, Copper, Estate, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 0; remaining_buys: 2)
+07:00:06 - INFO - Supply: Silver gained (38 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 4 actions and bought Silver
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 13 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Copper, Copper, Copper, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Copper, Copper, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 2)
+07:00:06 - INFO - Supply: Forager gained (2 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 4 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 13 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Patrician, Copper, Patrician, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Patrician, Forager, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Forager, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Estate, Copper, Forager, Copper, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Estate, Copper, Copper, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 0; remaining_buys: 2)
+07:00:06 - INFO - Supply: Silver gained (37 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 4 actions and bought Silver
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 14 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Estate, Forager, Forager, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Estate, Forager, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: )
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Forager)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 4 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 14 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Snowy Village, Copper, Patrician, Silver
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Snowy Village, Copper, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Snowy Village, Copper, Silver, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Snowy Village, Copper, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Estate, Snowy Village, Copper, Silver, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Estate, Copper, Silver, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Estate, Copper, Silver, Silver, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Estate, Copper, Silver, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Silver, Silver, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Silver, Silver, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Silver, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 4; coins_added: 2; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (9 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 4 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 15 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Copper, Forager, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Forager, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: )
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: )
+07:00:06 - INFO - Player 1 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Forager)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 5 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 15 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Snowy Village, Copper, Patrician, Copper, Snowy Village
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Copper, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Snowy Village, Copper, Copper, Snowy Village, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Snowy Village, Copper, Copper, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Copper, Snowy Village, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Copper, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Silver, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 1)
+07:00:06 - INFO - Supply: Silver gained (36 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 4 actions and bought Silver
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 16 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Forager, Forager, Patrician, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager, Patrician, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 16 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Patrician, Silver, Snowy Village, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Silver, Snowy Village, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Silver, Snowy Village, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Silver, Snowy Village, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Forager, Silver, Snowy Village, Copper, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Silver, Snowy Village, Copper, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Silver, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Silver, Silver, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Silver, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Silver, Silver, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Silver, Silver, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Silver, Silver, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Silver, Silver, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Silver, Silver, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Silver, Silver, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Silver, Silver, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Silver, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 4; coins_added: 2; coins_after: 6; remaining_treasures: Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 6; coins_added: 2; coins_after: 8; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Province (cost: 8; remaining_coins: 0; remaining_buys: 1)
+07:00:06 - INFO - Supply: Province gained (7 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 7 actions and bought Province
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 17 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Forager, Patrician, Forager, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Patrician, Forager, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 3 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 17 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Snowy Village, Silver, Patrician, Snowy Village
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Snowy Village, Silver, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Estate, Snowy Village, Silver, Snowy Village, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Estate, Snowy Village, Silver, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Silver, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Silver, Snowy Village, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Silver, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Silver, Silver, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Silver, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 4; coins_added: 2; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 1)
+07:00:06 - INFO - Supply: Emporium gained (8 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 4 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 18 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Forager, Forager, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 2 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 18 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Snowy Village, Silver, Patrician, Copper, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Silver, Copper, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Snowy Village, Silver, Copper, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Snowy Village, Silver, Copper, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Silver, Province; new_hand: Snowy Village, Silver, Copper, Forager, Silver, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 1; hand: Snowy Village, Silver, Copper, Silver, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Silver, Silver, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Silver, Silver, Province, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 4; hand: Silver, Silver, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Silver, Silver, Province, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Silver, Silver, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Silver, Silver, Province, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Silver, Silver, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Silver, Silver, Province, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Silver, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 4; coins_added: 2; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 1)
+07:00:06 - INFO - Supply: Emporium gained (7 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 7 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 19 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 19 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Snowy Village, Emporium, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Snowy Village, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Snowy Village, Emporium, Forager, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Snowy Village, Emporium, Forager, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Silver; new_hand: Snowy Village, Emporium, Forager, Forager, Copper, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Snowy Village, Forager, Forager, Copper, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Patrician; new_hand: Snowy Village, Forager, Forager, Copper, Silver, Snowy Village, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Snowy Village, Forager, Forager, Copper, Silver, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Snowy Village, Forager, Forager, Copper, Silver, Snowy Village, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Snowy Village, Forager, Forager, Copper, Silver, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Silver, Patrician; new_hand: Snowy Village, Forager, Forager, Copper, Silver, Snowy Village, Silver, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Snowy Village, Forager, Forager, Copper, Silver, Snowy Village, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Province; new_hand: Snowy Village, Forager, Forager, Copper, Silver, Snowy Village, Silver, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Snowy Village, Forager, Copper, Silver, Snowy Village, Silver, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Snowy Village, Silver, Snowy Village, Silver, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Snowy Village, Silver, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Silver, Province, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 6; hand: Snowy Village, Silver, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Snowy Village, Silver, Province, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 5; hand: Silver, Province, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Silver, Province, Silver, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Silver, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 4; coins_added: 2; coins_after: 6; remaining_treasures: Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 6; coins_added: 2; coins_after: 8; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Province (cost: 8; remaining_coins: 0; remaining_buys: 2)
+07:00:06 - INFO - Supply: Province gained (6 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 11 actions and bought Province
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 20 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 20 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Snowy Village, Silver, Patrician, Province
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Silver, Patrician, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Snowy Village, Silver, Patrician, Province, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Silver, Province, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Silver, Province, Snowy Village, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Silver, Province, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Silver, Province, Snowy Village, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Silver, Province, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Snowy Village, Silver, Province, Snowy Village, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Snowy Village, Silver, Province, Snowy Village, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Province, Emporium; new_hand: Snowy Village, Silver, Province, Snowy Village, Forager, Province, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Snowy Village, Silver, Province, Snowy Village, Forager, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Copper, Patrician; new_hand: Snowy Village, Silver, Province, Snowy Village, Forager, Province, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Snowy Village, Silver, Province, Snowy Village, Forager, Province, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Snowy Village, Silver, Province, Snowy Village, Forager, Province, Copper, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 2; hand: Snowy Village, Silver, Province, Snowy Village, Province, Copper, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 2; hand: Silver, Province, Snowy Village, Province, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Silver, Province, Snowy Village, Province, Snowy Village, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 5; hand: Silver, Province, Province, Snowy Village, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Silver, Province, Province, Snowy Village, Silver, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 4; hand: Silver, Province, Province, Snowy Village, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Forager, Silver; new_hand: Silver, Province, Province, Snowy Village, Silver, Forager, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Silver, Province, Province, Snowy Village, Silver, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 2; hand: Province, Province, Silver, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 4; coins_added: 2; coins_after: 6; remaining_treasures: Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Silver (coins_before: 6; coins_added: 2; coins_after: 8; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Province (cost: 8; remaining_coins: 0; remaining_buys: 2)
+07:00:06 - INFO - Supply: Province gained (5 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 13 actions and bought Province
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 21 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 21 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Snowy Village, Silver, Patrician, Forager, Province
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Silver, Forager, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Snowy Village, Silver, Forager, Province, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Snowy Village, Silver, Province, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Snowy Village, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 2)
+07:00:06 - INFO - Supply: Snowy Village gained (6 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 3 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 22 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 22 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Snowy Village, Patrician, Province, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Province, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Province, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Province, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Province, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Province, Emporium, Patrician, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Snowy Village, Province, Emporium, Patrician, Province, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Province, Emporium, Province, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Snowy Village, Province, Emporium, Province, Emporium, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Snowy Village, Province, Province, Emporium, Silver)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Emporium; new_hand: Snowy Village, Province, Province, Emporium, Silver, Snowy Village, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Snowy Village, Province, Province, Silver, Snowy Village, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Province, Forager; new_hand: Snowy Village, Province, Province, Silver, Snowy Village, Emporium, Province, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Snowy Village, Province, Province, Silver, Snowy Village, Province, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Forager, Patrician; new_hand: Snowy Village, Province, Province, Silver, Snowy Village, Province, Forager, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Snowy Village, Province, Province, Silver, Snowy Village, Province, Forager, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Snowy Village, Province, Province, Silver, Snowy Village, Province, Forager, Forager, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Snowy Village, Province, Province, Silver, Snowy Village, Province, Forager, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Snowy Village, Province, Province, Snowy Village, Province, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Province, Province, Province, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: Province, Province, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 2)
+07:00:06 - INFO - Supply: Snowy Village gained (5 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 12 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 23 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 23 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Snowy Village, Forager, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Snowy Village, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Province; new_hand: Emporium, Snowy Village, Forager, Patrician, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Snowy Village, Forager, Province, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Snowy Village, Forager, Province, Province, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Snowy Village, Forager, Province, Province, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Forager, Emporium; new_hand: Snowy Village, Forager, Province, Province, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Snowy Village, Forager, Province, Province, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Snowy Village; new_hand: Snowy Village, Forager, Province, Province, Forager, Emporium, Patrician, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Snowy Village, Forager, Province, Province, Forager, Emporium, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Province; new_hand: Snowy Village, Forager, Province, Province, Forager, Emporium, Snowy Village, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Snowy Village, Forager, Province, Province, Forager, Snowy Village, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Snowy Village, Forager, Province, Province, Forager, Snowy Village, Province, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Snowy Village, Forager, Province, Province, Forager, Snowy Village, Province, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Snowy Village, Forager, Province, Province, Forager, Snowy Village, Province, Patrician, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Snowy Village, Forager, Province, Province, Forager, Snowy Village, Province, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Snowy Village, Province, Province, Forager, Snowy Village, Province, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Province, Province, Snowy Village, Province, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Province, Province, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: Province, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 2)
+07:00:06 - INFO - Supply: Snowy Village gained (4 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 12 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 24 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 24 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Forager, Snowy Village, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Snowy Village, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Snowy Village, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Snowy Village, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Snowy Village, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Snowy Village, Emporium, Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Snowy Village, Emporium, Emporium, Province, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Snowy Village, Emporium, Emporium, Province, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Emporium, Forager, Snowy Village, Emporium, Emporium, Province, Province, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Snowy Village, Emporium, Emporium, Province, Province, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Snowy Village; new_hand: Forager, Snowy Village, Emporium, Emporium, Province, Province, Snowy Village, Patrician, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Snowy Village, Emporium, Emporium, Province, Province, Snowy Village, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Forager, Snowy Village, Emporium, Emporium, Province, Province, Snowy Village, Snowy Village, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Snowy Village, Emporium, Province, Province, Snowy Village, Snowy Village, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Snowy Village, Province, Province, Snowy Village, Snowy Village, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Snowy Village, Province, Province, Snowy Village, Snowy Village, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Province, Province, Snowy Village, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Province, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 2)
+07:00:06 - INFO - Supply: Snowy Village gained (3 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 12 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 25 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 25 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Emporium, Snowy Village, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Snowy Village, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Snowy Village, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Snowy Village, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Snowy Village, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Snowy Village, Patrician, Province)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Snowy Village, Patrician, Province, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Snowy Village, Province, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Snowy Village, Province, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Snowy Village, Province, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Forager, Emporium, Snowy Village, Province, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Snowy Village, Province, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Snowy Village, Snowy Village; new_hand: Forager, Snowy Village, Province, Emporium, Emporium, Forager, Snowy Village, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Snowy Village, Province, Emporium, Forager, Snowy Village, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Snowy Village, Province, Forager, Snowy Village, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Snowy Village, Province, Forager, Snowy Village, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Province, Snowy Village, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 6; hand: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 2)
+07:00:06 - INFO - Supply: Snowy Village gained (2 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 12 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 26 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 26 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Snowy Village, Patrician, Emporium, Snowy Village, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Emporium, Snowy Village, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Snowy Village, Emporium, Snowy Village, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Emporium, Snowy Village, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Emporium, Snowy Village, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Emporium, Snowy Village, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Snowy Village, Emporium, Snowy Village, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Snowy Village, Snowy Village, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Snowy Village, Snowy Village, Emporium, Forager, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Snowy Village, Snowy Village, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Snowy Village, Snowy Village, Emporium, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Snowy Village, Snowy Village, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Snowy Village, Snowy Village, Emporium, Forager, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Snowy Village, Snowy Village, Forager, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Snowy Village, Snowy Village, Forager, Emporium, Forager, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Snowy Village, Snowy Village, Forager, Forager, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Snowy Village, Snowy Village, Forager, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Snowy Village, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Snowy Village (remaining_actions: 3; hand: )
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 2)
+07:00:06 - INFO - Supply: Snowy Village gained (1 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 11 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 27 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 27 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Snowy Village, Patrician, Forager, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Snowy Village, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Snowy Village, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Snowy Village, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Snowy Village, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Snowy Village, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Emporium, Snowy Village, Forager, Emporium, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Snowy Village, Forager, Emporium, Snowy Village, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 2 cards (drawn_cards: Patrician, Patrician; new_hand: Snowy Village, Forager, Emporium, Snowy Village, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Snowy Village, Forager, Emporium, Snowy Village, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Snowy Village, Forager, Emporium, Snowy Village, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Snowy Village, Forager, Emporium, Snowy Village, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Snowy Village, Forager, Snowy Village, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Snowy Village, Forager, Snowy Village, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Snowy Village, Snowy Village, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 2)
+07:00:06 - INFO - Supply: Snowy Village gained (0 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 10 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 28 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 28 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Forager, Emporium, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Forager, Emporium, Patrician, Emporium, Snowy Village)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Snowy Village, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Snowy Village, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Snowy Village, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Forager, Emporium, Emporium, Snowy Village, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Snowy Village, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Snowy Village, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 1; hand: Forager, Emporium, Snowy Village, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Snowy Village, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Snowy Village, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Snowy Village, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 10 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 29 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 29 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Emporium, Patrician, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium, Patrician, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Forager, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Forager)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 30 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 30 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Patrician, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 31 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 31 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Patrician, Emporium, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 32 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 32 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Patrician, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Patrician, Patrician, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Patrician, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 33 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 33 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Patrician, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Patrician, Patrician, Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 34 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 34 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Emporium, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 35 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 35 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Forager, Patrician, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Patrician, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Patrician, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 36 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 36 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Patrician, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 37 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 37 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Emporium, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 38 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 38 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Forager, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Forager, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 39 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 39 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Patrician, Emporium, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 40 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 40 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Forager, Patrician, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Patrician, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 41 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 41 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Patrician, Forager, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Patrician, Forager, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Forager, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Forager, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 42 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 42 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Forager, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 43 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 43 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Patrician, Patrician, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Patrician, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 44 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 44 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Emporium, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 45 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 45 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Patrician, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 46 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 46 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Patrician, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 47 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 47 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Emporium, Patrician, Forager, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 48 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 48 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Patrician, Forager, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Forager, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 49 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 49 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Emporium, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 50 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 50 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Forager, Patrician, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 51 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 51 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Patrician, Forager, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 52 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 52 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Forager, Patrician, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Patrician, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 53 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 53 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Patrician, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 54 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 54 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Emporium, Patrician, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Emporium, Patrician, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Forager, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 55 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 55 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Emporium, Patrician, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 56 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 56 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Patrician, Patrician, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Patrician, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Forager, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 57 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 57 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Patrician, Emporium, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Patrician, Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 58 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 58 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Emporium, Patrician, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Patrician, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 59 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 59 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Emporium, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Emporium, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Patrician, Patrician, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 60 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 60 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Patrician, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 61 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 61 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Forager, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Forager, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Forager, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Patrician, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Patrician, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 62 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 62 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Emporium, Forager, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Emporium, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 63 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 63 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Patrician, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Patrician, Patrician, Patrician, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Patrician, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Emporium, Forager, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 64 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 64 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Forager, Patrician, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 65 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 65 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Emporium, Patrician, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Emporium, Patrician, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Forager, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 66 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 66 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Emporium, Emporium, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 67 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 67 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Forager, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Patrician, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 68 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 68 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Patrician, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Patrician, Patrician, Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 69 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 69 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Patrician, Patrician, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Patrician, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 70 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 70 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Patrician, Forager, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Forager, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 71 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 71 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Patrician, Emporium, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 72 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 72 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Patrician, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Patrician, Patrician, Patrician, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 73 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 73 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Emporium, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 74 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 74 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Forager, Patrician, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 75 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 75 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Patrician, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Patrician, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 76 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 76 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Patrician, Emporium, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 77 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 77 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Forager, Patrician, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Patrician, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 78 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 78 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Emporium, Patrician, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 79 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 79 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Patrician, Forager, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 80 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 80 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Emporium, Patrician, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 81 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 81 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Forager, Patrician, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 82 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 82 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Emporium, Patrician, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 83 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 83 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Emporium, Forager, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 84 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 84 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Patrician, Emporium, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 85 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 85 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Emporium, Forager, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Emporium, Forager, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 86 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 86 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Patrician, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 87 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 87 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Patrician, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Patrician, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 88 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 88 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Patrician, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Patrician, Patrician, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 89 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 89 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Patrician, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Patrician, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Patrician, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 90 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 90 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Emporium, Patrician, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Emporium, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 91 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 91 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Forager, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 92 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 92 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Patrician, Forager, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Patrician, Patrician, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 93 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 93 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Forager, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Forager, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 94 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 94 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Emporium, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 95 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 95 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Patrician, Forager, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Patrician, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Forager, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 96 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 96 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Emporium, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Emporium, Patrician, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 97 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 97 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Patrician, Emporium, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Patrician, Patrician, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 98 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 98 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Patrician, Patrician, Patrician, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Emporium; new_hand: Forager, Patrician, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Patrician, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 99 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 99 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Patrician, Patrician, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Emporium, Patrician, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Patrician, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Patrician, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Emporium, Forager, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Emporium, Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Emporium, Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 100 - Player 1 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard2) played 1 action and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 100 - Player 2 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Forager, Emporium, Emporium, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Patrician, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Emporium, Emporium, Emporium, Patrician, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 0; hand: Forager, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 1; hand: Forager, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Emporium (remaining_actions: 2; hand: Forager)
+07:00:06 - INFO - Player 2 (CustomBoard3): plays Forager (remaining_actions: 3; hand: )
+07:00:06 - INFO - Summary: Player 2 (CustomBoard3) played 9 actions and bought nothing
+07:00:06 - INFO - Game over: Maximum turns reached
+07:00:06 - INFO - 
+============================================================
+07:00:06 - INFO - Game Over!
+07:00:06 - INFO - Winner: Player 2 (CustomBoard3)
+07:00:06 - INFO - 
+Final Scores:
+07:00:06 - INFO -   Player 1 (CustomBoard2): 0
+07:00:06 - INFO -   Player 2 (CustomBoard3): 12
+07:00:06 - INFO -     Emporium x3 -> 6 VP
+07:00:06 - INFO -     VP Tokens: 6
+07:00:06 - INFO - 
+Final Supply State:
+07:00:06 - INFO -   Copper: 46 remaining
+07:00:06 - INFO -   Silver: 36 remaining
+07:00:06 - INFO -   Gold: 30 remaining
+07:00:06 - INFO -   Estate: 8 remaining
+07:00:06 - INFO -   Duchy: 8 remaining
+07:00:06 - INFO -   Province: 5 remaining
+07:00:06 - INFO -   Curse: 10 remaining
+07:00:06 - INFO -   Collection: 10 remaining
+07:00:06 - INFO -   Emporium: 7 remaining
+07:00:06 - INFO -   Forager: 2 remaining
+07:00:06 - INFO -   Miser: 10 remaining
+07:00:06 - INFO -   Modify: 10 remaining
+07:00:06 - INFO -   Patrician: Empty
+07:00:06 - INFO -   Rats: 10 remaining
+07:00:06 - INFO -   Rebuild: 10 remaining
+07:00:06 - INFO -   Skulk: 10 remaining
+07:00:06 - INFO -   Snowy Village: Empty
+07:00:06 - INFO - ============================================================
+

--- a/battle_logs/game_20250615_070006_168818.log
+++ b/battle_logs/game_20250615_070006_168818.log
@@ -1,0 +1,1101 @@
+07:00:06 - INFO - ============================================================
+07:00:06 - INFO - Starting Game 5
+07:00:06 - INFO - Players: Player 1 (CustomBoard3), Player 2 (CustomBoard2)
+07:00:06 - INFO - ============================================================
+07:00:06 - INFO - Supply initialized: {'Copper': 46, 'Silver': 40, 'Gold': 30, 'Estate': 8, 'Duchy': 8, 'Province': 8, 'Curse': 10, 'Collection': 10, 'Emporium': 10, 'Forager': 10, 'Miser': 10, 'Modify': 10, 'Patrician': 10, 'Rats': 10, 'Rebuild': 10, 'Skulk': 10, 'Snowy Village': 10}
+07:00:06 - INFO - Game initialized with players: Player 1 (CustomBoard3), Player 2 (CustomBoard2)
+07:00:06 - INFO - Kingdom cards: Collection, Emporium, Forager, Miser, Modify, Patrician, Rats, Rebuild, Skulk, Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 1 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Estate, Estate, Copper, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (9 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 0 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 1 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Estate, Copper, Copper, Estate
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (8 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 0 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 2 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Copper, Copper, Estate
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (7 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 0 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 2 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Estate, Copper, Copper, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (6 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 0 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 3 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Copper, Estate, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (5 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 0 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 3 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Patrician, Copper, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (9 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 1 action and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 4 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Copper, Estate, Patrician, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Patrician, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Estate, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (4 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 2 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 4 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Copper, Estate, Estate, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Patrician (cost: 2; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (3 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 0 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 5 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Copper, Patrician, Copper, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Copper, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (2 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 2 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 5 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Copper, Copper, Estate, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Estate, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Estate; new_hand: Copper, Copper, Estate, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (8 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 4 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 6 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Estate, Patrician, Estate, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Estate, Estate, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Estate, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (1 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 2 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 6 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Copper, Copper, Emporium, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Estate, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Estate, Patrician; new_hand: Estate, Copper, Copper, Copper, Estate, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Estate, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Copper, Copper, Copper, Estate, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Estate, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Copper, Copper, Copper, Estate, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Estate, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Estate, Copper, Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Estate, Copper, Copper, Copper, Estate, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (7 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 5 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 7 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Patrician, Patrician, Estate, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Patrician, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Patrician, Estate, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Patrician (cost: 2; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Patrician gained (0 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 2 actions and bought Patrician
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 7 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Copper, Emporium, Estate, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Estate, Copper, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Emporium, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Estate, Copper, Estate, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Estate, Copper; new_hand: Estate, Copper, Estate, Copper, Emporium, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Estate, Copper, Estate, Copper, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Estate, Copper, Estate, Copper, Estate, Copper, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Estate, Copper, Estate, Copper, Estate, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Estate, Copper, Estate, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Estate, Copper, Estate, Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Estate, Copper, Estate, Copper, Estate, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (6 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 5 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 8 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Patrician, Copper, Copper, Estate
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Copper, Estate, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Snowy Village gained (9 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 2 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 8 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Patrician, Estate, Patrician, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Patrician, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Estate, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Estate; new_hand: Copper, Estate, Copper, Copper, Copper, Patrician, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Copper, Estate, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Estate, Copper, Copper, Copper, Estate, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Copper, Estate, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Estate, Copper; new_hand: Copper, Estate, Copper, Copper, Copper, Estate, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (5 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 5 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 9 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Copper, Copper, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Patrician, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Snowy Village gained (8 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 2 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 9 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Emporium, Copper, Copper, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Emporium, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Emporium, Copper, Copper, Copper, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Emporium, Copper, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Emporium, Copper, Copper, Copper, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Emporium, Copper, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Emporium, Copper, Copper, Copper, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Copper, Copper, Copper, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Estate, Copper; new_hand: Copper, Copper, Copper, Emporium, Estate, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Copper, Copper, Copper, Estate, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Estate, Copper; new_hand: Copper, Copper, Copper, Estate, Estate, Copper, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (4 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 5 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 10 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Snowy Village, Estate, Patrician, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Snowy Village, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Snowy Village, Estate, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Snowy Village, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Snowy Village, Estate, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Estate, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Estate, Copper, Estate, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Copper, Estate, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Snowy Village (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Snowy Village gained (7 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 4 actions and bought Snowy Village
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 10 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Patrician, Emporium, Copper, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Emporium, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Estate, Emporium; new_hand: Copper, Copper, Emporium, Copper, Estate, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Copper, Copper, Copper, Estate, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Estate, Patrician; new_hand: Copper, Copper, Copper, Estate, Emporium, Estate, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Copper, Copper, Copper, Estate, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Estate, Emporium, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Copper, Copper, Copper, Estate, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Copper, Copper, Copper, Estate, Estate, Copper, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 3; hand: Copper, Copper, Copper, Estate, Estate, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Copper, Copper, Estate, Estate, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 3; hand: Copper, Copper, Copper, Estate, Estate, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Copper, Copper, Copper, Estate, Estate, Copper, Emporium, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 4; hand: Copper, Copper, Copper, Estate, Estate, Copper, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Estate; new_hand: Copper, Copper, Copper, Estate, Estate, Copper, Emporium, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 5; hand: Copper, Copper, Copper, Estate, Estate, Copper, Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (3 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 9 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 11 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Patrician, Patrician, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Patrician, Patrician, Patrician, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Patrician, Patrician, Patrician, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Patrician, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Patrician, Patrician, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Patrician, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Patrician, Copper, Copper, Patrician, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Patrician, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Patrician, Estate, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Forager gained (9 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 6 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 11 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Copper, Emporium, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Copper, Copper, Copper, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Copper, Copper, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Copper, Emporium, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Copper, Copper, Copper, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Copper; new_hand: Copper, Copper, Copper, Emporium, Estate, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Copper, Copper, Copper, Emporium, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Copper, Copper, Emporium, Estate, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Copper, Copper, Copper, Estate, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Estate, Estate; new_hand: Copper, Copper, Copper, Estate, Copper, Emporium, Emporium, Estate, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 3; hand: Copper, Copper, Copper, Estate, Copper, Emporium, Estate, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Copper; new_hand: Copper, Copper, Copper, Estate, Copper, Emporium, Estate, Estate, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 4; hand: Copper, Copper, Copper, Estate, Copper, Estate, Estate, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Copper; new_hand: Copper, Copper, Copper, Estate, Copper, Estate, Estate, Emporium, Copper, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 5; hand: Copper, Copper, Copper, Estate, Copper, Estate, Estate, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Copper, Copper, Estate, Copper, Estate, Estate, Emporium, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 5; hand: Copper, Copper, Copper, Estate, Copper, Estate, Estate, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Estate, Copper, Estate, Estate, Copper, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 6; hand: Copper, Copper, Copper, Estate, Copper, Estate, Estate, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (2 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 10 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 12 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Copper, Snowy Village, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Copper, Snowy Village, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Copper, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Forager gained (8 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 2 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 12 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Emporium, Emporium, Emporium, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Emporium, Emporium, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Estate, Estate; new_hand: Emporium, Emporium, Emporium, Copper, Estate, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Emporium, Emporium, Copper, Estate, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Emporium, Emporium, Copper, Estate, Estate, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Emporium, Emporium, Copper, Estate, Estate, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Emporium, Emporium, Copper, Estate, Estate, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Emporium, Copper, Estate, Estate, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Emporium, Copper, Estate, Estate, Emporium, Copper, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 3; hand: Emporium, Copper, Estate, Estate, Emporium, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Emporium, Copper, Estate, Estate, Emporium, Copper, Emporium, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 3; hand: Copper, Estate, Estate, Emporium, Copper, Emporium, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Copper, Estate, Estate, Emporium, Copper, Emporium, Emporium, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 4; hand: Copper, Estate, Estate, Copper, Emporium, Emporium, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Estate; new_hand: Copper, Estate, Estate, Copper, Emporium, Emporium, Copper, Copper, Copper, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 5; hand: Copper, Estate, Estate, Copper, Emporium, Copper, Copper, Copper, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Copper; new_hand: Copper, Estate, Estate, Copper, Emporium, Copper, Copper, Copper, Emporium, Estate, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 6; hand: Copper, Estate, Estate, Copper, Emporium, Copper, Copper, Copper, Emporium, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Estate, Copper, Emporium, Copper, Copper, Copper, Emporium, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 6; hand: Copper, Estate, Estate, Copper, Copper, Copper, Copper, Emporium, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 7; hand: Copper, Estate, Estate, Copper, Copper, Copper, Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (1 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 11 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 13 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Snowy Village, Snowy Village, Patrician, Patrician, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Snowy Village, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Snowy Village, Snowy Village, Patrician, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Snowy Village, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Snowy Village, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Snowy Village, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Copper, Estate, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Snowy Village, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Copper, Estate, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Snowy Village, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Snowy Village, Copper, Estate, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Copper, Estate, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Silver gained (39 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 6 actions and bought Silver
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 13 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Estate, Emporium, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Copper, Estate, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Copper, Copper, Estate, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Copper, Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Copper, Copper, Estate, Copper, Copper, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Copper, Copper, Estate, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Copper, Estate, Copper, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Copper, Copper, Estate, Copper, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Emporium; new_hand: Copper, Copper, Estate, Copper, Copper, Emporium, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 3; hand: Copper, Copper, Estate, Copper, Copper, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Emporium; new_hand: Copper, Copper, Estate, Copper, Copper, Emporium, Copper, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 4; hand: Copper, Copper, Estate, Copper, Copper, Copper, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Copper; new_hand: Copper, Copper, Estate, Copper, Copper, Copper, Emporium, Emporium, Emporium, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 5; hand: Copper, Copper, Estate, Copper, Copper, Copper, Emporium, Emporium, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Estate; new_hand: Copper, Copper, Estate, Copper, Copper, Copper, Emporium, Emporium, Emporium, Copper, Patrician, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 6; hand: Copper, Copper, Estate, Copper, Copper, Copper, Emporium, Emporium, Emporium, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Estate, Copper, Copper, Copper, Emporium, Emporium, Emporium, Copper, Estate, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 6; hand: Copper, Copper, Estate, Copper, Copper, Copper, Emporium, Emporium, Copper, Estate, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Copper; new_hand: Copper, Copper, Estate, Copper, Copper, Copper, Emporium, Emporium, Copper, Estate, Estate, Patrician, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 7; hand: Copper, Copper, Estate, Copper, Copper, Copper, Emporium, Emporium, Copper, Estate, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 7; hand: Copper, Copper, Estate, Copper, Copper, Copper, Emporium, Copper, Estate, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 8; hand: Copper, Copper, Estate, Copper, Copper, Copper, Copper, Estate, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Emporium (cost: 5; remaining_coins: 2; remaining_buys: 0)
+07:00:06 - INFO - Supply: Emporium gained (0 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 12 actions and bought Emporium
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 14 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Snowy Village, Patrician, Forager, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Snowy Village, Forager, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Snowy Village, Forager, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Snowy Village, Forager, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Snowy Village, Forager, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Snowy Village, Forager, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Snowy Village, Forager, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Estate, Snowy Village, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Copper, Copper, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: )
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 6 actions and bought nothing
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 14 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Patrician, Emporium, Estate, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Emporium, Estate, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Emporium, Estate, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Emporium, Estate, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Emporium, Estate, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Estate, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Estate; new_hand: Copper, Estate, Emporium, Copper, Emporium, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Copper, Estate, Copper, Emporium, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Emporium; new_hand: Copper, Estate, Copper, Emporium, Copper, Estate, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Copper, Estate, Copper, Copper, Estate, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Emporium; new_hand: Copper, Estate, Copper, Copper, Estate, Emporium, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 3; hand: Copper, Estate, Copper, Copper, Estate, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Emporium; new_hand: Copper, Estate, Copper, Copper, Estate, Emporium, Copper, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 4; hand: Copper, Estate, Copper, Copper, Estate, Copper, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Copper; new_hand: Copper, Estate, Copper, Copper, Estate, Copper, Emporium, Copper, Emporium, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 5; hand: Copper, Estate, Copper, Copper, Estate, Copper, Copper, Emporium, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Estate; new_hand: Copper, Estate, Copper, Copper, Estate, Copper, Copper, Emporium, Emporium, Copper, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 6; hand: Copper, Estate, Copper, Copper, Estate, Copper, Copper, Emporium, Copper, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Copper, Estate, Copper, Copper, Estate, Copper, Copper, Emporium, Copper, Emporium, Estate, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 7; hand: Copper, Estate, Copper, Copper, Estate, Copper, Copper, Emporium, Copper, Emporium, Estate, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Estate, Copper, Copper, Estate, Copper, Copper, Emporium, Copper, Emporium, Estate, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 7; hand: Copper, Estate, Copper, Copper, Estate, Copper, Copper, Copper, Emporium, Estate, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 8; hand: Copper, Estate, Copper, Copper, Estate, Copper, Copper, Copper, Estate, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 9; hand: Copper, Estate, Copper, Copper, Estate, Copper, Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 4; remaining_buys: 0)
+07:00:06 - INFO - Supply: Forager gained (7 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 13 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 15 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Patrician, Estate, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Estate, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Patrician, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Estate, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 0)
+07:00:06 - INFO - Supply: Silver gained (38 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 3 actions and bought Silver
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 15 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Patrician, Copper, Copper, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Copper, Copper, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Copper, Copper, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Copper, Copper, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Copper, Copper, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Emporium; new_hand: Copper, Copper, Copper, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Copper, Copper, Copper, Emporium, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Copper, Copper, Copper, Emporium, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Copper, Copper, Copper, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Copper, Emporium, Emporium, Emporium, Emporium, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Copper, Copper, Copper, Emporium, Emporium, Emporium, Emporium, Estate, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Copper, Copper, Copper, Emporium, Emporium, Emporium, Emporium, Estate, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 3; hand: Copper, Copper, Copper, Emporium, Emporium, Emporium, Estate, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Emporium; new_hand: Copper, Copper, Copper, Emporium, Emporium, Emporium, Estate, Emporium, Copper, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 4; hand: Copper, Copper, Copper, Emporium, Emporium, Estate, Emporium, Copper, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Estate, Estate; new_hand: Copper, Copper, Copper, Emporium, Emporium, Estate, Emporium, Copper, Copper, Emporium, Emporium, Estate, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 5; hand: Copper, Copper, Copper, Emporium, Estate, Emporium, Copper, Copper, Emporium, Emporium, Estate, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Forager, Copper; new_hand: Copper, Copper, Copper, Emporium, Estate, Emporium, Copper, Copper, Emporium, Emporium, Estate, Estate, Forager, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 6; hand: Copper, Copper, Copper, Emporium, Estate, Emporium, Copper, Copper, Emporium, Emporium, Estate, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 6; hand: Copper, Copper, Copper, Emporium, Copper, Copper, Emporium, Emporium, Estate, Estate, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Copper, Emporium, Copper, Copper, Emporium, Emporium, Estate, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 7; hand: Copper, Copper, Copper, Copper, Copper, Emporium, Emporium, Estate, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 8; hand: Copper, Copper, Copper, Copper, Copper, Emporium, Estate, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 9; hand: Copper, Copper, Copper, Copper, Copper, Estate, Estate, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 7; coins_added: 1; coins_after: 8; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Province (cost: 8; remaining_coins: 0; remaining_buys: 1)
+07:00:06 - INFO - Supply: Province gained (7 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 14 actions and bought Province
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 16 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Copper, Patrician, Forager, Snowy Village
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Patrician, Forager, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Copper, Patrician, Forager, Snowy Village, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Forager, Snowy Village, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Copper, Forager, Snowy Village, Silver, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Copper, Snowy Village, Silver, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Silver, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Silver, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Silver, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Silver, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Silver, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Silver, Snowy Village, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Silver, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Silver, Snowy Village, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Silver, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Silver, Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 1)
+07:00:06 - INFO - Supply: Silver gained (37 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 8 actions and bought Silver
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 16 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Estate, Copper, Emporium, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Estate, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Emporium; new_hand: Estate, Copper, Emporium, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Estate, Copper, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Estate, Copper, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Estate, Copper, Emporium, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Copper, Emporium, Emporium, Emporium, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Estate, Copper, Emporium, Emporium, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Estate, Copper, Emporium, Emporium, Emporium, Emporium, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Estate, Copper, Emporium, Emporium, Emporium, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Copper; new_hand: Estate, Copper, Emporium, Emporium, Emporium, Emporium, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 3; hand: Estate, Copper, Emporium, Emporium, Emporium, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Forager; new_hand: Estate, Copper, Emporium, Emporium, Emporium, Copper, Copper, Copper, Copper, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 4; hand: Estate, Copper, Emporium, Emporium, Emporium, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 4; hand: Copper, Emporium, Emporium, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Province, Patrician; new_hand: Copper, Emporium, Emporium, Copper, Copper, Copper, Copper, Province, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 5; hand: Copper, Emporium, Emporium, Copper, Copper, Copper, Copper, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Copper; new_hand: Copper, Emporium, Emporium, Copper, Copper, Copper, Copper, Province, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 5; hand: Copper, Emporium, Copper, Copper, Copper, Copper, Province, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Emporium; new_hand: Copper, Emporium, Copper, Copper, Copper, Copper, Province, Copper, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 6; hand: Copper, Copper, Copper, Copper, Copper, Province, Copper, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Estate; new_hand: Copper, Copper, Copper, Copper, Copper, Province, Copper, Emporium, Copper, Emporium, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 7; hand: Copper, Copper, Copper, Copper, Copper, Province, Copper, Copper, Emporium, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 8; hand: Copper, Copper, Copper, Copper, Copper, Province, Copper, Copper, Emporium, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 9; hand: Copper, Copper, Copper, Copper, Copper, Province, Copper, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 7; coins_added: 1; coins_after: 8; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Province (cost: 8; remaining_coins: 0; remaining_buys: 1)
+07:00:06 - INFO - Supply: Province gained (6 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 14 actions and bought Province
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 17 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Copper, Copper, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Forager, Copper, Copper, Patrician, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Copper, Copper, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Forager, Copper, Copper, Silver, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Copper, Copper, Silver, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Silver, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 4; coins_added: 2; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Gold (cost: 6; remaining_coins: 0; remaining_buys: 1)
+07:00:06 - INFO - Supply: Gold gained (29 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 3 actions and bought Gold
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 17 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Copper, Emporium, Emporium, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Emporium, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Copper, Emporium, Emporium, Copper, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Copper, Emporium, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Emporium, Emporium, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Copper, Emporium, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Patrician; new_hand: Copper, Emporium, Copper, Emporium, Emporium, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Copper, Emporium, Copper, Emporium, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Estate; new_hand: Copper, Emporium, Copper, Emporium, Emporium, Copper, Estate)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Copper, Copper, Emporium, Emporium, Copper, Estate, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Emporium; new_hand: Copper, Copper, Emporium, Emporium, Copper, Estate, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 3; hand: Copper, Copper, Emporium, Copper, Estate, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Province; new_hand: Copper, Copper, Emporium, Copper, Estate, Emporium, Copper, Emporium, Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 4; hand: Copper, Copper, Copper, Estate, Emporium, Copper, Emporium, Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Copper; new_hand: Copper, Copper, Copper, Estate, Emporium, Copper, Emporium, Emporium, Province, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 5; hand: Copper, Copper, Copper, Estate, Copper, Emporium, Emporium, Province, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Forager, Copper; new_hand: Copper, Copper, Copper, Estate, Copper, Emporium, Emporium, Province, Emporium, Copper, Forager, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 6; hand: Copper, Copper, Copper, Estate, Copper, Emporium, Emporium, Province, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 6; hand: Copper, Copper, Copper, Copper, Emporium, Province, Emporium, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Patrician; new_hand: Copper, Copper, Copper, Copper, Emporium, Province, Emporium, Copper, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 7; hand: Copper, Copper, Copper, Copper, Emporium, Province, Emporium, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Copper, Copper, Copper, Emporium, Province, Emporium, Copper, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 7; hand: Copper, Copper, Copper, Copper, Province, Emporium, Copper, Copper, Copper, Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 8; hand: Copper, Copper, Copper, Copper, Province, Copper, Copper, Copper, Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 9; hand: Copper, Copper, Copper, Copper, Province, Copper, Copper, Copper, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 6; coins_added: 1; coins_after: 7; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 7; coins_added: 1; coins_after: 8; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Province (cost: 8; remaining_coins: 0; remaining_buys: 1)
+07:00:06 - INFO - Supply: Province gained (5 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 14 actions and bought Province
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 18 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Estate, Patrician, Snowy Village, Patrician, Estate
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Snowy Village, Patrician, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Estate, Snowy Village, Patrician, Estate, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Estate, Snowy Village, Estate, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Estate, Snowy Village, Estate, Snowy Village, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Estate, Snowy Village, Estate, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Estate, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Estate, Snowy Village, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Estate, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Estate, Snowy Village, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 2; hand: Estate, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Estate, Copper, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 2; coins_added: 2; coins_after: 4; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Silver (cost: 3; remaining_coins: 1; remaining_buys: 1)
+07:00:06 - INFO - Supply: Silver gained (36 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 6 actions and bought Silver
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 18 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Copper, Emporium, Forager, Emporium
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Copper, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Emporium; new_hand: Copper, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Emporium; new_hand: Copper, Copper, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Copper, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Province, Province; new_hand: Copper, Copper, Copper, Emporium, Province, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 3; hand: Copper, Copper, Copper, Province, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Province; new_hand: Copper, Copper, Copper, Province, Province, Copper, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 2; remaining_buys: 1)
+07:00:06 - INFO - Supply: Forager gained (6 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 5 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 19 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Snowy Village, Copper, Copper, Patrician, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Copper, Copper, Patrician, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Snowy Village; new_hand: Snowy Village, Copper, Copper, Patrician, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Copper, Snowy Village)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Snowy Village, Copper, Copper, Snowy Village, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Copper, Snowy Village, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Snowy Village, Silver, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Copper, Copper, Snowy Village, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Copper, Snowy Village, Silver, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 2; hand: Copper, Copper, Snowy Village, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Copper, Snowy Village, Silver, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Copper, Copper, Silver, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Copper, Copper, Silver, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Copper, Silver, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 1; coins_added: 1; coins_after: 2; remaining_treasures: Silver, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Modify (cost: 5; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Modify gained (9 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 7 actions and bought Modify
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 19 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Emporium, Copper, Emporium, Copper
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 0; hand: Emporium, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Copper, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Copper, Emporium, Copper, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Copper, Emporium, Copper, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Emporium, Copper, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Copper, Copper, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Copper, Copper, Emporium, Emporium, Emporium, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Copper, Copper, Emporium, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Copper, Copper, Emporium, Emporium, Emporium, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 2; hand: Copper, Copper, Emporium, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Copper, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Emporium; new_hand: Copper, Emporium, Emporium, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 3; hand: Copper, Emporium, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Province, Copper; new_hand: Copper, Emporium, Emporium, Copper, Emporium, Province, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 4; hand: Copper, Emporium, Copper, Emporium, Province, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Emporium; new_hand: Copper, Emporium, Copper, Emporium, Province, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 5; hand: Copper, Copper, Emporium, Province, Copper, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Province, Emporium; new_hand: Copper, Copper, Emporium, Province, Copper, Copper, Emporium, Province, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 6; hand: Copper, Copper, Province, Copper, Copper, Emporium, Province, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Forager; new_hand: Copper, Copper, Province, Copper, Copper, Emporium, Province, Emporium, Copper, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 7; hand: Copper, Copper, Province, Copper, Copper, Emporium, Province, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 7; hand: Copper, Province, Copper, Copper, Province, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Province; new_hand: Copper, Province, Copper, Copper, Province, Emporium, Copper, Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 8; hand: Copper, Province, Copper, Copper, Province, Copper, Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 9; hand: Copper, Province, Copper, Copper, Province, Copper, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Copper, Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 3; coins_added: 1; coins_after: 4; remaining_treasures: Copper, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 4; coins_added: 1; coins_after: 5; remaining_treasures: Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Copper (coins_before: 5; coins_added: 1; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 3; remaining_buys: 2)
+07:00:06 - INFO - Supply: Forager gained (5 remaining)
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 0; remaining_buys: 1)
+07:00:06 - INFO - Supply: Forager gained (4 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 15 actions and bought Forager, Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 20 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Silver, Silver, Snowy Village, Patrician, Silver
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Silver, Silver, Snowy Village, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Silver, Silver, Snowy Village, Silver, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Silver, Silver, Silver, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Forager; new_hand: Silver, Silver, Silver, Copper, Gold, Forager)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 3; hand: Silver, Silver, Silver, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 1; coins_added: 2; coins_after: 3; remaining_treasures: Silver, Silver, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: Silver, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 5; coins_added: 2; coins_after: 7; remaining_treasures: Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 7; coins_added: 3; coins_after: 10; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Province (cost: 8; remaining_coins: 2; remaining_buys: 1)
+07:00:06 - INFO - Supply: Province gained (4 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 3 actions and bought Province
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 20 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Emporium, Emporium, Copper, Province
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: Copper, Emporium, Copper, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Emporium; new_hand: Copper, Emporium, Copper, Province, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Copper, Copper, Province, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Copper, Patrician; new_hand: Copper, Copper, Province, Copper, Emporium, Copper, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Copper, Copper, Province, Copper, Emporium, Copper)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Copper, Copper, Province, Copper, Emporium, Copper, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Copper, Copper, Province, Copper, Copper, Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Forager, Forager; new_hand: Copper, Copper, Province, Copper, Copper, Emporium, Province, Forager, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 3; hand: Copper, Copper, Province, Copper, Copper, Emporium, Province, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 3; hand: Copper, Province, Copper, Copper, Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 3; hand: Province, Copper, Copper, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Province; new_hand: Province, Copper, Copper, Province, Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 4; hand: Province, Copper, Copper, Province, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Forager, Patrician; new_hand: Province, Copper, Copper, Province, Province, Forager, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 5; hand: Province, Copper, Copper, Province, Province, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 5; hand: Province, Copper, Province, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Province, Copper, Province, Province, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 5; hand: Province, Copper, Province, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Patrician, Emporium; new_hand: Province, Copper, Province, Province, Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 6; hand: Province, Copper, Province, Province, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Province, Copper, Province, Province, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 6; hand: Province, Copper, Province, Province, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 6; hand: Province, Province, Province, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Emporium; new_hand: Province, Province, Province, Emporium, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 7; hand: Province, Province, Province, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 8; hand: Province, Province, Province, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 9; hand: Province, Province, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 4)
+07:00:06 - INFO - Supply: Forager gained (3 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 17 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 21 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Patrician, Forager, Patrician, Gold, Province
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Patrician, Gold, Province)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Forager, Patrician, Gold, Province, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Gold, Province, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Forager, Gold, Province, Patrician, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Forager, Gold, Province, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Silver; new_hand: Forager, Gold, Province, Silver, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Gold, Province, Silver, Silver, Modify)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Modify (remaining_actions: 0; hand: Gold, Province, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 2; coins_added: 3; coins_after: 5; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Collection (cost: 5; remaining_coins: 0; remaining_buys: 1)
+07:00:06 - INFO - Supply: Collection gained (9 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 5 actions and bought Collection
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 21 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Forager, Emporium, Forager, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Emporium, Emporium, Forager, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 3)
+07:00:06 - INFO - Supply: Forager gained (2 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 3 actions and bought Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 22 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Snowy Village, Copper, Forager, Silver, Patrician
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Forager, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Snowy Village, Copper, Forager, Silver, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Snowy Village, Copper, Forager, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Snowy Village, Copper, Forager, Silver, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Forager (remaining_actions: 0; hand: Snowy Village, Copper, Silver, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Silver, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Silver, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Silver, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Silver, Copper, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 2; coins_added: 1; coins_after: 3; remaining_treasures: Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 3; coins_added: 2; coins_after: 5; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Collection (cost: 5; remaining_coins: 0; remaining_buys: 1)
+07:00:06 - INFO - Supply: Collection gained (8 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 5 actions and bought Collection
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 22 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Emporium, Forager, Patrician, Emporium, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Emporium, Patrician, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Patrician, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 0; hand: )
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 1; hand: Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 1; hand: Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Patrician; new_hand: Emporium, Province, Emporium, Patrician)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Patrician (remaining_actions: 2; hand: Emporium, Province, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Emporium; new_hand: Emporium, Province, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 2; hand: Province, Emporium, Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Emporium, Emporium; new_hand: Province, Emporium, Emporium, Province, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 3; hand: Province, Emporium, Province, Emporium, Emporium)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Province, Forager; new_hand: Province, Emporium, Province, Emporium, Emporium, Province, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 4; hand: Province, Emporium, Province, Emporium, Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 4; hand: Province, Emporium, Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 2 cards (drawn_cards: Forager, Forager; new_hand: Province, Emporium, Emporium, Province, Forager, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 5; hand: Province, Emporium, Emporium, Province, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 5; hand: Emporium, Emporium, Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Emporium (remaining_actions: 5; hand: Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): draws 1 card (drawn_cards: Forager; new_hand: Province, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 6; hand: Province)
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Province (cost: 8; remaining_coins: 4; remaining_buys: 6)
+07:00:06 - INFO - Supply: Province gained (3 remaining)
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 5)
+07:00:06 - INFO - Supply: Forager gained (1 remaining)
+07:00:06 - INFO - Summary: Player 2 (CustomBoard2) played 14 actions and bought Province, Forager
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 23 - Player 1 (CustomBoard3)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Copper, Snowy Village, Snowy Village, Patrician, Silver
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Snowy Village, Snowy Village, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Snowy Village, Snowy Village, Silver, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Copper, Snowy Village, Snowy Village, Silver)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Copper; new_hand: Copper, Snowy Village, Snowy Village, Silver, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 0; hand: Copper, Snowy Village, Silver, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Copper, Snowy Village, Silver, Copper, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 3; hand: Copper, Snowy Village, Silver, Copper)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Modify; new_hand: Copper, Snowy Village, Silver, Copper, Modify)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Modify (remaining_actions: 2; hand: Copper, Snowy Village, Silver, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Snowy Village (remaining_actions: 1; hand: Silver, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Patrician; new_hand: Silver, Copper, Gold, Patrician)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Patrician (remaining_actions: 0; hand: Silver, Copper, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): draws 1 card (drawn_cards: Estate; new_hand: Silver, Copper, Gold, Estate)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Copper (coins_before: 0; coins_added: 1; coins_after: 1; remaining_treasures: Silver, Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Silver (coins_before: 1; coins_added: 2; coins_after: 3; remaining_treasures: Gold)
+07:00:06 - INFO - Player 1 (CustomBoard3): plays Gold (coins_before: 3; coins_added: 3; coins_after: 6; remaining_treasures: )
+07:00:06 - INFO - Player 1 (CustomBoard3): buys Gold (cost: 6; remaining_coins: 0; remaining_buys: 0)
+07:00:06 - INFO - Supply: Gold gained (28 remaining)
+07:00:06 - INFO - Summary: Player 1 (CustomBoard3) played 7 actions and bought Gold
+07:00:06 - INFO - 
+========================================
+07:00:06 - INFO - Turn 23 - Player 2 (CustomBoard2)
+07:00:06 - INFO - Resources: 1 actions, 1 buys, 0 coins
+07:00:06 - INFO - Hand: Forager, Forager, Forager, Emporium, Forager
+07:00:06 - INFO - ----------------------------------------
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Forager, Forager, Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: Emporium, Forager)
+07:00:06 - INFO - Player 2 (CustomBoard2): plays Forager (remaining_actions: 0; hand: )
+07:00:06 - INFO - Player 2 (CustomBoard2): buys Forager (cost: 3; remaining_coins: 1; remaining_buys: 3)
+07:00:06 - INFO - Supply: Forager gained (0 remaining)
+07:00:06 - INFO - Game over: Three piles depleted
+07:00:06 - INFO - 
+============================================================
+07:00:06 - INFO - Game Over!
+07:00:06 - INFO - Winner: Player 2 (CustomBoard2)
+07:00:06 - INFO - 
+Final Scores:
+07:00:06 - INFO -   Player 1 (CustomBoard3): 7
+07:00:06 - INFO -     Province x1 -> 6 VP
+07:00:06 - INFO -     Estate x1 -> 1 VP
+07:00:06 - INFO -   Player 2 (CustomBoard2): 36
+07:00:06 - INFO -     Province x1 -> 6 VP
+07:00:06 - INFO -     Emporium x5 -> 10 VP
+07:00:06 - INFO -     VP Tokens: 20
+07:00:06 - INFO - 
+Final Supply State:
+07:00:06 - INFO -   Copper: 46 remaining
+07:00:06 - INFO -   Silver: 36 remaining
+07:00:06 - INFO -   Gold: 28 remaining
+07:00:06 - INFO -   Estate: 8 remaining
+07:00:06 - INFO -   Duchy: 8 remaining
+07:00:06 - INFO -   Province: 3 remaining
+07:00:06 - INFO -   Curse: 10 remaining
+07:00:06 - INFO -   Collection: 8 remaining
+07:00:06 - INFO -   Emporium: Empty
+07:00:06 - INFO -   Forager: Empty
+07:00:06 - INFO -   Miser: 10 remaining
+07:00:06 - INFO -   Modify: 8 remaining
+07:00:06 - INFO -   Patrician: Empty
+07:00:06 - INFO -   Rats: 10 remaining
+07:00:06 - INFO -   Rebuild: 10 remaining
+07:00:06 - INFO -   Skulk: 10 remaining
+07:00:06 - INFO -   Snowy Village: 7 remaining
+07:00:06 - INFO - ============================================================
+

--- a/battle_logs/metrics/game_20250615_070005_843795_metrics.json
+++ b/battle_logs/metrics/game_20250615_070005_843795_metrics.json
@@ -1,0 +1,26 @@
+{
+  "turn_count": 101,
+  "cards_played": {
+    "Copper": 89,
+    "Patrician": 463,
+    "Forager": 203,
+    "Snowy Village": 22,
+    "Emporium": 496,
+    "Silver": 6
+  },
+  "victory_points": {
+    "GeneticAI-139792715874960": 24,
+    "GeneticAI-139792715876496": 0
+  },
+  "actions_played": {
+    "GeneticAI-139792715874960": 1057,
+    "GeneticAI-139792715876496": 127
+  },
+  "cards_bought": {
+    "Patrician": 10,
+    "Snowy Village": 6,
+    "Forager": 10,
+    "Emporium": 6,
+    "Silver": 2
+  }
+}

--- a/battle_logs/metrics/game_20250615_070005_960829_metrics.json
+++ b/battle_logs/metrics/game_20250615_070005_960829_metrics.json
@@ -1,0 +1,29 @@
+{
+  "turn_count": 23,
+  "cards_played": {
+    "Copper": 91,
+    "Patrician": 77,
+    "Forager": 48,
+    "Snowy Village": 25,
+    "Silver": 14,
+    "Emporium": 25,
+    "Gold": 1
+  },
+  "victory_points": {
+    "GeneticAI-139792715886720": 2,
+    "GeneticAI-139792715877600": 38
+  },
+  "actions_played": {
+    "GeneticAI-139792715886720": 54,
+    "GeneticAI-139792715877600": 121
+  },
+  "cards_bought": {
+    "Patrician": 10,
+    "Forager": 10,
+    "Snowy Village": 3,
+    "Silver": 6,
+    "Emporium": 10,
+    "Skulk": 1,
+    "Province": 2
+  }
+}

--- a/battle_logs/metrics/game_20250615_070005_994950_metrics.json
+++ b/battle_logs/metrics/game_20250615_070005_994950_metrics.json
@@ -1,0 +1,30 @@
+{
+  "turn_count": 33,
+  "cards_played": {
+    "Copper": 161,
+    "Patrician": 132,
+    "Emporium": 77,
+    "Forager": 55,
+    "Snowy Village": 37,
+    "Gold": 20,
+    "Modify": 3
+  },
+  "victory_points": {
+    "GeneticAI-139792715754496": 69,
+    "GeneticAI-139792715889744": 8
+  },
+  "actions_played": {
+    "GeneticAI-139792715754496": 215,
+    "GeneticAI-139792715889744": 89
+  },
+  "cards_bought": {
+    "Patrician": 10,
+    "Emporium": 10,
+    "Snowy Village": 4,
+    "Forager": 7,
+    "Gold": 4,
+    "Province": 8,
+    "Modify": 2,
+    "Estate": 4
+  }
+}

--- a/battle_logs/metrics/game_20250615_070006_044965_metrics.json
+++ b/battle_logs/metrics/game_20250615_070006_044965_metrics.json
@@ -1,0 +1,27 @@
+{
+  "turn_count": 101,
+  "cards_played": {
+    "Copper": 83,
+    "Patrician": 459,
+    "Forager": 206,
+    "Snowy Village": 29,
+    "Silver": 13,
+    "Emporium": 245
+  },
+  "victory_points": {
+    "GeneticAI-139792715907488": 0,
+    "GeneticAI-139792715875920": 12
+  },
+  "actions_played": {
+    "GeneticAI-139792715907488": 128,
+    "GeneticAI-139792715875920": 811
+  },
+  "cards_bought": {
+    "Patrician": 10,
+    "Forager": 8,
+    "Snowy Village": 10,
+    "Silver": 4,
+    "Emporium": 3,
+    "Province": 3
+  }
+}

--- a/battle_logs/metrics/game_20250615_070006_168818_metrics.json
+++ b/battle_logs/metrics/game_20250615_070006_168818_metrics.json
@@ -1,0 +1,32 @@
+{
+  "turn_count": 23,
+  "cards_played": {
+    "Copper": 163,
+    "Patrician": 103,
+    "Emporium": 111,
+    "Snowy Village": 16,
+    "Forager": 30,
+    "Silver": 10,
+    "Gold": 3,
+    "Modify": 2
+  },
+  "victory_points": {
+    "GeneticAI-139792715893744": 7,
+    "GeneticAI-139792715904832": 36
+  },
+  "actions_played": {
+    "GeneticAI-139792715904832": 179,
+    "GeneticAI-139792715893744": 83
+  },
+  "cards_bought": {
+    "Patrician": 10,
+    "Emporium": 10,
+    "Snowy Village": 3,
+    "Forager": 10,
+    "Silver": 4,
+    "Province": 5,
+    "Gold": 2,
+    "Modify": 1,
+    "Collection": 2
+  }
+}

--- a/dominion/strategy/strategies/custom_board_strategy2.py
+++ b/dominion/strategy/strategies/custom_board_strategy2.py
@@ -22,7 +22,6 @@ class CustomBoardStrategy2(EnhancedStrategy):
             PriorityRule("Collection"),
             PriorityRule("Skulk"),
             PriorityRule("Miser"),
-            PriorityRule("Looting"),
             PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
             PriorityRule("Gold"),
             PriorityRule("Silver"),


### PR DESCRIPTION
## Summary
- log the Custom Board Strategy3 vs Custom Board Strategy2 matchup
- remove an invalid `Looting` card reference so the strategies run

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e6b4a845083279b61e1ab4cf4b1a7