### PR TITLE
Fix Menagerie card implementations

### DIFF
--- a/dominion/cards/menagerie/mastermind.py
+++ b/dominion/cards/menagerie/mastermind.py
@@ -25,7 +25,8 @@ class Mastermind(Card):
 
         choice = player.ai.choose_action(game_state, actions + [None])
         if choice is None:
-            choice = actions[0]
+            self.duration_persistent = False
+            return
 
         if choice in player.hand:
             player.hand.remove(choice)

--- a/dominion/cards/menagerie/paddock.py
+++ b/dominion/cards/menagerie/paddock.py
@@ -16,11 +16,12 @@ class Paddock(Card):
         from ..registry import get_card
 
         player = game_state.current_player
-        for _ in range(2):
-            try:
-                horse = get_card("Horse")
-            except ValueError:
-                break
+        try:
+            horse = get_card("Horse")
+        except ValueError:
+            horse = None
+
+        if horse is not None:
             game_state.gain_card(player, horse)
 
         player.actions += game_state.empty_piles


### PR DESCRIPTION
## Summary
- update Mastermind so skipping the triple-play is optional as intended
- ensure Paddock only gains a single Horse when played

## Testing
- pytest tests/test_new_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68dc08f71ba883279474737147611cdb