### PR TITLE
Fix split pile counts

### DIFF
--- a/dominion/cards/empires/emporium.py
+++ b/dominion/cards/empires/emporium.py
@@ -1,10 +1,9 @@
-from ..base_card import Card, CardCost, CardStats, CardType
-from ..split_pile import SplitPileMixin
+from ..base_card import CardCost, CardStats, CardType
+from ..split_pile import BottomSplitPileCard
 
 
-class Emporium(SplitPileMixin, Card):
+class Emporium(BottomSplitPileCard):
     partner_card_name = "Patrician"
-    bottom = True
     def __init__(self):
         super().__init__(
             name="Emporium",

--- a/dominion/cards/empires/patrician.py
+++ b/dominion/cards/empires/patrician.py
@@ -1,10 +1,9 @@
-from ..base_card import Card, CardCost, CardStats, CardType
-from ..split_pile import SplitPileMixin
+from ..base_card import CardCost, CardStats, CardType
+from ..split_pile import TopSplitPileCard
 
 
-class Patrician(SplitPileMixin, Card):
+class Patrician(TopSplitPileCard):
     partner_card_name = "Emporium"
-    bottom = False
     def __init__(self):
         super().__init__(
             name="Patrician",

--- a/dominion/cards/prosperity/city.py
+++ b/dominion/cards/prosperity/city.py
@@ -12,7 +12,7 @@ class City(Card):
 
     def play_effect(self, game_state):
         player = game_state.current_player
-        empty_piles = sum(1 for count in game_state.supply.values() if count == 0)
+        empty_piles = game_state.empty_piles
 
         if empty_piles >= 1:
             game_state.draw_cards(player, 1)

--- a/dominion/cards/split_pile.py
+++ b/dominion/cards/split_pile.py
@@ -15,3 +15,15 @@ class SplitPileMixin(Card):
         if self.bottom and game_state.supply.get(self.partner_card_name, 0) > 0:
             return False
         return super().may_be_bought(game_state)
+
+
+class TopSplitPileCard(SplitPileMixin):
+    """Base class for the top card in a split pile."""
+
+    bottom = False
+
+
+class BottomSplitPileCard(SplitPileMixin):
+    """Base class for the bottom card in a split pile."""
+
+    bottom = True

--- a/dominion/strategy/condition_parser.py
+++ b/dominion/strategy/condition_parser.py
@@ -110,7 +110,7 @@ class ConditionTransformer(Transformer):
             elif ref_type == "provinces_left":
                 return context.state.supply.get("Province", 0)
             elif ref_type == "empty_piles":
-                return sum(1 for count in context.state.supply.values() if count == 0)
+                return context.state.empty_piles
             raise ValueError(f"Unknown state reference type: {ref_type} (from {ref})")
 
         return get_state_value

--- a/dominion/strategy/enhanced_strategy.py
+++ b/dominion/strategy/enhanced_strategy.py
@@ -105,10 +105,7 @@ class EnhancedStrategy:
         expr = expr.replace(
             "state.provinces_left", 'state.supply.get("Province", 0)'
         )
-        expr = expr.replace(
-            "state.empty_piles",
-            'sum(1 for v in state.supply.values() if v == 0)'
-        )
+        expr = expr.replace("state.empty_piles", "state.empty_piles")
 
         def count(name_str: str) -> int:
             names = [n.strip() for n in name_str.split("/")]

--- a/tests/test_split_piles.py
+++ b/tests/test_split_piles.py
@@ -7,7 +7,7 @@ from tests.utils import DummyAI
 def test_patrician_emporium_supply_and_buy_rule():
     players = [PlayerState(DummyAI()) for _ in range(2)]
     state = GameState(players)
-    state.setup_supply([get_card("Patrician"), get_card("Emporium")])
+    state.setup_supply([get_card("Patrician")])
 
     # Split pile should start with five of each card
     assert state.supply["Patrician"] == 5
@@ -20,3 +20,23 @@ def test_patrician_emporium_supply_and_buy_rule():
     state.supply["Patrician"] = 0
     # Once Patricians are gone Emporium becomes available
     assert emp.may_be_bought(state)
+
+
+def test_split_pile_counts_as_single_empty_pile():
+    players = [PlayerState(DummyAI()) for _ in range(2)]
+    state = GameState(players)
+    state.setup_supply([get_card("Patrician"), get_card("Village")])
+
+    # Deplete two other piles
+    state.supply["Copper"] = 0
+    state.supply["Village"] = 0
+
+    # Deplete top half only
+    state.supply["Patrician"] = 0
+    assert state.empty_piles == 2
+    assert not state.is_game_over()
+
+    # Deplete bottom half as well
+    state.supply["Emporium"] = 0
+    assert state.empty_piles == 3
+    assert state.is_game_over()


### PR DESCRIPTION
## Summary
- treat split piles as a single supply pile
- expose `GameState.empty_piles`
- use `empty_piles` in City card, condition parser, and enhanced strategy
- auto-add partner cards for split piles in supply
- provide `TopSplitPileCard` and `BottomSplitPileCard`
- test that split piles count correctly for game end

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e7127ab2083279e2b61f456e22264