### PR TITLE
Add remaining Menagerie events and supporting mechanics

### DIFF
--- a/dominion/cards/menagerie/__init__.py
+++ b/dominion/cards/menagerie/__init__.py
@@ -1,0 +1,5 @@
+"""Menagerie expansion cards."""
+
+from .horse import Horse
+
+__all__ = ["Horse"]

--- a/dominion/cards/menagerie/horse.py
+++ b/dominion/cards/menagerie/horse.py
@@ -1,0 +1,19 @@
+"""Implementation of the Horse card from Menagerie."""
+
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Horse(Card):
+    def __init__(self):
+        super().__init__(
+            name="Horse",
+            cost=CardCost(coins=0),
+            stats=CardStats(actions=1, cards=2),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+        if self in player.in_play:
+            player.in_play.remove(self)
+        game_state.supply["Horse"] = game_state.supply.get("Horse", 0) + 1

--- a/dominion/cards/registry.py
+++ b/dominion/cards/registry.py
@@ -81,6 +81,7 @@ from dominion.cards.plunder import FirstMate, Barbarian
 from dominion.cards.dark_ages import Ironmonger, Marauder, Spoils, Ruins
 from dominion.cards.adventures import Giant
 from dominion.cards.nocturne import TragicHero
+from dominion.cards.menagerie import Horse
 
 from dominion.cards.treasures import Copper, Gold, Silver
 from dominion.cards.victory import Curse, Duchy, Estate, Province
@@ -184,6 +185,7 @@ CARD_TYPES: dict[str, Type[Card]] = {
     "Ruins": Ruins,
     "Giant": Giant,
     "Tragic Hero": TragicHero,
+    "Horse": Horse,
 }
 
 

--- a/dominion/events/menagerie_events.py
+++ b/dominion/events/menagerie_events.py
@@ -3,6 +3,16 @@ from dominion.cards.registry import get_card
 from .base_event import Event
 
 
+HORSE_PILE_COUNT = 30
+
+
+def ensure_horse_pile(game_state) -> None:
+    """Ensure the shared Horse pile exists in the supply."""
+
+    if "Horse" not in game_state.supply:
+        game_state.supply["Horse"] = HORSE_PILE_COUNT
+
+
 class Desperation(Event):
     """+1 Buy, gain a Curse."""
 
@@ -66,7 +76,7 @@ class Toil(Event):
 
 
 class Enhance(Event):
-    """Trash a card to gain one costing up to 3 more."""
+    """Trash a non-Victory card to gain one costing up to 2 more."""
 
     def __init__(self):
         super().__init__("Enhance", CardCost(coins=3))
@@ -75,17 +85,18 @@ class Enhance(Event):
         if not player.hand:
             return
         card = player.ai.choose_card_to_trash(game_state, player.hand + [None])
-        if not card:
+        if not card or card.is_victory:
             return
         player.hand.remove(card)
         game_state.trash_card(player, card)
-        max_cost = card.cost.coins + 3
+        max_cost = card.cost.coins + 2
         affordable = [
             name
             for name, count in game_state.supply.items()
             if count > 0 and get_card(name).cost.coins <= max_cost
         ]
         if affordable:
+            affordable.sort(key=lambda name: (get_card(name).cost.coins, name), reverse=True)
             gain = get_card(affordable[0])
             game_state.supply[gain.name] -= 1
             game_state.gain_card(player, gain)
@@ -135,7 +146,164 @@ class Ride(Event):
         except ValueError:
             return
 
+        ensure_horse_pile(game_state)
         if game_state.supply.get("Horse", 0) > 0:
             game_state.supply["Horse"] -= 1
 
         game_state.gain_card(player, horse)
+
+
+class Banish(Event):
+    """Exile any number of cards with the same name from your hand."""
+
+    def __init__(self):
+        super().__init__("Banish", CardCost(coins=4))
+
+    def on_buy(self, game_state, player) -> None:
+        if not player.hand:
+            return
+
+        grouped: dict[str, list] = {}
+        for card in player.hand:
+            grouped.setdefault(card.name, []).append(card)
+
+        # Choose the card name with the most copies to provide a reasonable default
+        target_name = max(grouped.items(), key=lambda item: (len(item[1]), item[0]))[0]
+        to_exile = grouped[target_name]
+
+        for card in to_exile:
+            player.hand.remove(card)
+            player.exile.append(card)
+
+
+class Bargain(Event):
+    """Gain a non-Victory costing up to 5; other players gain Horses."""
+
+    def __init__(self):
+        super().__init__("Bargain", CardCost(coins=3))
+
+    def on_buy(self, game_state, player) -> None:
+        supply_cards = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            card = get_card(name)
+            if not card.is_victory and card.cost.coins <= 5:
+                supply_cards.append(card)
+
+        if supply_cards:
+            supply_cards.sort(key=lambda c: (c.cost.coins, c.name), reverse=True)
+            gain = supply_cards[0]
+            game_state.supply[gain.name] -= 1
+            game_state.gain_card(player, gain)
+
+        ensure_horse_pile(game_state)
+        for other in game_state.players:
+            if other is player:
+                continue
+            if game_state.supply.get("Horse", 0) <= 0:
+                break
+            game_state.supply["Horse"] -= 1
+            horse = get_card("Horse")
+            game_state.gain_card(other, horse)
+
+
+class Invest(Event):
+    """Exile an Action card from the Supply; others draw when they gain it."""
+
+    def __init__(self):
+        super().__init__("Invest", CardCost(coins=4))
+
+    def on_buy(self, game_state, player) -> None:
+        available = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            card = get_card(name)
+            if card.is_action:
+                available.append(card)
+
+        if not available:
+            return
+
+        available.sort(key=lambda c: (c.cost.coins, c.name), reverse=True)
+        chosen = available[0]
+        game_state.supply[chosen.name] -= 1
+        player.exile.append(chosen)
+        player.invested_exile.append(chosen)
+        game_state.notify_invest(chosen.name, player)
+
+
+class Populate(Event):
+    """Gain one of each Action card from the Supply."""
+
+    def __init__(self):
+        super().__init__("Populate", CardCost(coins=10))
+
+    def on_buy(self, game_state, player) -> None:
+        action_names = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            card = get_card(name)
+            if card.is_action:
+                action_names.append(name)
+
+        for name in action_names:
+            if game_state.supply.get(name, 0) <= 0:
+                continue
+            game_state.supply[name] -= 1
+            gained = get_card(name)
+            game_state.gain_card(player, gained)
+
+
+class Stampede(Event):
+    """Gain 5 Horses if your hand is empty."""
+
+    def __init__(self):
+        super().__init__("Stampede", CardCost(coins=5))
+
+    def may_be_bought(self, game_state, player) -> bool:
+        return len(player.hand) == 0
+
+    def on_buy(self, game_state, player) -> None:
+        ensure_horse_pile(game_state)
+        for _ in range(5):
+            if game_state.supply.get("Horse", 0) <= 0:
+                break
+            game_state.supply["Horse"] -= 1
+            horse = get_card("Horse")
+            game_state.gain_card(player, horse)
+
+
+class Transport(Event):
+    """Move an Action to or from Exile."""
+
+    def __init__(self):
+        super().__init__("Transport", CardCost(coins=3))
+
+    def on_buy(self, game_state, player) -> None:
+        exiled_actions = [card for card in player.exile if card.is_action]
+        if exiled_actions:
+            card = exiled_actions[0]
+            player.exile.remove(card)
+            if card in player.invested_exile:
+                player.invested_exile.remove(card)
+            player.deck.insert(0, card)
+            return
+
+        available = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            card = get_card(name)
+            if card.is_action:
+                available.append(card)
+
+        if not available:
+            return
+
+        available.sort(key=lambda c: (c.cost.coins, c.name), reverse=True)
+        chosen = available[0]
+        game_state.supply[chosen.name] -= 1
+        player.exile.append(chosen)

--- a/dominion/events/registry.py
+++ b/dominion/events/registry.py
@@ -6,14 +6,20 @@ from .base_event import Event
 from .gain_silver import GainSilver
 from .looting import Looting
 from .menagerie_events import (
+    Banish,
+    Bargain,
     Delay,
     Desperation,
     Enhance,
     Gamble,
+    Invest,
     March,
+    Populate,
     Ride,
     SeizeTheDay,
+    Stampede,
     Toil,
+    Transport,
 )
 
 EVENT_TYPES: dict[str, Type[Event]] = {
@@ -27,6 +33,12 @@ EVENT_TYPES: dict[str, Type[Event]] = {
     "Delay": Delay,
     "Ride": Ride,
     "Seize the Day": SeizeTheDay,
+    "Banish": Banish,
+    "Bargain": Bargain,
+    "Invest": Invest,
+    "Populate": Populate,
+    "Stampede": Stampede,
+    "Transport": Transport,
 }
 
 

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -23,6 +23,8 @@ class PlayerState:
     duration: list[Card] = field(default_factory=list)
     multiplied_durations: list[Card] = field(default_factory=list)
     projects: list = field(default_factory=list)
+    exile: list[Card] = field(default_factory=list)
+    invested_exile: list[Card] = field(default_factory=list)
 
     # Misc counters
     vp_tokens: int = 0
@@ -75,6 +77,8 @@ class PlayerState:
         self.duration = []
         self.multiplied_durations = []
         self.projects = []
+        self.exile = []
+        self.invested_exile = []
 
         # Reset resources
         self.actions = 1


### PR DESCRIPTION
## Summary
- add the missing Menagerie events and a shared Horse pile helper
- implement the Horse card and register it with the card registry
- extend player and game state to track Exile/Invest interactions so the new events function

## Testing
- pytest *(fails: existing indentation error in dominion/simulation/genetic_trainer.py)*

------
https://chatgpt.com/codex/tasks/task_e_68daf21b434c8327a0187fd63de94f93