### PR TITLE
Fix Inventor cost filtering

### DIFF
--- a/dominion/cards/renaissance/inventor.py
+++ b/dominion/cards/renaissance/inventor.py
@@ -20,13 +20,26 @@ class Inventor(Card):
         for name, count in game_state.supply.items():
             if count <= 0:
                 continue
+
             card = get_card(name)
-            if card.cost.coins <= 4:
-                choices.append(card)
+
+            # Inventor should respect existing cost modifiers (including other
+            # Inventors played earlier in the turn). ``get_card_cost`` applies the
+            # player's current reductions, so we use it rather than the printed
+            # cost on the pile.
+            if game_state.get_card_cost(player, card) > 4:
+                continue
+
+            # Cards with potion costs cannot be gained by Inventor, matching the
+            # official Workshop-style rules text.
+            if card.cost.potions > 0:
+                continue
+
+            choices.append(card)
 
         if choices:
-            choices.sort(key=lambda c: (c.cost.coins, c.name), reverse=True)
-            gain = choices[0]
+            chosen = player.ai.choose_buy(game_state, choices)
+            gain = chosen if chosen else max(choices, key=lambda c: (c.cost.coins, c.name))
             game_state.supply[gain.name] -= 1
             game_state.gain_card(player, gain)
 


### PR DESCRIPTION
## Summary
- make Inventor respect existing cost modifiers and potion requirements when choosing a gain
- defer to the AI's gain priorities when multiple cards are eligible

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc097ed4f88327976580fb0e74030e