### PR TITLE
Fix Torturer choice handling

### DIFF
--- a/dominion/cards/intrigue/torturer.py
+++ b/dominion/cards/intrigue/torturer.py
@@ -16,50 +16,51 @@ class Torturer(Card):
         player = game_state.current_player
 
         def attack_target(target):
-            hand_size = len(target.hand)
             curses_remaining = game_state.supply.get("Curse", 0)
-
-            if hand_size < 2:
-                if curses_remaining > 0:
-                    gained = game_state.give_curse_to_player(target, to_hand=True)
-                    if gained:
-                        game_state.log_callback(
-                            (
-                                "action",
-                                target.ai.name,
-                                "takes Curse to hand due to Torturer",
-                                {
-                                    "curses_remaining": game_state.supply.get("Curse", 0),
-                                    "hand": [c.name for c in target.hand],
-                                },
-                            )
-                        )
-                return
 
             choose_discard = target.ai.choose_torturer_attack(game_state, target)
             if not choose_discard and curses_remaining == 0:
                 choose_discard = True
 
             if choose_discard:
-                cards_to_discard = target.ai.choose_cards_to_discard(
-                    game_state, target, list(target.hand), 2, reason="torturer"
-                )
-                for card in cards_to_discard:
-                    if card in target.hand:
-                        target.hand.remove(card)
-                        game_state.discard_card(target, card)
-                game_state.log_callback(
-                    (
-                        "action",
-                        target.ai.name,
-                        "discards 2 cards due to Torturer",
-                        {
-                            "discarded_cards": [c.name for c in cards_to_discard],
-                            "remaining_hand": [c.name for c in target.hand],
-                        },
+                max_discards = min(2, len(target.hand))
+                if max_discards == 0 and curses_remaining > 0:
+                    # The player cannot discard any cards, so they must take the Curse
+                    choose_discard = False
+                else:
+                    cards_to_discard = target.ai.choose_cards_to_discard(
+                        game_state,
+                        target,
+                        list(target.hand),
+                        max_discards,
+                        reason="torturer",
                     )
-                )
-            else:
+                    # Ensure we only discard cards actually still in hand
+                    discarded: list[Card] = []
+                    for card in cards_to_discard[:max_discards]:
+                        if card in target.hand:
+                            target.hand.remove(card)
+                            game_state.discard_card(target, card)
+                            discarded.append(card)
+
+                    if discarded:
+                        discard_count = len(discarded)
+                        card_desc = "card" if discard_count == 1 else "cards"
+                        game_state.log_callback(
+                            (
+                                "action",
+                                target.ai.name,
+                                f"discards {discard_count} {card_desc} due to Torturer",
+                                {
+                                    "discarded_cards": [c.name for c in discarded],
+                                    "remaining_hand": [c.name for c in target.hand],
+                                },
+                            )
+                        )
+                    else:
+                        choose_discard = False
+
+            if not choose_discard:
                 gained = game_state.give_curse_to_player(target, to_hand=True)
                 if gained:
                     game_state.log_callback(


### PR DESCRIPTION
## Summary
- allow Torturer's victims to choose the discard option regardless of hand size and only force a Curse when no discard is possible
- adjust Torturer logging to reflect the number of cards actually discarded

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc08ef4bd88327b102ea8024abf528