### PR TITLE
Add tests for Renaissance Inventor behavior

### DIFF
--- a/tests/test_inventor.py
+++ b/tests/test_inventor.py
@@ -1,0 +1,51 @@
+from dominion.cards.registry import get_card
+from dominion.game.player_state import PlayerState
+from dominion.game.game_state import GameState
+from tests.utils import DummyAI
+
+
+def play_action(state, player, card):
+    player.hand.remove(card)
+    player.in_play.append(card)
+    card.on_play(state)
+
+
+def test_inventor_gains_reduced_cost_card_and_adds_discount():
+    ai = DummyAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([])
+
+    # Only keep the piles we care about for this test
+    state.supply = {"Laboratory": 10}
+
+    inventor = get_card("Inventor")
+    player.hand = [inventor]
+    player.actions = 1
+    player.cost_reduction = 1
+
+    play_action(state, player, inventor)
+
+    assert any(card.name == "Laboratory" for card in player.discard)
+    assert state.supply["Laboratory"] == 9
+    assert player.cost_reduction == 2
+
+
+def test_inventor_handles_no_affordable_cards_but_still_reduces_cost():
+    ai = DummyAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([])
+
+    # Provide only an unaffordable pile
+    state.supply = {"Laboratory": 10}
+
+    inventor = get_card("Inventor")
+    player.hand = [inventor]
+    player.actions = 1
+
+    play_action(state, player, inventor)
+
+    assert not player.discard
+    assert state.supply["Laboratory"] == 10
+    assert player.cost_reduction == 1


### PR DESCRIPTION
## Summary
- add targeted tests covering Inventor gaining reduced-cost cards and providing discounts
- ensure Inventor still applies its cost reduction even when no card can be gained

## Testing
- pytest tests/test_acting_troupe.py tests/test_inventor.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dc0d2b5d348327970369b52a8c297e