### PR TITLE
Allow First Mate to stop replaying actions

### DIFF
--- a/dominion/cards/plunder/first_mate.py
+++ b/dominion/cards/plunder/first_mate.py
@@ -33,12 +33,25 @@ class FirstMate(Card):
 
         chosen_name = choice.name
 
-        # Play all copies of the chosen card currently in hand.  If the card
-        # draws more copies of itself they will also be played.
+        # Play copies of the chosen card, letting the AI decide after each play
+        # whether to continue.  Newly drawn copies remain eligible to be played
+        # on subsequent iterations.
+        first_iteration = True
         while True:
-            card_to_play = next((c for c in player.hand if c.name == chosen_name), None)
-            if card_to_play is None:
+            matching_cards = [c for c in player.hand if c.name == chosen_name]
+            if not matching_cards:
                 break
+
+            if first_iteration:
+                card_to_play = matching_cards[0]
+                first_iteration = False
+            else:
+                card_to_play = player.ai.choose_action(
+                    game_state, matching_cards + [None]
+                )
+                if card_to_play is None:
+                    break
+
             player.hand.remove(card_to_play)
             player.in_play.append(card_to_play)
             card_to_play.on_play(game_state)

--- a/tests/test_new_cards.py
+++ b/tests/test_new_cards.py
@@ -3,6 +3,25 @@ from dominion.game.game_state import GameState
 from tests.utils import ChooseFirstActionAI
 
 
+class StopAfterOneVillageAI(ChooseFirstActionAI):
+    """AI that stops First Mate after playing a single copy of the named card."""
+
+    def __init__(self):
+        super().__init__()
+        self._first_mate_resolution_calls = 0
+
+    def choose_action(self, state, choices):
+        non_none = [c for c in choices if c is not None]
+        if non_none and all(card.name == "Village" for card in non_none):
+            if self._first_mate_resolution_calls == 0:
+                self._first_mate_resolution_calls += 1
+                return non_none[0]
+            return None
+
+        self._first_mate_resolution_calls = 0
+        return super().choose_action(state, choices)
+
+
 def test_new_card_registry():
     names = [
         "Trail",
@@ -40,4 +59,27 @@ def test_first_mate_effect():
     # First Mate should also be in play
     assert any(c.name == "First Mate" for c in player.in_play)
     # Hand should be drawn up to 6 cards
+    assert len(player.hand) == 6
+
+
+def test_first_mate_can_stop_after_first_copy():
+    ai = StopAfterOneVillageAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("First Mate"), get_card("Village")])
+
+    player = state.players[0]
+
+    player.hand = [get_card("First Mate"), get_card("Village"), get_card("Village")]
+    player.deck = [get_card("Copper") for _ in range(10)]
+    player.discard = []
+    player.actions = 1
+
+    state.phase = "action"
+    state.handle_action_phase()
+
+    # Only one Village should have been played
+    assert sum(1 for c in player.in_play if c.name == "Village") == 1
+    # The other Village should remain in hand
+    assert any(c.name == "Village" for c in player.hand)
+    # Draw-to-six cleanup should still occur
     assert len(player.hand) == 6


### PR DESCRIPTION
## Summary
- allow First Mate to consult the AI between replays so it can stop early
- keep the replay loop compatible with newly drawn copies and retain draw-to-six cleanup
- add regression coverage that verifies both full replay and early stop behaviors

## Testing
- pytest tests/test_new_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68db18bcc1bc8327b6dde18b276f867d