### PR TITLE
Add First Mate card implementation

### DIFF
--- a/dominion/cards/missing_cards.py
+++ b/dominion/cards/missing_cards.py
@@ -75,7 +75,7 @@ class FirstMate(Card):
     def __init__(self):
         super().__init__(
             name="First Mate",
-            cost=CardCost(coins=4),
+            cost=CardCost(coins=5),
             stats=CardStats(),
-            types=[CardType.ACTION, CardType.DURATION],
+            types=[CardType.ACTION],
         )

--- a/dominion/cards/plunder/first_mate.py
+++ b/dominion/cards/plunder/first_mate.py
@@ -2,10 +2,53 @@ from ..base_card import Card, CardCost, CardStats, CardType
 
 
 class FirstMate(Card):
+    """Implementation of the First Mate card from the Plunder expansion."""
+
     def __init__(self):
+        # According to the Dominion Strategy wiki the card costs 5 Coins and is
+        # a simple Action card (no Duration type).
         super().__init__(
             name="First Mate",
-            cost=CardCost(coins=4),
+            cost=CardCost(coins=5),
             stats=CardStats(),
-            types=[CardType.ACTION, CardType.DURATION],
+            types=[CardType.ACTION],
         )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        # Determine all Action cards currently in hand.
+        actions_in_hand = [c for c in player.hand if c.is_action]
+        if not actions_in_hand:
+            # No Action cards to play, just draw up to six.
+            self._draw_to_six(game_state, player)
+            return
+
+        # Allow the AI to choose an Action card to play copies of.  Passing None
+        # lets the AI decide to skip playing any card if desired.
+        choice = player.ai.choose_action(game_state, actions_in_hand + [None])
+        if choice is None:
+            self._draw_to_six(game_state, player)
+            return
+
+        chosen_name = choice.name
+
+        # Play all copies of the chosen card currently in hand.  If the card
+        # draws more copies of itself they will also be played.
+        while True:
+            card_to_play = next((c for c in player.hand if c.name == chosen_name), None)
+            if card_to_play is None:
+                break
+            player.hand.remove(card_to_play)
+            player.in_play.append(card_to_play)
+            card_to_play.on_play(game_state)
+
+        self._draw_to_six(game_state, player)
+
+    @staticmethod
+    def _draw_to_six(game_state, player):
+        """Helper to draw until the player has six cards in hand."""
+        while len(player.hand) < 6:
+            if not player.deck and not player.discard:
+                break
+            game_state.draw_cards(player, 1)

--- a/tests/test_new_cards.py
+++ b/tests/test_new_cards.py
@@ -1,4 +1,6 @@
 from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from tests.utils import ChooseFirstActionAI
 
 
 def test_new_card_registry():
@@ -15,3 +17,27 @@ def test_new_card_registry():
     for name in names:
         card = get_card(name)
         assert card.name == name
+
+
+def test_first_mate_effect():
+    ai = ChooseFirstActionAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("First Mate"), get_card("Village")])
+
+    player = state.players[0]
+
+    # Set up a controlled hand and deck
+    player.hand = [get_card("First Mate"), get_card("Village"), get_card("Village")]
+    player.deck = [get_card("Copper") for _ in range(10)]
+    player.discard = []
+    player.actions = 1
+
+    state.phase = "action"
+    state.handle_action_phase()
+
+    # Both Villages should have been played
+    assert sum(1 for c in player.in_play if c.name == "Village") == 2
+    # First Mate should also be in play
+    assert any(c.name == "First Mate" for c in player.in_play)
+    # Hand should be drawn up to 6 cards
+    assert len(player.hand) == 6


### PR DESCRIPTION
## Summary
- implement `First Mate` action card logic and fix stats
- update placeholder card definitions
- test the new card's behavior

## Testing
- `pip install lark -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684efb5bf7448327a2b25d6a66cd91e3