### PR TITLE
Implement Patrol effect with AI ordering

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -66,3 +66,19 @@ class AI(ABC):
 
         low_value_cards = [card for card in hand if is_low_value(card)]
         return len(low_value_cards) >= 2
+
+    def order_cards_for_patrol(
+        self, state: GameState, player: PlayerState, cards: list[Card]
+    ) -> list[Card]:
+        """Return cards in draw priority order for Patrol's topdeck effect."""
+
+        def priority(card: Card) -> tuple[int, int, str]:
+            score = 0
+            if card.is_action:
+                score += 200
+            if card.is_treasure:
+                score += 100 + card.cost.coins
+            score += card.cost.coins
+            return (score, card.stats.cards, card.name)
+
+        return sorted(cards, key=priority, reverse=True)

--- a/dominion/cards/intrigue/patrol.py
+++ b/dominion/cards/intrigue/patrol.py
@@ -9,3 +9,41 @@ class Patrol(Card):
             stats=CardStats(actions=1, cards=3),
             types=[CardType.ACTION],
         )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        revealed: list[Card] = []
+        for _ in range(4):
+            if not player.deck and player.discard:
+                player.shuffle_discard_into_deck()
+            if not player.deck:
+                break
+            revealed.append(player.deck.pop())
+
+        if not revealed:
+            return
+
+        to_hand: list[Card] = []
+        to_topdeck: list[Card] = []
+        for card in revealed:
+            if card.is_victory or CardType.CURSE in card.types:
+                to_hand.append(card)
+            else:
+                to_topdeck.append(card)
+
+        if to_hand:
+            player.hand.extend(to_hand)
+
+        if not to_topdeck:
+            return
+
+        ordered = player.ai.order_cards_for_patrol(game_state, player, to_topdeck.copy())
+
+        if ordered is None or len(ordered) != len(to_topdeck) or {
+            id(card) for card in ordered
+        } != {id(card) for card in to_topdeck}:
+            ordered = to_topdeck
+
+        for card in reversed(ordered):
+            player.deck.append(card)

--- a/tests/test_patrol.py
+++ b/tests/test_patrol.py
@@ -1,0 +1,55 @@
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+
+from tests.utils import ChooseFirstActionAI
+
+
+class PatrolOrderingAI(ChooseFirstActionAI):
+    def order_cards_for_patrol(self, state, player, cards):
+        priority = {"Silver": 3, "Village": 2, "Copper": 1}
+        return sorted(cards, key=lambda card: priority.get(card.name, 0), reverse=True)
+
+
+def _setup_state(ai):
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Patrol")])
+    return state, state.players[0]
+
+
+def test_patrol_moves_victory_and_curse_into_hand_and_orders_deck():
+    ai = PatrolOrderingAI()
+    state, player = _setup_state(ai)
+
+    player.hand = []
+    player.deck = [
+        get_card("Gold"),
+        get_card("Copper"),
+        get_card("Estate"),
+        get_card("Silver"),
+        get_card("Curse"),
+    ]
+    player.discard = []
+
+    patrol = get_card("Patrol")
+    patrol.play_effect(state)
+
+    assert sorted(card.name for card in player.hand) == ["Curse", "Estate"]
+    assert [card.name for card in player.deck] == ["Gold", "Copper", "Silver"]
+
+
+def test_patrol_shuffles_if_needed_and_respects_ai_order(monkeypatch):
+    ai = PatrolOrderingAI()
+    state, player = _setup_state(ai)
+
+    player.hand = []
+    player.deck = [get_card("Copper"), get_card("Silver")]
+    player.discard = [get_card("Curse"), get_card("Estate"), get_card("Village")]
+
+    monkeypatch.setattr("dominion.game.player_state.random.shuffle", lambda seq: None)
+
+    patrol = get_card("Patrol")
+    patrol.play_effect(state)
+
+    assert sorted(card.name for card in player.hand) == ["Estate"]
+    assert player.discard == []
+    assert [card.name for card in player.deck] == ["Curse", "Copper", "Village", "Silver"]


### PR DESCRIPTION
## Summary
- implement Patrol's reveal effect to move Victory/Curses to hand and topdeck the rest
- add an AI hook for ordering Patrol's returned cards with a default heuristic
- cover Patrol's behavior with unit tests including shuffle handling

## Testing
- pytest tests/test_patrol.py

------
https://chatgpt.com/codex/tasks/task_e_68db18b5b5b0832787ff433e6a234e9e