### PR TITLE
Fix Taskmaster duration persistence handling

### DIFF
--- a/dominion/cards/allies/taskmaster.py
+++ b/dominion/cards/allies/taskmaster.py
@@ -12,12 +12,13 @@ class Taskmaster(Card):
 
     def play_effect(self, game_state):
         player = game_state.current_player
+        self.duration_persistent = False
         player.duration.append(self)
 
     def on_duration(self, game_state):
         player = game_state.current_player
-        if getattr(player, "gained_five_last_turn", False):
-            if not player.ignore_action_bonuses:
-                player.actions += 1
-            player.coins += 1
-            player.duration.append(self)
+        if not player.ignore_action_bonuses:
+            player.actions += 1
+        player.coins += 1
+
+        self.duration_persistent = getattr(player, "gained_five_last_turn", False)

--- a/tests/test_taskmaster.py
+++ b/tests/test_taskmaster.py
@@ -1,0 +1,61 @@
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from tests.utils import DummyAI
+
+
+def make_state_with_taskmaster():
+    player = PlayerState(DummyAI())
+    state = GameState(players=[player])
+    state.log_callback = lambda *args, **kwargs: None
+    taskmaster = get_card("Taskmaster")
+    taskmaster.play_effect(state)
+    # Sanity check to ensure setup matches gameplay expectations
+    assert player.duration == [taskmaster]
+    return state, player, taskmaster
+
+
+def test_taskmaster_leaves_without_five_cost_gain():
+    state, player, taskmaster = make_state_with_taskmaster()
+    player.actions = 0
+    player.coins = 0
+    player.gained_five_last_turn = False
+
+    state.do_duration_phase()
+
+    assert player.actions == 1
+    assert player.coins == 1
+    assert taskmaster not in player.duration
+    assert taskmaster in player.discard
+
+
+def test_taskmaster_persists_across_consecutive_five_cost_gains():
+    state, player, taskmaster = make_state_with_taskmaster()
+    player.actions = 0
+    player.coins = 0
+
+    player.gained_five_last_turn = True
+    state.do_duration_phase()
+
+    assert player.actions == 1
+    assert player.coins == 1
+    assert player.duration == [taskmaster]
+    assert taskmaster.duration_persistent is True
+    assert taskmaster not in player.discard
+
+    player.gained_five_last_turn = True
+    state.do_duration_phase()
+
+    assert player.actions == 2
+    assert player.coins == 2
+    assert player.duration == [taskmaster]
+    assert taskmaster.duration_persistent is True
+    assert player.discard == []
+
+    player.gained_five_last_turn = False
+    state.do_duration_phase()
+
+    assert player.actions == 3
+    assert player.coins == 3
+    assert taskmaster not in player.duration
+    assert player.discard == [taskmaster]


### PR DESCRIPTION
## Summary
- ensure Taskmaster always grants its duration bonuses and only persists when a $5 gain occurred
- reset the persistence flag when played to avoid lingering state
- add focused unit tests covering both removal and consecutive persistence scenarios

## Testing
- pytest tests/test_taskmaster.py

------
https://chatgpt.com/codex/tasks/task_e_68db18aff9648327a4d01317d0504d26