### PR TITLE
Implement Hex support

### DIFF
--- a/dominion/cards/nocturne/skulk.py
+++ b/dominion/cards/nocturne/skulk.py
@@ -15,13 +15,21 @@ class Skulk(Card):
     def play_effect(self, game_state):
         player = game_state.current_player
 
-        def attack(target):
-            game_state.give_hex_to_player(target)
+        targets = [other for other in game_state.players if other is not player]
+        if not targets:
+            return
 
-        for other in game_state.players:
-            if other is player:
-                continue
+        hex_name = game_state.draw_hex()
+        if not hex_name:
+            return
+
+        def attack(target):
+            game_state.resolve_hex(target, hex_name)
+
+        for other in targets:
             game_state.attack_player(other, attack)
+
+        game_state.discard_hex(hex_name)
 
     def on_gain(self, game_state, player):
         super().on_gain(game_state, player)

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1,4 +1,6 @@
+import random
 from dataclasses import dataclass, field
+from typing import Optional
 
 from dominion.cards.base_card import Card
 from dominion.cards.registry import get_card
@@ -19,6 +21,8 @@ class GameState:
     turn_number: int = 1
     extra_turn: bool = False
     copper_value: int = 1
+    hex_deck: list[str] = field(default_factory=list)
+    hex_discard: list[str] = field(default_factory=list)
 
     def __post_init__(self):
         """Initialize with default logger that prints to console."""
@@ -180,6 +184,8 @@ class GameState:
         player.coins_spent_this_turn = 0
         player.banned_buys = []
         player.topdeck_gains = False
+        player.cannot_buy_actions = False
+        player.envious_effect_active = False
 
         # Return any cards delayed by the Delay event
         if self.current_player.delayed_cards:
@@ -320,9 +326,26 @@ class GameState:
 
         self.phase = "treasure"
 
+    def _handle_start_of_buy_phase_effects(self) -> None:
+        """Apply state effects that trigger at the start of the buy phase."""
+
+        player = self.current_player
+        player.cannot_buy_actions = False
+        player.envious_effect_active = False
+
+        if player.deluded:
+            player.deluded = False
+            player.cannot_buy_actions = True
+
+        if player.envious:
+            player.envious = False
+            player.envious_effect_active = True
+
     def handle_treasure_phase(self):
         """Handle the treasure phase of a turn."""
         player = self.current_player
+
+        self._handle_start_of_buy_phase_effects()
 
         while True:
             treasures = [card for card in player.hand if card.is_treasure]
@@ -339,25 +362,36 @@ class GameState:
                     self.logger.current_metrics.cards_played.get(choice.name, 0) + 1
                 )
 
-            # Log treasure play with context
-            context = {
-                "coins_before": player.coins,
-                "coins_added": choice.stats.coins,
-                "coins_after": player.coins + choice.stats.coins,
-                "remaining_treasures": [c.name for c in player.hand if c != choice and c.is_treasure],
-            }
-            self.log_callback(("action", player.ai.name, f"plays {choice}", context))
-
+            coins_before = player.coins
             player.hand.remove(choice)
             player.in_play.append(choice)
-            if (
+
+            blocked = (
                 getattr(player, "highwayman_attacks", 0) > 0
                 and not getattr(player, "highwayman_blocked_this_turn", False)
-            ):
+            )
+            if blocked:
                 player.highwayman_blocked_this_turn = True
-                continue
+                coins_after = player.coins
+            else:
+                choice.on_play(self)
+                coins_after = player.coins
+                if (
+                    player.envious_effect_active
+                    and choice.name in {"Silver", "Gold"}
+                    and coins_after > coins_before + 1
+                ):
+                    player.coins = coins_before + 1
+                    coins_after = player.coins
 
-            choice.on_play(self)
+            remaining = [c.name for c in player.hand if c.is_treasure]
+            context = {
+                "coins_before": coins_before,
+                "coins_added": coins_after - coins_before,
+                "coins_after": coins_after,
+                "remaining_treasures": remaining,
+            }
+            self.log_callback(("action", player.ai.name, f"plays {choice}", context))
 
         self.phase = "buy"
 
@@ -441,6 +475,7 @@ class GameState:
                     and card.cost.potions <= player.potions
                     and card.may_be_bought(self)
                     and card_name not in player.banned_buys
+                    and (not player.cannot_buy_actions or not card.is_action)
                 ):
                     affordable.append(card)
 
@@ -535,6 +570,8 @@ class GameState:
         player.goons_played = 0
         player.groundskeeper_bonus = 0
         player.topdeck_gains = False
+        player.cannot_buy_actions = False
+        player.envious_effect_active = False
         player.cost_reduction = 0
         player.innovation_used = False
         player.cards_gained_this_turn = 0
@@ -701,15 +738,52 @@ class GameState:
 
         return True
 
+    def _ensure_hex_deck(self) -> None:
+        from dominion.hexes import create_hex_deck
+
+        if not self.hex_deck:
+            if self.hex_discard:
+                self.hex_deck = list(self.hex_discard)
+                random.shuffle(self.hex_deck)
+                self.hex_discard = []
+            else:
+                self.hex_deck = create_hex_deck()
+
+    def draw_hex(self) -> Optional[str]:
+        """Draw the next Hex name from the Hex deck, shuffling if needed."""
+
+        self._ensure_hex_deck()
+        if not self.hex_deck:
+            return None
+        return self.hex_deck.pop()
+
+    def resolve_hex(self, player: PlayerState, hex_name: str) -> None:
+        """Apply the Hex ``hex_name`` to ``player`` and log the result."""
+
+        if not hex_name:
+            return
+
+        from dominion.hexes import resolve_hex
+
+        self.log_callback(("action", player.ai.name, f"receives Hex: {hex_name}", {}))
+        resolve_hex(hex_name, self, player)
+
+    def discard_hex(self, hex_name: Optional[str]) -> None:
+        """Place a revealed Hex into the Hex discard pile."""
+
+        if hex_name:
+            self.hex_discard.append(hex_name)
+
     def give_hex_to_player(self, player):
-        """Give the targeted player a Hex.
+        """Give the targeted player the next Hex from the Hex deck."""
 
-        The full Hex system is not yet modelled in the simulator. As an
-        approximation, receiving a Hex gives the player a Curse if any remain
-        in the supply.
-        """
+        hex_name = self.draw_hex()
+        if not hex_name:
+            return None
 
-        self.give_curse_to_player(player)
+        self.resolve_hex(player, hex_name)
+        self.discard_hex(hex_name)
+        return hex_name
 
     def gain_card(self, player: PlayerState, card: Card, to_deck: bool = False) -> Card:
         """Add a card to a player's discard or deck, honoring topdeck effects.

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -27,6 +27,13 @@ class PlayerState:
     exile: list[Card] = field(default_factory=list)
     invested_exile: list[Card] = field(default_factory=list)
 
+    # States and hex penalties
+    deluded: bool = False
+    envious: bool = False
+    misery: int = 0
+    cannot_buy_actions: bool = False
+    envious_effect_active: bool = False
+
     # Misc counters
     vp_tokens: int = 0
     villagers: int = 0
@@ -127,6 +134,11 @@ class PlayerState:
         self.flagship_pending = []
         self.highwayman_attacks = 0
         self.highwayman_blocked_this_turn = False
+        self.deluded = False
+        self.envious = False
+        self.misery = 0
+        self.cannot_buy_actions = False
+        self.envious_effect_active = False
 
         # Draw initial hand of 5 cards
         self.draw_cards(5)
@@ -177,6 +189,7 @@ class PlayerState:
                 for card in (self.hand + self.deck + self.discard + self.in_play + self.duration)
             )
             + self.vp_tokens
+            - 2 * self.misery
         )
 
     def all_cards(self) -> list[Card]:
@@ -198,6 +211,11 @@ class PlayerState:
 
         if self.vp_tokens:
             points["VP Tokens"] += self.vp_tokens
+
+        if self.misery:
+            label = "Miserable" if self.misery == 1 else "Twice Miserable"
+            points[label] -= 2 * self.misery
+            counts[label] = 1
 
         breakdown = {name: {"count": counts.get(name, 0), "vp": vp} for name, vp in points.items()}
         return breakdown

--- a/dominion/hexes.py
+++ b/dominion/hexes.py
@@ -1,0 +1,228 @@
+"""Definitions of Dominion Hex effects used by Doom cards."""
+
+from __future__ import annotations
+
+import random
+from typing import Callable, TYPE_CHECKING
+
+from dominion.cards.registry import get_card
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from dominion.game.game_state import GameState
+    from dominion.game.player_state import PlayerState
+
+HexEffect = Callable[["GameState", "PlayerState"], None]
+
+
+def bad_omens(game_state: "GameState", player: "PlayerState") -> None:
+    """Move the deck to the discard and topdeck up to two Coppers."""
+
+    if player.deck:
+        player.discard.extend(player.deck)
+        player.deck.clear()
+
+    coppers = [card for card in player.discard if card.name == "Copper"]
+    for _ in range(min(2, len(coppers))):
+        copper = coppers.pop()
+        if copper in player.discard:
+            player.discard.remove(copper)
+        player.deck.append(copper)
+
+
+def delusion(game_state: "GameState", player: "PlayerState") -> None:
+    """Give the player the Deluded state if possible."""
+
+    if not player.deluded and not player.envious:
+        player.deluded = True
+
+
+def envy(game_state: "GameState", player: "PlayerState") -> None:
+    """Give the player the Envious state if possible."""
+
+    if not player.deluded and not player.envious:
+        player.envious = True
+
+
+def famine(game_state: "GameState", player: "PlayerState") -> None:
+    """Reveal three cards, discarding Actions and shuffling the rest back."""
+
+    revealed = []
+    for _ in range(3):
+        if not player.deck:
+            player.shuffle_discard_into_deck()
+        if not player.deck:
+            break
+        revealed.append(player.deck.pop())
+
+    to_keep = []
+    for card in revealed:
+        if card.is_action:
+            game_state.discard_card(player, card)
+        else:
+            to_keep.append(card)
+
+    random.shuffle(to_keep)
+    player.deck.extend(to_keep)
+
+
+def fear(game_state: "GameState", player: "PlayerState") -> None:
+    """Force the player to discard an Action or Treasure if possible."""
+
+    if len(player.hand) < 5:
+        return
+
+    choices = [card for card in player.hand if card.is_action or card.is_treasure]
+    if not choices:
+        return
+
+    selected = player.ai.choose_cards_to_discard(game_state, player, choices, 1)
+    card = selected[0] if selected else choices[0]
+    if card in player.hand:
+        player.hand.remove(card)
+        game_state.discard_card(player, card)
+
+
+def greed(game_state: "GameState", player: "PlayerState") -> None:
+    """Gain a Copper to the top of the player's deck."""
+
+    if game_state.supply.get("Copper", 0) <= 0:
+        return
+
+    copper = get_card("Copper")
+    game_state.supply["Copper"] -= 1
+    game_state.gain_card(player, copper, to_deck=True)
+
+
+def haunting(game_state: "GameState", player: "PlayerState") -> None:
+    """Topdeck a card if the player has at least four in hand."""
+
+    if len(player.hand) < 4:
+        return
+
+    choices = list(player.hand)
+    selected = player.ai.choose_cards_to_discard(game_state, player, choices, 1)
+    card = selected[0] if selected else choices[0]
+    if card in player.hand:
+        player.hand.remove(card)
+        player.deck.append(card)
+
+
+def locusts(game_state: "GameState", player: "PlayerState") -> None:
+    """Trash the top deck card and gain an appropriate replacement."""
+
+    if not player.deck:
+        player.shuffle_discard_into_deck()
+    if not player.deck:
+        return
+
+    trashed = player.deck.pop()
+    game_state.trash_card(player, trashed)
+
+    if trashed.name in {"Copper", "Estate"}:
+        game_state.give_curse_to_player(player)
+        return
+
+    trashed_types = set(trashed.types)
+    trashed_cost = trashed.cost.coins
+    candidates = []
+    for name, count in game_state.supply.items():
+        if count <= 0:
+            continue
+        card = get_card(name)
+        if card.cost.coins < trashed_cost and trashed_types.intersection(card.types):
+            candidates.append(card)
+
+    if candidates:
+        gain = max(candidates, key=lambda c: (c.cost.coins, c.stats.cards, c.name))
+        game_state.supply[gain.name] -= 1
+        game_state.gain_card(player, gain)
+
+
+def misery(game_state: "GameState", player: "PlayerState") -> None:
+    """Increase the player's Misery penalty."""
+
+    player.misery = min(2, player.misery + 1)
+
+
+def plague(game_state: "GameState", player: "PlayerState") -> None:
+    """Give the player a Curse directly to hand."""
+
+    game_state.give_curse_to_player(player, to_hand=True)
+
+
+def poverty(game_state: "GameState", player: "PlayerState") -> None:
+    """Force the player to discard down to three cards."""
+
+    discard_target = max(0, len(player.hand) - 3)
+    if discard_target <= 0:
+        return
+
+    choices = list(player.hand)
+    selected = player.ai.choose_cards_to_discard(game_state, player, choices, discard_target)
+    if len(selected) < discard_target:
+        remaining = [card for card in choices if card not in selected]
+        selected.extend(remaining[: discard_target - len(selected)])
+
+    for card in selected[:discard_target]:
+        if card in player.hand:
+            player.hand.remove(card)
+            game_state.discard_card(player, card)
+
+
+def war(game_state: "GameState", player: "PlayerState") -> None:
+    """Reveal until a card costing $3 or $4 is trashed."""
+
+    revealed = []
+    target = None
+
+    while True:
+        if not player.deck:
+            player.shuffle_discard_into_deck()
+        if not player.deck:
+            break
+        card = player.deck.pop()
+        revealed.append(card)
+        if card.cost.coins in (3, 4):
+            target = card
+            break
+
+    if target:
+        revealed.pop()
+        game_state.trash_card(player, target)
+        for card in revealed:
+            game_state.discard_card(player, card)
+    else:
+        for card in revealed:
+            game_state.discard_card(player, card)
+
+
+HEX_EFFECTS: dict[str, HexEffect] = {
+    "Bad Omens": bad_omens,
+    "Delusion": delusion,
+    "Envy": envy,
+    "Famine": famine,
+    "Fear": fear,
+    "Greed": greed,
+    "Haunting": haunting,
+    "Locusts": locusts,
+    "Misery": misery,
+    "Plague": plague,
+    "Poverty": poverty,
+    "War": war,
+}
+
+
+def create_hex_deck() -> list[str]:
+    """Return a shuffled list of Hex names for a new game."""
+
+    names = list(HEX_EFFECTS.keys())
+    random.shuffle(names)
+    return names
+
+
+def resolve_hex(name: str, game_state: "GameState", player: "PlayerState") -> None:
+    """Execute the Hex ``name`` for ``player`` if it exists."""
+
+    effect = HEX_EFFECTS.get(name)
+    if effect is not None:
+        effect(game_state, player)

--- a/tests/test_hexes.py
+++ b/tests/test_hexes.py
@@ -1,0 +1,114 @@
+from dominion.cards.nocturne.skulk import Skulk
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from dominion.hexes import resolve_hex
+from tests.utils import DummyAI
+
+
+class PlayAllTreasuresAI(DummyAI):
+    """AI that plays every available treasure in order."""
+
+    def choose_treasure(self, state, choices):
+        for choice in choices:
+            if choice is not None:
+                return choice
+        return None
+
+
+class DiscardLowestAI(DummyAI):
+    """AI that always discards the lowest value card presented."""
+
+    def choose_cards_to_discard(self, state, player, choices, count, *, reason=None):
+        return super().choose_cards_to_discard(state, player, choices, count)
+
+
+def make_state_with_player(ai=None):
+    player = PlayerState(ai or DummyAI())
+    state = GameState([player])
+    state.log_callback = lambda *_: None
+    return state, player
+
+
+def test_bad_omens_topdecks_coppers():
+    state, player = make_state_with_player()
+    player.deck = [get_card("Estate"), get_card("Silver"), get_card("Copper"), get_card("Copper")]
+    player.discard = [get_card("Gold")]
+
+    resolve_hex("Bad Omens", state, player)
+
+    assert [card.name for card in player.deck] == ["Copper", "Copper"]
+    assert sorted(card.name for card in player.discard) == ["Estate", "Gold", "Silver"]
+
+
+def test_delusion_blocks_action_buys():
+    state, player = make_state_with_player()
+    state.supply = {"Smithy": 10, "Silver": 10}
+    player.coins = 5
+
+    resolve_hex("Delusion", state, player)
+    assert player.deluded
+
+    state._handle_start_of_buy_phase_effects()
+
+    affordable = state._get_affordable_cards(player)
+    names = {card.name for card in affordable}
+    assert "Silver" in names
+    assert "Smithy" not in names
+    assert player.cannot_buy_actions
+
+
+def test_envy_reduces_silver_output():
+    state, player = make_state_with_player(PlayAllTreasuresAI())
+    state.supply = {}
+    player.hand = [get_card("Silver")]
+    player.envious = True
+
+    state.handle_treasure_phase()
+
+    assert player.coins == 1
+    assert not player.envious
+    assert player.envious_effect_active
+
+
+def test_misery_affects_scoring():
+    state, player = make_state_with_player()
+    player.hand = [get_card("Estate")]
+
+    resolve_hex("Misery", state, player)
+    resolve_hex("Misery", state, player)
+
+    assert player.misery == 2
+    assert player.get_victory_points(state) == -3
+
+
+def test_locusts_trashes_and_gains_cheaper_card():
+    state, player = make_state_with_player(DiscardLowestAI())
+    state.supply = {"Copper": 10, "Curse": 10}
+    player.deck = [get_card("Silver")]
+
+    resolve_hex("Locusts", state, player)
+
+    assert any(card.name == "Silver" for card in state.trash)
+    assert [card.name for card in player.discard] == ["Copper"]
+    assert state.supply["Copper"] == 9
+
+
+def test_skulk_hexes_all_targets_with_same_hex():
+    players = [PlayerState(DummyAI()) for _ in range(2)]
+    state = GameState(players)
+    state.log_callback = lambda *_: None
+    state.current_player_index = 0
+    state.supply = {"Copper": 10, "Curse": 10}
+    state.hex_deck = ["Greed"]
+
+    victim = players[1]
+    victim.deck = []
+    victim.discard = []
+
+    Skulk().play_effect(state)
+
+    assert victim.deck and victim.deck[-1].name == "Copper"
+    assert state.supply["Copper"] == 9
+    assert state.hex_deck == []
+    assert state.hex_discard == ["Greed"]


### PR DESCRIPTION
## Summary
- implement the full Hex system with reusable hex effects and a managed hex deck
- extend player and game state tracking for Deluded/Envious and Misery penalties
- update Skulk to share a single revealed Hex and add coverage for key hex behaviours

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc0e17c34c83278479b14d199c7124