### PR TITLE
Implement Crown's double-play effect

### DIFF
--- a/dominion/cards/empires/crown.py
+++ b/dominion/cards/empires/crown.py
@@ -2,7 +2,7 @@ from ..base_card import Card, CardCost, CardStats, CardType
 
 
 class Crown(Card):
-    """Simplified Crown that boosts economy in either phase."""
+    """Lets you double-play an Action (action phase) or Treasure (treasure phase)."""
 
     def __init__(self):
         super().__init__(
@@ -13,5 +13,35 @@ class Crown(Card):
         )
 
     def play_effect(self, game_state):
-        # In this simplified model Crown just grants its printed bonuses.
-        pass
+        """Play another card from hand twice based on the current phase."""
+
+        player = game_state.current_player
+
+        if game_state.phase == "action":
+            targets = [card for card in player.hand if card.is_action]
+            if not targets:
+                return
+
+            choice = player.ai.choose_action(game_state, targets + [None])
+            if choice is None:
+                choice = targets[0]
+
+            player.hand.remove(choice)
+            player.in_play.append(choice)
+
+            for _ in range(2):
+                choice.on_play(game_state)
+        else:
+            treasures = [card for card in player.hand if card.is_treasure]
+            if not treasures:
+                return
+
+            choice = player.ai.choose_treasure(game_state, treasures + [None])
+            if choice is None:
+                choice = treasures[0]
+
+            player.hand.remove(choice)
+            player.in_play.append(choice)
+
+            for _ in range(2):
+                choice.on_play(game_state)


### PR DESCRIPTION
## Summary
- implement Crown so it now plays an action or treasure from hand twice depending on the current phase
- ensure the chosen card is moved from hand to play before resolving the two plays

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc08e7ee908327b0bf71118a494ce3