### PR TITLE
Add coloredlogs dependency and restore pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-matplotlib
-seaborn
-scipy
-tqdm
+coloredlogs
 lark
+matplotlib
 pytest
+scipy
+seaborn
+tqdm


### PR DESCRIPTION
## Summary
- add the missing coloredlogs dependency so it is installed with the project
- restore pytest in the requirements list to avoid breaking existing workflows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db18862a3c8327b79126220025d138