### PR TITLE
Implement Hinterlands card behaviors

### DIFF
--- a/dominion/cards/hinterlands/inn.py
+++ b/dominion/cards/hinterlands/inn.py
@@ -1,3 +1,5 @@
+import random
+
 from ..base_card import Card, CardCost, CardStats, CardType
 
 
@@ -9,3 +11,22 @@ class Inn(Card):
             stats=CardStats(actions=2, cards=2),
             types=[CardType.ACTION],
         )
+
+    def on_gain(self, game_state, player):
+        """Shuffle any Actions from the discard pile back into the deck."""
+
+        super().on_gain(game_state, player)
+
+        # Gather the action cards currently in the discard pile.
+        action_cards = [card for card in player.discard if card.is_action]
+
+        if not action_cards:
+            return
+
+        # Remove the chosen cards from the discard pile.
+        for card in action_cards:
+            player.discard.remove(card)
+
+        # Shuffle them into the current deck.
+        player.deck.extend(action_cards)
+        random.shuffle(player.deck)

--- a/dominion/cards/hinterlands/trader.py
+++ b/dominion/cards/hinterlands/trader.py
@@ -1,11 +1,47 @@
 from ..base_card import Card, CardCost, CardStats, CardType
 
 
+def _gain_silver(game_state, player):
+    """Gain a Silver for ``player`` if any remain in the supply."""
+
+    from ..registry import get_card
+
+    if game_state.supply.get("Silver", 0) <= 0:
+        return False
+
+    silver = get_card("Silver")
+    game_state.supply["Silver"] -= 1
+    game_state.gain_card(player, silver)
+    return True
+
+
 class Trader(Card):
     def __init__(self):
         super().__init__(
             name="Trader",
             cost=CardCost(coins=4),
-            stats=CardStats(),
+            stats=CardStats(actions=1, cards=1),
             types=[CardType.ACTION, CardType.REACTION],
         )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        # Trader always gains a Silver on play if one is available.
+        _gain_silver(game_state, player)
+
+        if not player.hand:
+            return
+
+        card_to_trash = player.ai.choose_card_to_trash(game_state, player.hand)
+
+        if not card_to_trash:
+            return
+
+        player.hand.remove(card_to_trash)
+        game_state.trash_card(player, card_to_trash)
+
+        # Gain Silvers equal to the trashed card's coin cost.
+        for _ in range(card_to_trash.cost.coins):
+            if not _gain_silver(game_state, player):
+                break

--- a/dominion/cards/hinterlands/trail.py
+++ b/dominion/cards/hinterlands/trail.py
@@ -6,6 +6,32 @@ class Trail(Card):
         super().__init__(
             name="Trail",
             cost=CardCost(coins=4),
-            stats=CardStats(),
-            types=[CardType.ACTION],
+            stats=CardStats(actions=1, cards=1),
+            types=[CardType.ACTION, CardType.REACTION],
         )
+
+    def _play_now(self, game_state, player):
+        """Play Trail immediately from its current location."""
+
+        # Remove the card from wherever it currently is.
+        if self in player.discard:
+            player.discard.remove(self)
+        elif self in player.deck:
+            player.deck.remove(self)
+        elif self in player.hand:
+            player.hand.remove(self)
+        elif self in game_state.trash:
+            game_state.trash.remove(self)
+        else:
+            return
+
+        player.in_play.append(self)
+        self.on_play(game_state)
+
+    def on_gain(self, game_state, player):
+        super().on_gain(game_state, player)
+        self._play_now(game_state, player)
+
+    def on_trash(self, game_state, player):
+        super().on_trash(game_state, player)
+        self._play_now(game_state, player)


### PR DESCRIPTION
## Summary
- implement Inn's on-gain ability to recycle Action cards into the deck
- give Trader its cantrip stats, Silver gaining, and trash-for-Silver effect
- update Trail to be a cantrip Reaction that plays itself when gained or trashed

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'coloredlogs')*


------
https://chatgpt.com/codex/tasks/task_e_68daf8a6af848327a4def87323755f04