### PR TITLE
Fix Trail reaction triggers

### DIFF
--- a/dominion/cards/hinterlands/trail.py
+++ b/dominion/cards/hinterlands/trail.py
@@ -13,25 +13,54 @@ class Trail(Card):
     def _play_now(self, game_state, player):
         """Play Trail immediately from its current location."""
 
-        # Remove the card from wherever it currently is.
+        origin = None
         if self in player.discard:
             player.discard.remove(self)
+            origin = "discard"
         elif self in player.deck:
             player.deck.remove(self)
+            origin = "deck"
         elif self in player.hand:
             player.hand.remove(self)
+            origin = "hand"
         elif self in game_state.trash:
             game_state.trash.remove(self)
+            origin = "trash"
+        elif self in player.in_play:
+            player.in_play.remove(self)
+            origin = "in_play"
         else:
             return
+
+        if self.is_action:
+            player.actions_played += 1
+            player.actions_this_turn += 1
 
         player.in_play.append(self)
         self.on_play(game_state)
 
+        if origin == "trash":
+            if self in player.in_play:
+                player.in_play.remove(self)
+            if self not in game_state.trash:
+                game_state.trash.append(self)
+
     def on_gain(self, game_state, player):
         super().on_gain(game_state, player)
-        self._play_now(game_state, player)
+        self.maybe_play_on_reaction(game_state, player)
 
     def on_trash(self, game_state, player):
         super().on_trash(game_state, player)
-        self._play_now(game_state, player)
+        self.maybe_play_on_reaction(game_state, player)
+
+    def maybe_play_on_reaction(self, game_state, player):
+        """Ask the AI if Trail should be played due to a reaction trigger."""
+
+        choice = player.ai.choose_action(game_state, [self, None])
+        if choice is self:
+            self._play_now(game_state, player)
+
+    def react_to_discard(self, game_state, player):
+        """Handle the discard trigger outside of clean-up."""
+
+        self.maybe_play_on_reaction(game_state, player)

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -665,6 +665,8 @@ class GameState:
                 return
             player.in_play.append(card)
             card.on_play(self)
+        elif hasattr(card, "react_to_discard"):
+            card.react_to_discard(self, player)
 
     def give_curse_to_player(self, player, *, to_hand: bool = False):
         """Give a curse card to a player.

--- a/tests/test_trail_card.py
+++ b/tests/test_trail_card.py
@@ -1,0 +1,107 @@
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from tests.utils import ChooseFirstActionAI
+
+
+class DeclineTrailAI(ChooseFirstActionAI):
+    """AI that declines optional Trail reactions."""
+
+    def choose_action(self, state, choices):
+        non_none = [card for card in choices if card is not None]
+        if non_none and all(card.name == "Trail" for card in non_none):
+            return None
+        return super().choose_action(state, choices)
+
+
+def _setup_game(ai):
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Trail")])
+    player = state.players[0]
+    player.hand = []
+    player.deck = []
+    player.discard = []
+    player.in_play = []
+    player.actions = 0
+    player.actions_this_turn = 0
+    player.actions_played = 0
+    return state, player
+
+
+def test_trail_reacts_to_discard():
+    ai = ChooseFirstActionAI()
+    state, player = _setup_game(ai)
+
+    trail = get_card("Trail")
+    player.hand = [trail]
+    player.deck = [get_card("Copper")]
+
+    player.hand.remove(trail)
+    state.discard_card(player, trail)
+
+    assert trail in player.in_play
+    assert trail not in player.discard
+    assert player.actions == 1
+    assert player.actions_this_turn == 1
+    assert player.actions_played == 1
+    assert len(player.hand) == 1  # Drew one card
+
+
+def test_trail_discard_reaction_can_be_declined():
+    ai = DeclineTrailAI()
+    state, player = _setup_game(ai)
+
+    trail = get_card("Trail")
+    player.hand = [trail]
+
+    player.hand.remove(trail)
+    state.discard_card(player, trail)
+
+    assert trail in player.discard
+    assert trail not in player.in_play
+    assert player.actions == 0
+
+
+def test_trail_can_play_when_gained():
+    ai = ChooseFirstActionAI()
+    state, player = _setup_game(ai)
+
+    player.deck = [get_card("Copper")]
+
+    gained = state.gain_card(player, get_card("Trail"))
+
+    assert gained in player.in_play
+    assert player.actions == 1
+    assert player.actions_this_turn == 1
+    assert player.actions_played == 1
+    assert len(player.hand) == 1
+
+
+def test_trail_gain_reaction_can_be_declined():
+    ai = DeclineTrailAI()
+    state, player = _setup_game(ai)
+
+    gained = state.gain_card(player, get_card("Trail"))
+
+    assert gained in player.discard
+    assert gained not in player.in_play
+
+
+def test_trail_trash_reaction_returns_to_trash():
+    ai = ChooseFirstActionAI()
+    state, player = _setup_game(ai)
+
+    trail = get_card("Trail")
+    player.deck = [get_card("Copper")]
+
+    # Simulate the card being trashed from hand
+    player.hand = [trail]
+    player.hand.remove(trail)
+
+    state.trash_card(player, trail)
+
+    assert trail in state.trash
+    assert trail not in player.in_play
+    assert player.actions == 1
+    assert player.actions_this_turn == 1
+    assert player.actions_played == 1
+    assert len(player.hand) == 1


### PR DESCRIPTION
## Summary
- update Trail so its reaction optionally plays it from any zone and keeps trashed copies in the trash
- allow discard handling to defer to card-specific reactions such as Trail
- add regression tests covering Trail's gain, discard, and trash triggers

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dbfa6a097c8327aac822634c178987