### PR TITLE
Fix Inn card to discard hand on play

### DIFF
--- a/dominion/cards/hinterlands/inn.py
+++ b/dominion/cards/hinterlands/inn.py
@@ -12,6 +12,19 @@ class Inn(Card):
             types=[CardType.ACTION],
         )
 
+    def play_effect(self, game_state):
+        """Discard the player's hand and draw the same number of cards."""
+
+        player = game_state.current_player
+
+        if not player.hand:
+            return
+
+        discard_count = len(player.hand)
+        player.discard.extend(player.hand)
+        player.hand = []
+        game_state.draw_cards(player, discard_count)
+
     def on_gain(self, game_state, player):
         """Shuffle any Actions from the discard pile back into the deck."""
 

--- a/tests/test_inn_card.py
+++ b/tests/test_inn_card.py
@@ -1,0 +1,47 @@
+from dominion.cards.registry import get_card
+from dominion.game.player_state import PlayerState
+from dominion.game.game_state import GameState
+from tests.utils import DummyAI
+
+
+def play_action(state, player, card):
+    player.hand.remove(card)
+    player.in_play.append(card)
+    card.on_play(state)
+
+
+def test_inn_discards_hand_and_draws_equal_cards():
+    ai = DummyAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([])
+
+    inn = get_card("Inn")
+    starting_hand = [inn, get_card("Copper"), get_card("Estate")]
+    player.hand = starting_hand[:]
+
+    player.deck = [
+        get_card("Copper"),
+        get_card("Silver"),
+        get_card("Gold"),
+        get_card("Estate"),
+        get_card("Village"),
+        get_card("Smithy"),
+    ]
+
+    play_action(state, player, inn)
+
+    assert [card.name for card in player.discard] == [
+        "Copper",
+        "Estate",
+        "Smithy",
+        "Village",
+    ]
+    assert [card.name for card in player.hand] == [
+        "Estate",
+        "Gold",
+        "Silver",
+        "Copper",
+    ]
+    assert inn in player.in_play
+


### PR DESCRIPTION
## Summary
- implement Inn's on-play effect so it discards the hand and draws the same number of cards
- add a regression test covering the Inn discard-and-draw behavior

## Testing
- pytest tests/test_inn_card.py

------
https://chatgpt.com/codex/tasks/task_e_68db0f6a53b083279e87d2d6b97111bd