### PR TITLE
Implement Torturer attack effect and curse handling

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from dominion.cards.base_card import Card
 from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
 
 
 class AI(ABC):
@@ -40,3 +41,28 @@ class AI(ABC):
     def use_amphora_now(self, state: GameState) -> bool:
         """Decide whether to take Amphora's bonus immediately."""
         return True
+
+    def choose_torturer_attack(self, state: GameState, player: PlayerState) -> bool:
+        """Choose whether to discard two cards or gain a Curse from Torturer.
+
+        The default heuristic discards when at least two low-value cards are
+        present (Curses, Estates, or Coppers). Otherwise, it keeps the valuable
+        hand and accepts the Curse.
+        """
+
+        hand = list(player.hand)
+
+        if len(hand) < 2:
+            return False
+
+        def is_low_value(card: Card) -> bool:
+            if card.name == "Curse":
+                return True
+            if card.name == "Copper":
+                return True
+            if card.is_victory and not card.is_action and card.cost.coins <= 2:
+                return True
+            return False
+
+        low_value_cards = [card for card in hand if is_low_value(card)]
+        return len(low_value_cards) >= 2

--- a/dominion/cards/intrigue/torturer.py
+++ b/dominion/cards/intrigue/torturer.py
@@ -9,3 +9,78 @@ class Torturer(Card):
             stats=CardStats(cards=3),
             types=[CardType.ACTION, CardType.ATTACK],
         )
+
+    def play_effect(self, game_state):
+        """Each other player discards two cards or gains a Curse to hand."""
+
+        player = game_state.current_player
+
+        def discard_priority(card: Card):
+            if card.name == "Curse":
+                return (0, card.name)
+            if card.is_victory and not card.is_action and card.cost.coins <= 2:
+                return (1, card.cost.coins, card.name)
+            if card.name == "Copper":
+                return (2, card.name)
+            return (3, card.cost.coins, card.name)
+
+        def attack_target(target):
+            hand_size = len(target.hand)
+            curses_remaining = game_state.supply.get("Curse", 0)
+
+            if hand_size < 2:
+                if curses_remaining > 0:
+                    gained = game_state.give_curse_to_player(target, to_hand=True)
+                    if gained:
+                        game_state.log_callback(
+                            (
+                                "action",
+                                target.ai.name,
+                                "takes Curse to hand due to Torturer",
+                                {
+                                    "curses_remaining": game_state.supply.get("Curse", 0),
+                                    "hand": [c.name for c in target.hand],
+                                },
+                            )
+                        )
+                return
+
+            choose_discard = target.ai.choose_torturer_attack(game_state, target)
+            if not choose_discard and curses_remaining == 0:
+                choose_discard = True
+
+            if choose_discard:
+                cards_to_discard = sorted(target.hand, key=discard_priority)[:2]
+                for card in cards_to_discard:
+                    target.hand.remove(card)
+                    target.discard.append(card)
+                game_state.log_callback(
+                    (
+                        "action",
+                        target.ai.name,
+                        "discards 2 cards due to Torturer",
+                        {
+                            "discarded_cards": [c.name for c in cards_to_discard],
+                            "remaining_hand": [c.name for c in target.hand],
+                        },
+                    )
+                )
+            else:
+                gained = game_state.give_curse_to_player(target, to_hand=True)
+                if gained:
+                    game_state.log_callback(
+                        (
+                            "action",
+                            target.ai.name,
+                            "takes Curse to hand due to Torturer",
+                            {
+                                "curses_remaining": game_state.supply.get("Curse", 0),
+                                "hand": [c.name for c in target.hand],
+                            },
+                        )
+                    )
+
+        for other in game_state.players:
+            if other is player:
+                continue
+            game_state.attack_player(other, attack_target)


### PR DESCRIPTION
## Summary
- add a default AI heuristic for responding to Torturer attacks
- implement Torturer's discard-or-curse attack and related logging
- allow curses to be gained directly to hand while returning the gained card from `gain_card`

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'coloredlogs')*

------
https://chatgpt.com/codex/tasks/task_e_68daf6fc914c832783b90ca1cd9546e6