### PR TITLE
Implement Acting Troupe with Villagers

### DIFF
--- a/dominion/cards/renaissance/acting_troupe.py
+++ b/dominion/cards/renaissance/acting_troupe.py
@@ -9,3 +9,19 @@ class ActingTroupe(Card):
             stats=CardStats(),
             types=[CardType.ACTION],
         )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+        player.villagers += 4
+        game_state.log_callback(
+            (
+                "action",
+                player.ai.name,
+                "gains 4 Villagers",
+                {"villagers_total": player.villagers},
+            )
+        )
+
+        if self in player.in_play:
+            player.in_play.remove(self)
+        game_state.trash_card(player, self)

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -193,11 +193,26 @@ class GameState:
         """Handle the action phase of a turn."""
         player = self.current_player
 
-        while player.actions > 0:
+        while True:
             action_cards = [card for card in player.hand if card.is_action]
 
             if not action_cards:
                 break
+
+            if player.actions == 0:
+                if player.villagers > 0:
+                    player.villagers -= 1
+                    player.actions += 1
+                    self.log_callback(
+                        (
+                            "action",
+                            player.ai.name,
+                            "spends a Villager for +1 Action",
+                            {"villagers_remaining": player.villagers},
+                        )
+                    )
+                else:
+                    break
 
             choice = player.ai.choose_action(self, action_cards + [None])
             if choice is None:

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -26,6 +26,7 @@ class PlayerState:
 
     # Misc counters
     vp_tokens: int = 0
+    villagers: int = 0
     miser_coppers: int = 0
     ignore_action_bonuses: bool = False
     collection_played: int = 0
@@ -74,6 +75,7 @@ class PlayerState:
         self.coins = 0
         self.potions = 0
         self.vp_tokens = 0
+        self.villagers = 0
         self.miser_coppers = 0
         self.ignore_action_bonuses = False
         self.collection_played = 0

--- a/tests/test_acting_troupe.py
+++ b/tests/test_acting_troupe.py
@@ -1,0 +1,41 @@
+from dominion.cards.registry import get_card
+from dominion.game.player_state import PlayerState
+from dominion.game.game_state import GameState
+from tests.utils import DummyAI, ChooseFirstActionAI
+
+
+def play_action(state, player, card):
+    player.hand.remove(card)
+    player.in_play.append(card)
+    card.on_play(state)
+
+
+def test_acting_troupe_gives_villagers_and_trashes():
+    ai = DummyAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([])
+
+    troupe = get_card("Acting Troupe")
+    player.hand = [troupe]
+    play_action(state, player, troupe)
+
+    assert player.villagers == 4
+    assert troupe in state.trash
+    assert troupe not in player.in_play
+
+
+def test_villagers_can_be_spent_for_actions():
+    ai = ChooseFirstActionAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([])
+
+    player.hand = [get_card("Village")]
+    player.actions = 0
+    player.villagers = 1
+    state.phase = "action"
+    state.handle_action_phase()
+
+    assert player.villagers == 0
+    assert player.actions == 2


### PR DESCRIPTION
## Summary
- implement full Acting Troupe card effect
- support Villagers token on `PlayerState`
- spend Villagers automatically in action phase
- add tests for Acting Troupe and Villagers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684efaee23348327a5154c53d875b014