### PR TITLE
Update turn summary logging to show available coins

### DIFF
--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -50,7 +50,7 @@ class GameState:
                 # (supply_change, card_name, count, remaining)
                 self.logger.log_supply_change(message[1], message[2], message[3])
             elif msg_type == "turn_summary":
-                # (turn_summary, player_name, actions_played, cards_bought, coins)
+                # (turn_summary, player_name, actions_played, cards_bought, coins_available)
                 self.logger.log_turn_summary(message[1], message[2], message[3], message[4])
         else:
             # Legacy string message support
@@ -467,7 +467,7 @@ class GameState:
                 player.ai.name,
                 player.actions_this_turn,
                 list(player.bought_this_turn),
-                player.coins_spent_this_turn,
+                player.coins_spent_this_turn + player.coins,
             )
         )
 

--- a/dominion/simulation/game_logger.py
+++ b/dominion/simulation/game_logger.py
@@ -154,7 +154,9 @@ class GameLogger:
 
         self.file_logger.info(f"Supply: {card_name} {'gained' if count < 0 else 'added'} " f"({remaining} remaining)")
 
-    def log_turn_summary(self, player_name: str, actions_played: int, cards_bought: list[str], coins: int):
+    def log_turn_summary(
+        self, player_name: str, actions_played: int, cards_bought: list[str], coins_available: int
+    ):
         """Log a concise summary at the end of each turn."""
         if not self.should_log_to_file:
             return
@@ -165,8 +167,10 @@ class GameLogger:
             buy_part = f"bought {', '.join(cards_bought)}"
         else:
             buy_part = "bought nothing"
-        coin_word = "coin" if coins == 1 else "coins"
-        self.file_logger.info(f"Summary: {player} played {action_part} and {buy_part} spending {coins} {coin_word}")
+        coin_word = "coin" if coins_available == 1 else "coins"
+        self.file_logger.info(
+            f"Summary: {player} played {action_part} and had {coins_available} {coin_word} and {buy_part}"
+        )
 
     def end_game(
         self,


### PR DESCRIPTION
## Summary
- update the turn summary log output to describe the total coins a player had available
- compute the total coins available for the summary before player resources reset

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'coloredlogs')*

------
https://chatgpt.com/codex/tasks/task_e_68db4a7d81ac8327b0adbcc291f87ead