### PR TITLE
Refactor strategy conditions

### DIFF
--- a/dominion/strategy/enhanced_strategy.py
+++ b/dominion/strategy/enhanced_strategy.py
@@ -8,7 +8,7 @@ file build on these classes.
 """
 
 from dataclasses import dataclass
-from typing import Callable, Iterable, Optional
+from typing import Callable, Iterable, Optional, ClassVar
 
 from dominion.game.card import Card
 from dominion.game.game_state import GameState
@@ -36,7 +36,7 @@ class PriorityRule:
     # Helper constructors -------------------------------------------------
     import operator as _op
 
-    _OP_MAP: dict[str, Callable[[int, int], bool]] = {
+    _OP_MAP: ClassVar[dict[str, Callable[[int, int], bool]]] = {
         "<": _op.lt,
         "<=": _op.le,
         ">": _op.gt,

--- a/dominion/strategy/strategies/chapel_witch_test.py
+++ b/dominion/strategy/strategies/chapel_witch_test.py
@@ -12,25 +12,37 @@ class ChapelWitchTestStrategy(EnhancedStrategy):
 
         # Define gain priorities
         self.gain_priority = [
-            PriorityRule("Province", "my.coins >= 8"),
-            PriorityRule("Witch", "my.count(Witch) == 0"),
-            PriorityRule("Chapel", "state.turn_number <= 5 AND my.count(Chapel) == 0"),
-            PriorityRule("Gold", "my.coins >= 6"),
-            PriorityRule("Silver", "my.coins >= 3"),
+            PriorityRule("Province", PriorityRule.resources("coins", ">=", 8)),
+            PriorityRule("Witch", lambda _s, me: me.count_in_deck("Witch") == 0),
+            PriorityRule(
+                "Chapel",
+                PriorityRule.and_(
+                    PriorityRule.turn_number("<=", 5),
+                    lambda _s, me: me.count_in_deck("Chapel") == 0,
+                ),
+            ),
+            PriorityRule("Gold", PriorityRule.resources("coins", ">=", 6)),
+            PriorityRule("Silver", PriorityRule.resources("coins", ">=", 3)),
             PriorityRule("Copper"),
         ]
 
         # Define action priorities
         self.action_priority = [
-            PriorityRule("Chapel", "my.count(Estate) > 0 OR my.count(Copper) > 3"),
+            PriorityRule(
+                "Chapel",
+                lambda _s, me: me.count_in_deck("Estate") > 0 or me.count_in_deck("Copper") > 3,
+            ),
             PriorityRule("Witch"),
         ]
 
         # Define trash priorities
         self.trash_priority = [
             PriorityRule("Curse"),
-            PriorityRule("Estate", "state.provinces_left > 4"),
-            PriorityRule("Copper", "my.count(Silver) + my.count(Gold) >= 3"),
+            PriorityRule("Estate", PriorityRule.provinces_left(">", 4)),
+            PriorityRule(
+                "Copper",
+                lambda _s, me: me.count_in_deck("Silver") + me.count_in_deck("Gold") >= 3,
+            ),
         ]
 
         # Define treasure priorities

--- a/dominion/strategy/strategies/collection_patrician_rebuild.py
+++ b/dominion/strategy/strategies/collection_patrician_rebuild.py
@@ -16,12 +16,12 @@ class CollectionPatricianRebuildStrategy(EnhancedStrategy):
         # Gain priorities
         self.gain_priority = [
             PriorityRule("Province"),
-            PriorityRule("Rebuild", "my.count(Rebuild) < 1"),
-            PriorityRule("Modify", "my.count(Modify) < 1"),
-            PriorityRule("Collection", "my.count(Collection) < 1"),
-            PriorityRule("Forager", "my.count(Forager) < 2"),
-            PriorityRule("Skulk", "my.count(Skulk) < 3"),
-            PriorityRule("Patrician", "my.count(Collection) >= 1"),
+            PriorityRule("Rebuild", lambda _s, me: me.count_in_deck("Rebuild") < 1),
+            PriorityRule("Modify", lambda _s, me: me.count_in_deck("Modify") < 1),
+            PriorityRule("Collection", lambda _s, me: me.count_in_deck("Collection") < 1),
+            PriorityRule("Forager", lambda _s, me: me.count_in_deck("Forager") < 2),
+            PriorityRule("Skulk", lambda _s, me: me.count_in_deck("Skulk") < 3),
+            PriorityRule("Patrician", lambda _s, me: me.count_in_deck("Collection") >= 1),
             PriorityRule("Gold"),
             PriorityRule("Silver"),
             PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),
@@ -42,10 +42,13 @@ class CollectionPatricianRebuildStrategy(EnhancedStrategy):
             PriorityRule("Curse"),
             PriorityRule("Estate"),
             PriorityRule("Copper"),
-            PriorityRule("Skulk", "my.count(Skulk) > 2"),
+            PriorityRule("Skulk", lambda _s, me: me.count_in_deck("Skulk") > 2),
             PriorityRule(
                 "Gold",
-                PriorityRule.and_(PriorityRule.provinces_left("<=", 2), "my.count(Modify) >= 1"),
+                PriorityRule.and_(
+                    PriorityRule.provinces_left("<=", 2),
+                    lambda _s, me: me.count_in_deck("Modify") >= 1,
+                ),
             ),
         ]
 

--- a/dominion/strategy/strategies/custom_board_strategy3.py
+++ b/dominion/strategy/strategies/custom_board_strategy3.py
@@ -13,13 +13,13 @@ class CustomBoardStrategy3(EnhancedStrategy):
         # Gain priorities
         self.gain_priority = [
             PriorityRule("Province"),
-            PriorityRule("Emporium", "my.count(Snowy Village) > 0"),  # Only if you can activate
+            PriorityRule("Emporium", lambda _s, me: me.count_in_deck("Snowy Village") > 0),  # Only if you can activate
             PriorityRule("Gold"),
             PriorityRule("Patrician"),
-            PriorityRule("Snowy Village", "my.count(Snowy Village) < 3"),
-            PriorityRule("Forager", "my.count(Forager) < 2"),
-            PriorityRule("Collection", "my.count(Collection) < 5"),
-            PriorityRule("Modify", "my.count(Modify) < 2"),
+            PriorityRule("Snowy Village", lambda _s, me: me.count_in_deck("Snowy Village") < 3),
+            PriorityRule("Forager", lambda _s, me: me.count_in_deck("Forager") < 2),
+            PriorityRule("Collection", lambda _s, me: me.count_in_deck("Collection") < 5),
+            PriorityRule("Modify", lambda _s, me: me.count_in_deck("Modify") < 2),
             PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
             PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),
             PriorityRule("Silver"),

--- a/dominion/strategy/strategies/custom_board_strategy4.py
+++ b/dominion/strategy/strategies/custom_board_strategy4.py
@@ -13,23 +13,44 @@ class CustomBoardStrategy4(EnhancedStrategy):
         # Gain priorities
         self.gain_priority = [
             # Province only after getting 4 loots
-            PriorityRule("Province", PriorityRule.and_("my.coins >= 8", "my.count(Looting) >= 4")),
+            PriorityRule(
+                "Province",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 8),
+                    lambda _s, me: me.count_in_deck("Looting") >= 4,
+                ),
+            ),
             # Early Collection priority
-            PriorityRule("Collection", PriorityRule.and_("my.coins >= 5", "my.count(Collection) == 0")),
+            PriorityRule(
+                "Collection",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 5),
+                    lambda _s, me: me.count_in_deck("Collection") == 0,
+                ),
+            ),
             # Looting at 6 coins
             PriorityRule("Looting"),
             # When Collection is in play, buy small actions with remaining money
-            PriorityRule("Patrician", "my.count(Collection) > 0"),
-            PriorityRule("Forager", "my.count(Collection) > 0"),
+            PriorityRule("Patrician", lambda _s, me: me.count_in_deck("Collection") > 0),
+            PriorityRule("Forager", lambda _s, me: me.count_in_deck("Collection") > 0),
             # Patrician with 2 coins when provinces > 2
-            PriorityRule("Patrician", PriorityRule.and_(PriorityRule.provinces_left(">", 2), "my.coins == 2")),
+            PriorityRule(
+                "Patrician",
+                PriorityRule.and_(
+                    PriorityRule.provinces_left(">", 2),
+                    PriorityRule.resources("coins", "==", 2),
+                ),
+            ),
             # Skulk at 4 coins (to trash with Forager)
             PriorityRule("Skulk"),
             # Get two Foragers, especially if bought Skulk
-            PriorityRule("Forager", "my.count(Forager) < 2"),
-            PriorityRule("Forager", "my.count(Skulk) > 0 and my.count(Forager) < 2"),
+            PriorityRule("Forager", lambda _s, me: me.count_in_deck("Forager") < 2),
+            PriorityRule(
+                "Forager",
+                lambda _s, me: me.count_in_deck("Skulk") > 0 and me.count_in_deck("Forager") < 2,
+            ),
             # Silver at 3 coins if already have one Forager
-            PriorityRule("Silver", "my.count(Forager) >= 1"),
+            PriorityRule("Silver", lambda _s, me: me.count_in_deck("Forager") >= 1),
             PriorityRule("Emporium"),
             # Late game victory
             PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),

--- a/dominion/strategy/strategies/rats_modify_rebuild.py
+++ b/dominion/strategy/strategies/rats_modify_rebuild.py
@@ -13,14 +13,14 @@ class RatsModifyRebuildStrategy(EnhancedStrategy):
         # Gain priorities
         self.gain_priority = [
             PriorityRule("Province"),
-            PriorityRule("Rebuild", "my.count(Rebuild) < 3"),
+            PriorityRule("Rebuild", lambda _s, me: me.count_in_deck("Rebuild") < 3),
             PriorityRule("Emporium"),
             PriorityRule("Duchy"),
-            PriorityRule("Patrician", "my.count(Patrician) < 2"),
-            PriorityRule("Modify", "my.count(Modify) < 2"),
+            PriorityRule("Patrician", lambda _s, me: me.count_in_deck("Patrician") < 2),
+            PriorityRule("Modify", lambda _s, me: me.count_in_deck("Modify") < 2),
             PriorityRule("Skulk"),
             PriorityRule("Rats"),
-            PriorityRule("Forager", "my.count(Forager) < 1"),
+            PriorityRule("Forager", lambda _s, me: me.count_in_deck("Forager") < 1),
             PriorityRule("Gold"),
             PriorityRule("Silver"),
             PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),

--- a/dominion/strategy/strategies/skulk_rebuild.py
+++ b/dominion/strategy/strategies/skulk_rebuild.py
@@ -12,10 +12,10 @@ class SkulkRebuildStrategy(EnhancedStrategy):
         # Gain priorities
         self.gain_priority = [
             PriorityRule("Province"),
-            PriorityRule("Rebuild", "my.count(Rebuild) < 3"),
-            PriorityRule("Duchy", ""),
+            PriorityRule("Rebuild", lambda _s, me: me.count_in_deck("Rebuild") < 3),
+            PriorityRule("Duchy"),
             PriorityRule("Skulk"),
-            PriorityRule("Forager", "my.count(Forager) < 1"),
+            PriorityRule("Forager", lambda _s, me: me.count_in_deck("Forager") < 1),
             PriorityRule("Gold"),
             PriorityRule("Silver"),
             PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),

--- a/dominion/strategy/strategies/skulk_rebuild_improved.py
+++ b/dominion/strategy/strategies/skulk_rebuild_improved.py
@@ -19,14 +19,17 @@ class SkulkRebuildImprovedStrategy(EnhancedStrategy):
             # Rebuild up to three copies early
             PriorityRule(
                 "Rebuild",
-                PriorityRule.and_(PriorityRule.provinces_left(">", 2), "my.count(Rebuild) < 3"),
+                PriorityRule.and_(
+                    PriorityRule.provinces_left(">", 2),
+                    lambda _s, me: me.count_in_deck("Rebuild") < 3,
+                ),
             ),
             # Duchies for points
             PriorityRule("Duchy"),
             # Pick up Skulks for Gold gain
             PriorityRule("Skulk"),
             # Two Foragers to accelerate trashing
-            PriorityRule("Forager", "my.count(Forager) < 2"),
+            PriorityRule("Forager", lambda _s, me: me.count_in_deck("Forager") < 2),
             # Gain Gold if affordable
             PriorityRule("Gold"),
             # Silver only early

--- a/dominion/strategy/strategies/torturer_engine.py
+++ b/dominion/strategy/strategies/torturer_engine.py
@@ -13,36 +13,87 @@ class TorturerEngine(EnhancedStrategy):
         # Gain priorities
         self.gain_priority = [
             # Province only when getting 12 coins
-            PriorityRule("Province", "my.coins >= 12"),
+            PriorityRule("Province", PriorityRule.resources("coins", ">=", 12)),
             # Engine cards - early priorities
-            PriorityRule("Torturer", PriorityRule.and_("my.coins >= 5", "my.count(Torturer) < 2")),
-            PriorityRule("Inn", PriorityRule.and_("my.coins >= 5", "my.count(Inn) == 0")),
-            PriorityRule("Snowy Village", PriorityRule.and_("my.coins >= 4", "my.count(Snowy Village) < 3")),
-            PriorityRule("Patrol", PriorityRule.and_("my.coins >= 5", "my.count(Patrol) < 2")),
+            PriorityRule(
+                "Torturer",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 5),
+                    lambda _s, me: me.count_in_deck("Torturer") < 2,
+                ),
+            ),
+            PriorityRule(
+                "Inn",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 5),
+                    lambda _s, me: me.count_in_deck("Inn") == 0,
+                ),
+            ),
+            PriorityRule(
+                "Snowy Village",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 4),
+                    lambda _s, me: me.count_in_deck("Snowy Village") < 3,
+                ),
+            ),
+            PriorityRule(
+                "Patrol",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 5),
+                    lambda _s, me: me.count_in_deck("Patrol") < 2,
+                ),
+            ),
             # Trail for defense against Torturer attacks
-            PriorityRule("Trail", PriorityRule.and_("my.coins >= 4", "my.count(Trail) == 0")),
+            PriorityRule(
+                "Trail",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 4),
+                    lambda _s, me: me.count_in_deck("Trail") == 0,
+                ),
+            ),
             # Taskmaster to play multiple Torturers
             PriorityRule(
-                "Taskmaster", PriorityRule.and_("my.coins >= 5", "my.count(Torturer) >= 1", "my.count(Taskmaster) < 2")
+                "Taskmaster",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 5),
+                    lambda _s, me: me.count_in_deck("Torturer") >= 1,
+                    lambda _s, me: me.count_in_deck("Taskmaster") < 2,
+                ),
             ),
             # Emporium for bonus points when we have long action chains
-            PriorityRule("Emporium", PriorityRule.and_("my.coins >= 5", "my.count(Snowy Village) >= 2")),
+            PriorityRule(
+                "Emporium",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 5),
+                    lambda _s, me: me.count_in_deck("Snowy Village") >= 2,
+                ),
+            ),
             # Acting Troupe if we need more villages
             PriorityRule(
                 "Acting Troupe",
-                PriorityRule.and_("my.coins >= 3", "my.count(Snowy Village) < 2", "my.count(Acting Troupe) == 0"),
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 3),
+                    lambda _s, me: me.count_in_deck("Snowy Village") < 2,
+                    lambda _s, me: me.count_in_deck("Acting Troupe") == 0,
+                ),
             ),
             # Patrician at 2 coins
-            PriorityRule("Patrician", "my.coins == 2"),
+            PriorityRule("Patrician", PriorityRule.resources("coins", "==", 2)),
             # Additional engine support
-            PriorityRule("Torturer", "my.coins >= 5"),  # More Torturers if needed
-            PriorityRule("Snowy Village", "my.coins >= 4"),  # More villages
+            PriorityRule("Torturer", PriorityRule.resources("coins", ">=", 5)),  # More Torturers if needed
+            PriorityRule("Snowy Village", PriorityRule.resources("coins", ">=", 4)),  # More villages
             # Late game victory
             PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
             PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),
             # Basic treasures for early game
-            PriorityRule("Silver", PriorityRule.and_("my.coins >= 3", "my.count(Silver) < 2")),
-            PriorityRule("Gold", "my.coins >= 6"),
+            PriorityRule(
+                "Silver",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 3),
+                    lambda _s, me: me.count_in_deck("Silver") < 2,
+                ),
+            ),
+            PriorityRule("Gold", PriorityRule.resources("coins", ">=", 6)),
         ]
 
         # Action priorities - village effects first, then draw, then attacks

--- a/dominion/strategy/strategies/torturer_engine3.py
+++ b/dominion/strategy/strategies/torturer_engine3.py
@@ -21,7 +21,7 @@ class TorturerEngine(EnhancedStrategy):
             PriorityRule(
                 "Province",
                 PriorityRule.and_(
-                    "my.coins >= 8",
+                    PriorityRule.resources("coins", ">=", 8),
                     PriorityRule.or_(PriorityRule.provinces_left("<=", 6), PriorityRule.turn_number(">=", 12)),
                 ),
             ),
@@ -29,43 +29,82 @@ class TorturerEngine(EnhancedStrategy):
             PriorityRule(
                 "Torturer",
                 PriorityRule.and_(
-                    "my.coins >= 5",
-                    "my.count(Torturer) < my.count(Snowy Village) + my.count(Inn) + my.count(Acting Troupe)",
+                    PriorityRule.resources("coins", ">=", 5),
+                    lambda _s, me: me.count_in_deck("Torturer") < me.count_in_deck("Snowy Village") + me.count_in_deck("Inn") + me.count_in_deck("Acting Troupe"),
                 ),
             ),
-            PriorityRule("Inn", PriorityRule.and_("my.coins >= 5", "my.count(Inn) == 0")),
-            PriorityRule("Snowy Village", PriorityRule.and_("my.coins >= 4", "my.count(Snowy Village) < 3")),
-            PriorityRule("Patrol", PriorityRule.and_("my.count(Patrol) < 2")),
+            PriorityRule(
+                "Inn",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 5),
+                    lambda _s, me: me.count_in_deck("Inn") == 0,
+                ),
+            ),
+            PriorityRule(
+                "Snowy Village",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 4),
+                    lambda _s, me: me.count_in_deck("Snowy Village") < 3,
+                ),
+            ),
+            PriorityRule("Patrol", PriorityRule.and_(lambda _s, me: me.count_in_deck("Patrol") < 2)),
             # Trails for defense against Torturer – aim for up to two copies
-            PriorityRule("Trail", PriorityRule.and_("my.count(Trail) < 2")),
+            PriorityRule("Trail", PriorityRule.and_(lambda _s, me: me.count_in_deck("Trail") < 2)),
             # Taskmaster to play multiple Torturers
             PriorityRule(
-                "Taskmaster", PriorityRule.and_("my.coins >= 5", "my.count(Torturer) >= 1", "my.count(Taskmaster) < 2")
+                "Taskmaster",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 5),
+                    lambda _s, me: me.count_in_deck("Torturer") >= 1,
+                    lambda _s, me: me.count_in_deck("Taskmaster") < 2,
+                ),
             ),
             # Emporium for bonus points when we have long action chains
-            PriorityRule("Emporium", PriorityRule.and_("my.count(Snowy Village) >= 2")),
+            PriorityRule("Emporium", PriorityRule.and_(lambda _s, me: me.count_in_deck("Snowy Village") >= 2)),
             # Acting Troupe if we need more villages
             PriorityRule(
                 "Acting Troupe",
-                PriorityRule.and_("my.coins >= 3", "my.count(Snowy Village) < 2", "my.count(Acting Troupe) == 0"),
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 3),
+                    lambda _s, me: me.count_in_deck("Snowy Village") < 2,
+                    lambda _s, me: me.count_in_deck("Acting Troupe") == 0,
+                ),
             ),
             # Patrician at exactly 2 coins
-            PriorityRule("Patrician", "my.coins == 2"),
+            PriorityRule("Patrician", PriorityRule.resources("coins", "==", 2)),
             # Additional engine support
-            PriorityRule("Snowy Village", "my.coins >= 4"),  # More villages
+            PriorityRule("Snowy Village", PriorityRule.resources("coins", ">=", 4)),  # More villages
             # Late-game victory cards
-            PriorityRule("Duchy", PriorityRule.and_("my.coins >= 5", PriorityRule.provinces_left("<=", 2))),
-            PriorityRule("Estate", "state.empty_piles >= 2"),
+            PriorityRule(
+                "Duchy",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 5),
+                    PriorityRule.provinces_left("<=", 2),
+                ),
+            ),
+            PriorityRule("Estate", lambda s, _me: s.empty_piles >= 2),
             # Basic treasures
-            PriorityRule("Silver", PriorityRule.and_("my.coins == 3", PriorityRule.turn_number("<=", 6))),
-            PriorityRule("Gold", PriorityRule.and_("my.coins >= 6", "my.count(Torturer) >= 2")),
+            PriorityRule(
+                "Silver",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", "==", 3),
+                    PriorityRule.turn_number("<=", 6),
+                ),
+            ),
+            PriorityRule(
+                "Gold",
+                PriorityRule.and_(
+                    PriorityRule.resources("coins", ">=", 6),
+                    lambda _s, me: me.count_in_deck("Torturer") >= 2,
+                ),
+            ),
         ]
 
         # Action priorities - village effects first, then draw, then attacks
         self.action_priority = [
             PriorityRule("Acting Troupe"),  # +4 actions
             PriorityRule("Patrician"),  # +1 card +1 action
-            PriorityRule("Snowy Village", "my.actions <= 1"),  # +1 card +3 actions when extra actions needed
+            PriorityRule("Snowy Village", PriorityRule.resources("actions", "<=", 1)),  # +1 card +3 actions when extra actions needed
             PriorityRule("Inn"),  # +2 cards +2 actions
             PriorityRule("Patrol"),  # +3 cards
             PriorityRule("Taskmaster"),  # Play other actions multiple times

--- a/dominion/strategy/strategies/ultimate_dominion.py
+++ b/dominion/strategy/strategies/ultimate_dominion.py
@@ -18,14 +18,23 @@ class UltimateDominionStrategy(BaseStrategy):
             # Early trashing
             PriorityRule(
                 "Chapel",
-                PriorityRule.and_(PriorityRule.turn_number("<=", 2), "my.count(Chapel) == 0"),
+                PriorityRule.and_(
+                    PriorityRule.turn_number("<=", 2),
+                    lambda _s, me: me.count_in_deck("Chapel") == 0,
+                ),
             ),
             # Draw and actions
             PriorityRule("Laboratory"),
             PriorityRule("Village", PriorityRule.resources("actions", "<", 2)),
             PriorityRule("Market"),
             PriorityRule("Festival"),
-            PriorityRule("Witch", PriorityRule.and_(PriorityRule.turn_number("<=", 10), "my.count(Witch) < 2")),
+            PriorityRule(
+                "Witch",
+                PriorityRule.and_(
+                    PriorityRule.turn_number("<=", 10),
+                    lambda _s, me: me.count_in_deck("Witch") < 2,
+                ),
+            ),
             # Economy
             PriorityRule("Gold"),
             PriorityRule("Silver"),
@@ -34,7 +43,10 @@ class UltimateDominionStrategy(BaseStrategy):
 
         # Action priorities
         self.action_priority = [
-            PriorityRule("Chapel", "my.count(Estate) > 0 or my.count(Copper) > 2"),
+            PriorityRule(
+                "Chapel",
+                lambda _s, me: me.count_in_deck("Estate") > 0 or me.count_in_deck("Copper") > 2,
+            ),
             PriorityRule("Witch"),
             PriorityRule("Village"),
             PriorityRule("Market"),
@@ -46,7 +58,10 @@ class UltimateDominionStrategy(BaseStrategy):
         self.trash_priority = [
             PriorityRule("Curse"),
             PriorityRule("Estate", PriorityRule.provinces_left(">", 4)),
-            PriorityRule("Copper", "my.count(Silver) + my.count(Gold) >= 3"),
+            PriorityRule(
+                "Copper",
+                lambda _s, me: me.count_in_deck("Silver") + me.count_in_deck("Gold") >= 3,
+            ),
         ]
 
         # Treasure play order

--- a/dominion/strategy/strategies/village_smithy_lab.py
+++ b/dominion/strategy/strategies/village_smithy_lab.py
@@ -12,30 +12,39 @@ class VillageSmithyLabStrategy(BaseStrategy):
 
         # Define gain priorities
         self.gain_priority = [
-            PriorityRule("Chapel", "state.turn_number <= 4"),
-            PriorityRule("Province", "my.coins >= 8"),
-            PriorityRule("Laboratory", "state.turn_number <= 10"),
-            PriorityRule("Village", "my.count(Smithy) + my.count(Laboratory) >= 2"),
-            PriorityRule("Gold", "my.coins >= 6"),
-            PriorityRule("Duchy", "state.provinces_left <= 4"),
-            PriorityRule("Silver", "my.coins >= 3"),
-            PriorityRule("Estate", "state.provinces_left <= 2"),
+            PriorityRule("Chapel", PriorityRule.turn_number("<=", 4)),
+            PriorityRule("Province", PriorityRule.resources("coins", ">=", 8)),
+            PriorityRule("Laboratory", PriorityRule.turn_number("<=", 10)),
+            PriorityRule(
+                "Village",
+                lambda _s, me: me.count_in_deck("Smithy") + me.count_in_deck("Laboratory") >= 2,
+            ),
+            PriorityRule("Gold", PriorityRule.resources("coins", ">=", 6)),
+            PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
+            PriorityRule("Silver", PriorityRule.resources("coins", ">=", 3)),
+            PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),
             PriorityRule("Copper"),
         ]
 
         # Define action priorities
         self.action_priority = [
-            PriorityRule("Chapel", "my.count(Estate) > 0 OR my.count(Copper) > 4"),
-            PriorityRule("Laboratory", "my.actions >= 1"),
-            PriorityRule("Village", "my.actions < 2"),
-            PriorityRule("Smithy", "my.actions >= 1"),
+            PriorityRule(
+                "Chapel",
+                lambda _s, me: me.count_in_deck("Estate") > 0 or me.count_in_deck("Copper") > 4,
+            ),
+            PriorityRule("Laboratory", PriorityRule.resources("actions", ">=", 1)),
+            PriorityRule("Village", PriorityRule.resources("actions", "<", 2)),
+            PriorityRule("Smithy", PriorityRule.resources("actions", ">=", 1)),
         ]
 
         # Define trash priorities
         self.trash_priority = [
             PriorityRule("Curse"),
-            PriorityRule("Estate", "state.turn_number <= 10"),
-            PriorityRule("Copper", "my.count(Silver) + my.count(Gold) >= 3"),
+            PriorityRule("Estate", PriorityRule.turn_number("<=", 10)),
+            PriorityRule(
+                "Copper",
+                lambda _s, me: me.count_in_deck("Silver") + me.count_in_deck("Gold") >= 3,
+            ),
         ]
 
         # Define treasure priorities

--- a/dominion/strategy/strategies/wharf_bridge_chapel_village.py
+++ b/dominion/strategy/strategies/wharf_bridge_chapel_village.py
@@ -12,19 +12,31 @@ class WharfBridgeChapelVillageStrategy(BaseStrategy):
 
         # Gain priorities
         self.gain_priority = [
-            PriorityRule("Province", "my.coins >= 8"),
-            PriorityRule("Chapel", "state.turn_number <= 2 AND my.count(Chapel) == 0"),
-            PriorityRule("Wharf", "my.count(Wharf) < 2"),
-            PriorityRule("Village", "my.count(Bridge) + my.count(Wharf) > my.count(Village)"),
-            PriorityRule("Bridge", "my.coins >= 4"),
-            PriorityRule("Gold", "my.coins >= 6"),
-            PriorityRule("Silver", "my.coins >= 3"),
+            PriorityRule("Province", PriorityRule.resources("coins", ">=", 8)),
+            PriorityRule(
+                "Chapel",
+                PriorityRule.and_(
+                    PriorityRule.turn_number("<=", 2),
+                    lambda _s, me: me.count_in_deck("Chapel") == 0,
+                ),
+            ),
+            PriorityRule("Wharf", lambda _s, me: me.count_in_deck("Wharf") < 2),
+            PriorityRule(
+                "Village",
+                lambda _s, me: me.count_in_deck("Bridge") + me.count_in_deck("Wharf") > me.count_in_deck("Village"),
+            ),
+            PriorityRule("Bridge", PriorityRule.resources("coins", ">=", 4)),
+            PriorityRule("Gold", PriorityRule.resources("coins", ">=", 6)),
+            PriorityRule("Silver", PriorityRule.resources("coins", ">=", 3)),
             PriorityRule("Copper"),
         ]
 
         # Action priorities
         self.action_priority = [
-            PriorityRule("Chapel", "my.count(Estate) > 0 OR my.count(Copper) > 3"),
+            PriorityRule(
+                "Chapel",
+                lambda _s, me: me.count_in_deck("Estate") > 0 or me.count_in_deck("Copper") > 3,
+            ),
             PriorityRule("Wharf"),
             PriorityRule("Bridge"),
             PriorityRule("Village"),
@@ -33,8 +45,11 @@ class WharfBridgeChapelVillageStrategy(BaseStrategy):
         # Trash priorities
         self.trash_priority = [
             PriorityRule("Curse"),
-            PriorityRule("Estate", "state.turn_number <= 12"),
-            PriorityRule("Copper", "my.count(Silver) + my.count(Gold) >= 2"),
+            PriorityRule("Estate", PriorityRule.turn_number("<=", 12)),
+            PriorityRule(
+                "Copper",
+                lambda _s, me: me.count_in_deck("Silver") + me.count_in_deck("Gold") >= 2,
+            ),
         ]
 
         # Treasure priorities

--- a/generated_strategies/strategy_20250615_102030.py
+++ b/generated_strategies/strategy_20250615_102030.py
@@ -13,9 +13,9 @@ class Strategy20250615_102030(EnhancedStrategy):
             PriorityRule('Smithy'),
             PriorityRule('Market'),
             PriorityRule('Festival'),
-            PriorityRule('Laboratory', 'state.turn_number <= 7'),
+            PriorityRule('Laboratory', PriorityRule.turn_number('<=', 7)),
             PriorityRule('Mine'),
-            PriorityRule('Witch', 'state.turn_number <= 9'),
+            PriorityRule('Witch', PriorityRule.turn_number('<=', 9)),
             PriorityRule('Moat'),
             PriorityRule('Workshop'),
             PriorityRule('Chapel'),
@@ -46,8 +46,8 @@ class Strategy20250615_102030(EnhancedStrategy):
 
         self.trash_priority = [
             PriorityRule('Curse'),
-            PriorityRule('Estate', 'state.provinces_left > 4'),
-            PriorityRule('Copper', 'my.count(Silver) + my.count(Gold) >= 3'),
+            PriorityRule('Estate', PriorityRule.provinces_left('>', 4)),
+            PriorityRule('Copper', lambda _s, me: me.count_in_deck('Silver') + me.count_in_deck('Gold') >= 3),
         ]
 
 def create_strategy20250615_102030() -> EnhancedStrategy:


### PR DESCRIPTION
## Summary
- convert PriorityRule `_OP_MAP` to `ClassVar`
- replace legacy string conditions with callables across strategies
- update generated strategy to use new helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b513a920c8327897c17cbfca320d9