### PR TITLE
Add BigMoneySmithy strategy

### DIFF
--- a/dominion/simulation/strategy_registry.py
+++ b/dominion/simulation/strategy_registry.py
@@ -2,6 +2,7 @@ from typing import Dict, Type
 
 from dominion.strategy.strategies.base_strategy import BaseStrategy
 from dominion.strategy.strategies.big_money import BigMoneyStrategy
+from dominion.strategy.strategies.big_money_smithy import BigMoneySmithyStrategy
 from dominion.strategy.strategies.chapel_witch import ChapelWitchStrategy
 from dominion.strategy.strategies.village_smithy_lab import VillageSmithyLabStrategy
 from dominion.strategy.strategies.wharf_bridge_chapel_village import (
@@ -19,6 +20,7 @@ class StrategyRegistry:
     def _register_core_strategies(self):
         """Register the core set of strategies"""
         self.register_strategy("BigMoney", BigMoneyStrategy)
+        self.register_strategy("BigMoneySmithy", BigMoneySmithyStrategy)
         self.register_strategy("ChapelWitch", ChapelWitchStrategy)
         self.register_strategy("VillageSmithyLab", VillageSmithyLabStrategy)
         self.register_strategy(

--- a/dominion/strategy/strategies/big_money_smithy.py
+++ b/dominion/strategy/strategies/big_money_smithy.py
@@ -1,0 +1,49 @@
+from .base_strategy import BaseStrategy, PriorityRule
+
+
+class BigMoneySmithyStrategy(BaseStrategy):
+    """Big Money strategy that adds Smithy for extra draw."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "BigMoneySmithy"
+        self.description = "Big Money strategy with Smithy support"
+        self.version = "2.0"
+
+        # ``gain_priority`` is unused because buying logic is implemented
+        # dynamically via :meth:`choose_gain`.
+        self.gain_priority = []
+
+        # Always play Smithy when available
+        self.action_priority = [PriorityRule("Smithy")]
+
+        # Treasure play order
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+    # ------------------------------------------------------------------
+    def choose_gain(self, state, player, choices):
+        """Dynamically choose a card to buy based on available coins."""
+        card_lookup = {c.name: c for c in choices if c is not None}
+        money = player.coins
+
+        if money >= 8 and "Province" in card_lookup:
+            return card_lookup["Province"]
+        if money >= 6 and "Gold" in card_lookup:
+            return card_lookup["Gold"]
+        if money == 4 and "Smithy" in card_lookup:
+            return card_lookup["Smithy"]
+        if money >= 3 and "Silver" in card_lookup:
+            return card_lookup["Silver"]
+
+        return None
+
+
+from dominion.strategy.enhanced_strategy import EnhancedStrategy
+
+
+def create_big_money_smithy() -> EnhancedStrategy:
+    return BigMoneySmithyStrategy()


### PR DESCRIPTION
## Summary
- implement a BigMoneySmithy strategy using existing strategy framework
- register the new strategy so it's available via StrategyRegistry
- refactor BigMoneySmithy to compute buy decisions dynamically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5db612448327bc047a3855967a43