### PR TITLE
Update README strategy names

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 To battle strategies:
 
 ```
-python -m dominion.simulation.strategy_battle ChapelWitch BigMoney --games 2
+python -m dominion.simulation.strategy_battle "Chapel Witch" "Big Money" --games 2
 ```
+
+Strategy names contain spaces, so be sure to wrap them in quotes when invoking the command line tools.
 
 Pass `--use-shelters` to start each player with Necropolis, Hovel and
 Overgrown Estate instead of three Estates.
@@ -20,7 +22,7 @@ The leaderboard will be written to `leaderboard.html` by default.
 Example reports can be generated using the generic comparison runner:
 
 ```
-python compare_strategies.py ChapelWitch BigMoney --games 50
+python compare_strategies.py "Chapel Witch" "Big Money" --games 50
 ```
 
 Reports are written to the `reports` directory.


### PR DESCRIPTION
## Summary
- fix README examples to use quoted strategy names with spaces

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e6f6d37448327aadb9cd1147840fd