### PR TITLE
Fix Duchess gain logic

### DIFF
--- a/dominion/cards/hinterlands/duchess.py
+++ b/dominion/cards/hinterlands/duchess.py
@@ -19,17 +19,6 @@ class Duchess(Card):
                 continue
             self._review_top_card(game_state, other, is_self=False)
 
-    def on_gain(self, game_state, player):
-        super().on_gain(game_state, player)
-
-        from ..registry import get_card
-
-        if game_state.supply.get("Duchy", 0) <= 0:
-            return
-
-        game_state.supply["Duchy"] -= 1
-        game_state.gain_card(player, get_card("Duchy"))
-
     def _review_top_card(self, game_state, target, *, is_self: bool) -> None:
         if not target.deck and target.discard:
             target.shuffle_discard_into_deck()

--- a/dominion/cards/victory.py
+++ b/dominion/cards/victory.py
@@ -16,6 +16,18 @@ class Duchy(Card):
     def starting_supply(self, game_state) -> int:
         return 8 if len(game_state.players) <= 2 else 12
 
+    def on_gain(self, game_state, player):
+        super().on_gain(game_state, player)
+
+        duchess_supply = game_state.supply.get("Duchess", 0)
+        if duchess_supply <= 0:
+            return
+
+        from .registry import get_card
+
+        game_state.supply["Duchess"] = duchess_supply - 1
+        game_state.gain_card(player, get_card("Duchess"))
+
 
 class Province(Card):
     def __init__(self):

--- a/tests/test_duchess.py
+++ b/tests/test_duchess.py
@@ -1,0 +1,52 @@
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+from tests.utils import DummyAI
+
+
+def _setup_player_and_state():
+    ai = DummyAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.supply = {"Duchess": 10, "Duchy": 8}
+    return state, player
+
+
+def test_gaining_duchess_does_not_gain_duchy():
+    state, player = _setup_player_and_state()
+
+    duchess = get_card("Duchess")
+    state.supply["Duchess"] -= 1
+    gained = state.gain_card(player, duchess)
+
+    assert gained.name == "Duchess"
+    assert all(card.name != "Duchy" for card in player.discard)
+    assert state.supply["Duchy"] == 8
+
+
+def test_gaining_duchy_gains_duchess_if_available():
+    state, player = _setup_player_and_state()
+
+    duchy = get_card("Duchy")
+    state.supply["Duchy"] -= 1
+    gained = state.gain_card(player, duchy)
+
+    names_in_discard = [card.name for card in player.discard]
+    assert gained.name == "Duchy"
+    assert names_in_discard.count("Duchy") == 1
+    assert names_in_discard.count("Duchess") == 1
+    assert state.supply["Duchess"] == 9
+
+
+def test_gaining_duchy_when_no_duchess_available():
+    state, player = _setup_player_and_state()
+    state.supply["Duchess"] = 0
+
+    duchy = get_card("Duchy")
+    state.supply["Duchy"] -= 1
+    gained = state.gain_card(player, duchy)
+
+    assert gained.name == "Duchy"
+    assert all(card.name != "Duchess" for card in player.discard)
+    assert state.supply["Duchess"] == 0


### PR DESCRIPTION
## Summary
- move the Duchess-on-Duchy gain trigger onto Duchy so the card behaves correctly
- ensure gaining Duchess no longer grants a Duchy and cover the interaction with new tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc04f34d448327abc6aa188a833224