### PR TITLE
Add Taskmaster card

### DIFF
--- a/dominion/cards/allies/taskmaster.py
+++ b/dominion/cards/allies/taskmaster.py
@@ -5,7 +5,19 @@ class Taskmaster(Card):
     def __init__(self):
         super().__init__(
             name="Taskmaster",
-            cost=CardCost(coins=4),
-            stats=CardStats(),
-            types=[CardType.ACTION],
+            cost=CardCost(coins=3),
+            stats=CardStats(actions=1, coins=1),
+            types=[CardType.ACTION, CardType.DURATION],
         )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+        player.duration.append(self)
+
+    def on_duration(self, game_state):
+        player = game_state.current_player
+        if getattr(player, "gained_five_last_turn", False):
+            if not player.ignore_action_bonuses:
+                player.actions += 1
+            player.coins += 1
+            player.duration.append(self)

--- a/dominion/cards/base_card.py
+++ b/dominion/cards/base_card.py
@@ -113,6 +113,8 @@ class Card:
         """Effects that happen when card is gained."""
         if self.is_action and getattr(player, "collection_played", 0) > 0:
             player.vp_tokens += player.collection_played
+        if self.cost.coins == 5:
+            player.gained_five_this_turn = True
 
     def on_trash(self, game_state, player):
         """Effects that happen when card is trashed. Override in subclasses."""

--- a/dominion/cards/missing_cards.py
+++ b/dominion/cards/missing_cards.py
@@ -25,9 +25,9 @@ class Taskmaster(Card):
     def __init__(self):
         super().__init__(
             name="Taskmaster",
-            cost=CardCost(coins=4),
-            stats=CardStats(),
-            types=[CardType.ACTION],
+            cost=CardCost(coins=3),
+            stats=CardStats(actions=1, coins=1),
+            types=[CardType.ACTION, CardType.DURATION],
         )
 
 

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -119,6 +119,8 @@ class GameState:
     def handle_start_phase(self):
         """Handle the start of turn phase."""
         self.current_player.turns_taken += 1
+        self.current_player.gained_five_last_turn = self.current_player.gained_five_this_turn
+        self.current_player.gained_five_this_turn = False
 
         # Reset per-turn flags
         self.current_player.ignore_action_bonuses = False

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -38,6 +38,8 @@ class PlayerState:
     banned_buys: list[str] = field(default_factory=list)
     delayed_cards: list[Card] = field(default_factory=list)
     seize_the_day_used: bool = False
+    gained_five_this_turn: bool = False
+    gained_five_last_turn: bool = False
 
     def initialize(self, use_shelters: bool = False):
         """Set up starting deck and draw initial hand.
@@ -84,6 +86,8 @@ class PlayerState:
         self.banned_buys = []
         self.delayed_cards = []
         self.seize_the_day_used = False
+        self.gained_five_this_turn = False
+        self.gained_five_last_turn = False
 
         # Draw initial hand of 5 cards
         self.draw_cards(5)


### PR DESCRIPTION
## Summary
- implement the Taskmaster action-duration card
- track when a player gains a $5-cost card
- use the flag at the start of the turn to repeat Taskmaster

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684efb11c6288327835d88d13ff3011b