### PR TITLE
Implement Trader trash exchange reaction

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -34,6 +34,30 @@ class AI(ABC):
         """Choose a card to trash from available choices."""
         pass
 
+    def choose_cards_to_trash(
+        self, state: GameState, choices: list[Card], count: int
+    ) -> list[Card]:
+        """Select up to ``count`` cards to trash, defaulting to single picks."""
+
+        remaining = list(choices)
+        selected: list[Card] = []
+
+        while remaining and len(selected) < count:
+            choice = self.choose_card_to_trash(state, remaining)
+            if choice is None or choice not in remaining:
+                break
+            selected.append(choice)
+            remaining.remove(choice)
+
+        return selected
+
+    def should_reveal_trader(
+        self, state: GameState, player: PlayerState, gained_card: Card, *, to_deck: bool
+    ) -> bool:
+        """Decide whether to reveal Trader to exchange a gain for Silver."""
+
+        return False
+
     def choose_way(self, state: GameState, card: Card, ways: list) -> Optional[object]:
         """Choose a Way to use when playing a card. Default is none."""
         return None

--- a/dominion/cards/hinterlands/trader.py
+++ b/dominion/cards/hinterlands/trader.py
@@ -27,21 +27,20 @@ class Trader(Card):
     def play_effect(self, game_state):
         player = game_state.current_player
 
-        # Trader always gains a Silver on play if one is available.
-        _gain_silver(game_state, player)
-
         if not player.hand:
             return
 
-        card_to_trash = player.ai.choose_card_to_trash(game_state, player.hand)
+        selections = player.ai.choose_cards_to_trash(game_state, list(player.hand), 1)
+        card_to_trash = selections[0] if selections else None
 
         if not card_to_trash:
             return
 
+        cost_in_coins = game_state.get_card_cost(player, card_to_trash)
         player.hand.remove(card_to_trash)
         game_state.trash_card(player, card_to_trash)
 
         # Gain Silvers equal to the trashed card's coin cost.
-        for _ in range(card_to_trash.cost.coins):
+        for _ in range(cost_in_coins):
             if not _gain_silver(game_state, player):
                 break

--- a/tests/test_trader.py
+++ b/tests/test_trader.py
@@ -1,0 +1,77 @@
+from typing import Optional, Set
+
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+
+from tests.utils import DummyAI
+
+
+class TraderTestAI(DummyAI):
+    def __init__(self, trash_target: Optional[str] = None, reveal_for: Optional[Set[str]] = None):
+        super().__init__()
+        self.trash_target = trash_target
+        self.reveal_for = reveal_for or set()
+
+    def choose_card_to_trash(self, state, choices):
+        if not self.trash_target:
+            return None
+        for card in choices:
+            if card.name == self.trash_target:
+                return card
+        return None
+
+    def should_reveal_trader(self, state, player, gained_card, *, to_deck):
+        return gained_card.name in self.reveal_for
+
+
+def _prepare_state(ai):
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Trader"), get_card("Duchy")])
+    player = state.players[0]
+    player.actions = 1
+    player.hand = []
+    player.in_play = []
+    player.discard = []
+    player.deck = []
+    return state, player
+
+
+def test_trader_trashes_and_gains_silvers():
+    ai = TraderTestAI(trash_target="Duchy")
+    state, player = _prepare_state(ai)
+
+    trader_card = get_card("Trader")
+    duchy = get_card("Duchy")
+    player.hand = [trader_card, duchy]
+    player.cost_reduction = 1
+
+    player.hand.remove(trader_card)
+    player.in_play.append(trader_card)
+
+    trader_card.play_effect(state)
+
+    assert all(card.name != "Duchy" for card in player.hand)
+    assert any(card.name == "Duchy" for card in state.trash)
+    silvers = [card for card in player.discard if card.name == "Silver"]
+    assert len(silvers) == 4
+
+
+def test_trader_reaction_exchanges_gain_for_silver():
+    ai = TraderTestAI(reveal_for={"Estate"})
+    state, player = _prepare_state(ai)
+
+    trader_card = get_card("Trader")
+    player.hand = [trader_card]
+
+    estate = get_card("Estate")
+    state.supply["Estate"] = 8
+    state.supply["Silver"] = 40
+
+    state.supply["Estate"] -= 1
+    gained = state.gain_card(player, estate, to_deck=True)
+
+    assert gained.name == "Silver"
+    assert player.deck[0].name == "Silver"
+    assert all(card.name != "Estate" for card in player.deck + player.discard)
+    assert state.supply["Estate"] == 8
+    assert state.supply["Silver"] == 39


### PR DESCRIPTION
## Summary
- enforce Trader trashing and dynamic Silver gains on play
- add a Trader reveal exchange hook to gain_card along with AI defaults for trash selections and reaction reveals
- cover the new behavior with targeted Trader tests

## Testing
- pytest tests/test_trader.py

------
https://chatgpt.com/codex/tasks/task_e_68db18b3c4b88327a056eefc137724fd