### PR TITLE
Fix Lookout trash priority to prefer low-value cards

### DIFF
--- a/dominion/cards/seaside/lookout.py
+++ b/dominion/cards/seaside/lookout.py
@@ -41,13 +41,13 @@ class Lookout(Card):
     @staticmethod
     def _trash_priority(card):
         if card.name == "Curse":
-            return (0, card.cost.coins)
+            return (0, card.cost.coins, card.name)
         if card.is_victory and not card.is_action:
-            return (1, card.cost.coins)
+            return (1, card.cost.coins, card.name)
         if card.name == "Copper":
-            return (2, card.cost.coins)
-        return (3, -card.cost.coins)
+            return (2, card.cost.coins, card.name)
+        return (3, card.cost.coins, card.name)
 
     @staticmethod
     def _discard_priority(card):
-        return (card.is_action, card.is_treasure, card.cost.coins)
+        return (card.is_action, card.is_treasure, card.cost.coins, card.name)


### PR DESCRIPTION
## Summary
- correct Lookout's trash priority so it favors trashing low-value cards instead of expensive ones
- add deterministic tie-breakers for Lookout's trash and discard selection heuristics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc098575e88327b07821d91a7e212e