### PR TITLE
Fix Emporium gain bonus condition

### DIFF
--- a/dominion/cards/empires/emporium.py
+++ b/dominion/cards/empires/emporium.py
@@ -15,5 +15,6 @@ class Emporium(BottomSplitPileCard):
 
     def on_gain(self, game_state, player):
         super().on_gain(game_state, player)
-        if any(card.name == "Patrician" for card in player.in_play):
+        actions_in_play = sum(1 for card in player.in_play if card.is_action)
+        if actions_in_play >= 5:
             player.vp_tokens += 2

--- a/tests/test_emporium.py
+++ b/tests/test_emporium.py
@@ -1,0 +1,30 @@
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+from tests.utils import DummyAI
+
+
+def _make_player_with_actions(action_count: int) -> tuple[GameState, PlayerState]:
+    player = PlayerState(DummyAI())
+    player.in_play = [get_card("Village") for _ in range(action_count)]
+    state = GameState(players=[player])
+    return state, player
+
+
+def test_emporium_grants_vp_tokens_when_five_actions_in_play():
+    state, player = _make_player_with_actions(5)
+    emporium = get_card("Emporium")
+
+    state.gain_card(player, emporium)
+
+    assert player.vp_tokens == 2
+
+
+def test_emporium_grants_no_bonus_with_fewer_than_five_actions():
+    state, player = _make_player_with_actions(4)
+    emporium = get_card("Emporium")
+
+    state.gain_card(player, emporium)
+
+    assert player.vp_tokens == 0


### PR DESCRIPTION
## Summary
- correct Emporium's on-gain bonus to check for five Actions in play
- add regression tests covering the victory token bonus condition

## Testing
- pytest tests/test_emporium.py

------
https://chatgpt.com/codex/tasks/task_e_68dbf847b5b08327963b1eee54a7cd1d