### PR TITLE
Fix Prosperity card behaviors

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -96,6 +96,41 @@ class AI(ABC):
 
         return False
 
+    def should_discard_for_vault(self, state: GameState, player: PlayerState) -> bool:
+        """Decide if the player should discard two cards for Vault's reaction."""
+
+        low_value = [
+            card
+            for card in player.hand
+            if card.name == "Copper"
+            or card.name == "Curse"
+            or (card.is_victory and not card.is_action and card.cost.coins <= 2)
+        ]
+        return len(low_value) >= 2
+
+    def choose_watchtower_reaction(
+        self, state: GameState, player: PlayerState, gained_card: Card
+    ) -> Optional[str]:
+        """Return 'trash', 'topdeck', or ``None`` when revealing Watchtower."""
+
+        if gained_card.name == "Curse":
+            return "trash"
+        return None
+
+    def should_topdeck_with_royal_seal(
+        self, state: GameState, player: PlayerState, gained_card: Card
+    ) -> bool:
+        """Decide whether to topdeck a gain thanks to Royal Seal."""
+
+        return False
+
+    def order_cards_for_topdeck(
+        self, state: GameState, player: PlayerState, cards: list[Card]
+    ) -> list[Card]:
+        """Return cards in the order they should be placed back on the deck."""
+
+        return list(cards)
+
     def choose_way(self, state: GameState, card: Card, ways: list) -> Optional[object]:
         """Choose a Way to use when playing a card. Default is none."""
         return None

--- a/dominion/cards/prosperity/goons.py
+++ b/dominion/cards/prosperity/goons.py
@@ -15,9 +15,45 @@ class Goons(Card):
         player.goons_played += 1
 
         def attack_target(target):
+            if len(target.hand) <= 3:
+                return
+
+            discard_needed = len(target.hand) - 3
+            selected = target.ai.choose_cards_to_discard(
+                game_state, target, list(target.hand), discard_needed, reason="goons"
+            )
+
+            discarded: list = []
+            for card in selected[:discard_needed]:
+                if card in target.hand:
+                    target.hand.remove(card)
+                    game_state.discard_card(target, card)
+                    discarded.append(card)
+
+            # Fallback in case the AI declined to discard enough cards
+            def discard_priority(card):
+                if card.name == "Curse":
+                    return (0, card.name)
+                if card.is_victory and not card.is_action:
+                    return (1, card.cost.coins, card.name)
+                if card.name == "Copper":
+                    return (2, card.name)
+                return (3, card.cost.coins, card.name)
+
             while len(target.hand) > 3:
-                card = target.hand.pop()
+                card = min(target.hand, key=discard_priority)
+                target.hand.remove(card)
                 game_state.discard_card(target, card)
+                discarded.append(card)
+
+            if discarded:
+                context = {
+                    "discarded_cards": [c.name for c in discarded],
+                    "remaining_hand": [c.name for c in target.hand],
+                }
+                game_state.log_callback(
+                    ("action", target.ai.name, "discards to 3 cards due to Goons", context)
+                )
 
         for other in game_state.players:
             if other is player:

--- a/dominion/cards/prosperity/hoard.py
+++ b/dominion/cards/prosperity/hoard.py
@@ -11,10 +11,5 @@ class Hoard(Card):
         )
 
     def on_buy(self, game_state):
-        from ..registry import get_card
-
-        if game_state.supply.get("Gold", 0) > 0:
-            game_state.supply["Gold"] -= 1
-            gold = get_card("Gold")
-            player = game_state.current_player
-            game_state.gain_card(player, gold)
+        """Hoard's bonus is handled while resolving purchases in GameState."""
+        pass

--- a/dominion/cards/prosperity/loan.py
+++ b/dominion/cards/prosperity/loan.py
@@ -13,12 +13,28 @@ class Loan(Card):
     def play_effect(self, game_state):
         player = game_state.current_player
         revealed = []
+        revealed_treasure = None
         while player.deck or player.discard:
             if not player.deck:
                 player.shuffle_discard_into_deck()
+            if not player.deck:
+                break
             card = player.deck.pop()
             if card.is_treasure:
-                game_state.trash_card(player, card)
+                revealed_treasure = card
                 break
             revealed.append(card)
-        player.discard.extend(revealed)
+
+        if revealed:
+            player.discard.extend(revealed)
+
+        if revealed_treasure is None:
+            return
+
+        choice = player.ai.choose_card_to_trash(
+            game_state, [revealed_treasure, None]
+        )
+        if choice is revealed_treasure:
+            game_state.trash_card(player, revealed_treasure)
+        else:
+            game_state.discard_card(player, revealed_treasure)

--- a/dominion/cards/prosperity/mint.py
+++ b/dominion/cards/prosperity/mint.py
@@ -27,9 +27,9 @@ class Mint(Card):
             gained = get_card(chosen.name)
             game_state.gain_card(player, gained)
 
-    def on_gain(self, game_state, player):
-        super().on_gain(game_state, player)
-        treasures = [c for c in player.in_play if c.is_treasure]
-        for t in treasures:
-            player.in_play.remove(t)
-            game_state.trash_card(player, t)
+    def on_buy(self, game_state):
+        player = game_state.current_player
+        treasures = [c for c in list(player.in_play) if c.is_treasure]
+        for treasure in treasures:
+            player.in_play.remove(treasure)
+            game_state.trash_card(player, treasure)

--- a/dominion/cards/prosperity/rabble.py
+++ b/dominion/cards/prosperity/rabble.py
@@ -22,13 +22,22 @@ class Rabble(Card):
                     break
                 revealed.append(target.deck.pop())
 
-            to_discard = [c for c in revealed if c.is_action or c.is_treasure]
+            to_discard = [c for c in list(revealed) if c.is_action or c.is_treasure]
             for card in to_discard:
-                game_state.discard_card(target, card)
-                revealed.remove(card)
+                if card in revealed:
+                    revealed.remove(card)
+                    game_state.discard_card(target, card)
 
-            while revealed:
-                target.deck.append(revealed.pop())
+            if revealed:
+                ordered = target.ai.order_cards_for_topdeck(
+                    game_state, target, list(revealed)
+                )
+                if set(ordered) != set(revealed) or len(ordered) != len(revealed):
+                    ordered = revealed
+                for card in reversed(ordered):
+                    if card in revealed:
+                        revealed.remove(card)
+                        target.deck.append(card)
 
         for other in game_state.players:
             if other is player:

--- a/dominion/cards/prosperity/royal_seal.py
+++ b/dominion/cards/prosperity/royal_seal.py
@@ -12,6 +12,3 @@ class RoyalSeal(Card):
 
     def on_gain(self, game_state, player):
         super().on_gain(game_state, player)
-        if self in player.discard:
-            player.discard.remove(self)
-            player.deck.append(self)

--- a/dominion/cards/prosperity/talisman.py
+++ b/dominion/cards/prosperity/talisman.py
@@ -11,20 +11,5 @@ class Talisman(Card):
         )
 
     def on_buy(self, game_state):
-        from ..registry import get_card
-
-        player = game_state.current_player
-        affordable = [
-            name
-            for name, count in game_state.supply.items()
-            if count > 0 and get_card(name).cost.coins <= 4
-        ]
-        if not affordable:
-            return
-
-        gain_card = player.ai.choose_buy(game_state, [get_card(n) for n in affordable])
-        if gain_card is None:
-            gain_card = get_card(affordable[0])
-
-        game_state.supply[gain_card.name] -= 1
-        game_state.gain_card(player, gain_card)
+        """Extra gains from Talisman are handled during the buy phase."""
+        pass

--- a/dominion/cards/prosperity/trade_route.py
+++ b/dominion/cards/prosperity/trade_route.py
@@ -13,21 +13,13 @@ class TradeRoute(Card):
     def play_effect(self, game_state):
         player = game_state.current_player
 
-        from ..registry import get_card
-
-        mat_tokens = 0
-        for name, count in game_state.supply.items():
-            card = get_card(name)
-            if card.is_victory:
-                if count < card.starting_supply(game_state):
-                    mat_tokens += 1
-
+        mat_tokens = getattr(game_state, "trade_route_mat_tokens", 0)
         player.coins += mat_tokens
 
         if not player.hand:
             return
 
-        trash_choice = player.ai.choose_card_to_trash(game_state, player.hand + [None])
+        trash_choice = player.ai.choose_card_to_trash(game_state, list(player.hand) + [None])
         if trash_choice:
             player.hand.remove(trash_choice)
             game_state.trash_card(player, trash_choice)

--- a/dominion/cards/prosperity/watchtower.py
+++ b/dominion/cards/prosperity/watchtower.py
@@ -12,13 +12,5 @@ class Watchtower(Card):
 
     def play_effect(self, game_state):
         player = game_state.current_player
-        discard_count = len(player.hand)
-        player.discard.extend(player.hand)
-        player.hand = []
-        player.coins += discard_count
-
-    def on_gain(self, game_state, player):
-        super().on_gain(game_state, player)
-        if self in player.discard:
-            player.discard.remove(self)
-            player.deck.append(self)
+        while len(player.hand) < 6:
+            game_state.draw_cards(player, 1)

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -19,6 +19,8 @@ class GameState:
     turn_number: int = 1
     extra_turn: bool = False
     copper_value: int = 1
+    trade_route_tokens_on_piles: dict[str, bool] = field(default_factory=dict)
+    trade_route_mat_tokens: int = 0
 
     def __post_init__(self):
         """Initialize with default logger that prints to console."""
@@ -128,6 +130,17 @@ class GameState:
             for name, count in extras.items():
                 if name not in self.supply:
                     self.supply[name] = count
+
+        if any(card.name == "Trade Route" for card in kingdom_cards):
+            self.trade_route_tokens_on_piles = {}
+            self.trade_route_mat_tokens = 0
+            for name in self.supply:
+                card = get_card(name)
+                if card.is_victory:
+                    self.trade_route_tokens_on_piles[name] = True
+        else:
+            self.trade_route_tokens_on_piles = {}
+            self.trade_route_mat_tokens = 0
 
         self.log_callback(f"Supply initialized: {self.supply}")
 
@@ -404,7 +417,9 @@ class GameState:
                 self.supply[choice.name] -= 1
                 self.log_callback(("supply_change", choice.name, -1, self.supply[choice.name]))
                 choice.on_buy(self)
-                self.gain_card(player, choice)
+                gained_card = self.gain_card(player, choice)
+
+                self._handle_on_buy_in_play_effects(player, choice, gained_card)
 
                 if player.goons_played:
                     player.vp_tokens += player.goons_played
@@ -733,6 +748,10 @@ class GameState:
             player.discard.append(actual_card)
         actual_card.on_gain(self, player)
 
+        self._handle_trade_route_token(actual_card)
+        self._handle_watchtower_reaction(player, actual_card)
+        self._handle_royal_seal_reaction(player, actual_card)
+
         for project in player.projects:
             if hasattr(project, "on_gain"):
                 project.on_gain(self, player, actual_card)
@@ -788,6 +807,88 @@ class GameState:
             matches = [card for card in other.invested_exile if card.name == card_name]
             for _ in matches:
                 self.draw_cards(other, 2)
+
+    def _handle_on_buy_in_play_effects(
+        self, player: PlayerState, bought_card: Card, gained_card: Card
+    ) -> None:
+        """Resolve cards like Hoard and Talisman that watch purchases."""
+
+        if not player.in_play:
+            return
+
+        from ..cards.registry import get_card
+
+        hoard_count = sum(1 for card in player.in_play if card.name == "Hoard")
+        if hoard_count and gained_card.is_victory:
+            for _ in range(hoard_count):
+                if self.supply.get("Gold", 0) <= 0:
+                    break
+                self.supply["Gold"] -= 1
+                self.gain_card(player, get_card("Gold"))
+
+        talisman_count = sum(1 for card in player.in_play if card.name == "Talisman")
+        if talisman_count and not bought_card.is_victory and bought_card.cost.coins <= 4:
+            for _ in range(talisman_count):
+                if self.supply.get(bought_card.name, 0) <= 0:
+                    break
+                self.supply[bought_card.name] -= 1
+                self.gain_card(player, get_card(bought_card.name))
+
+    def _handle_trade_route_token(self, gained_card: Card) -> None:
+        """Move Trade Route tokens from piles to the mat when cards are gained."""
+
+        if not self.trade_route_tokens_on_piles:
+            return
+
+        if self.trade_route_tokens_on_piles.get(gained_card.name):
+            self.trade_route_tokens_on_piles[gained_card.name] = False
+            self.trade_route_mat_tokens += 1
+
+    def _handle_watchtower_reaction(self, player: PlayerState, gained_card: Card) -> None:
+        """Offer Watchtower reactions for gains."""
+
+        watchtowers = [card for card in player.hand if card.name == "Watchtower"]
+        if not watchtowers:
+            return
+
+        decision = player.ai.choose_watchtower_reaction(self, player, gained_card)
+        if decision not in {"trash", "topdeck"}:
+            return
+
+        if not self._remove_gained_card_from_zones(player, gained_card):
+            return
+
+        if decision == "trash":
+            self.trash_card(player, gained_card)
+        else:
+            player.deck.append(gained_card)
+
+    def _handle_royal_seal_reaction(self, player: PlayerState, gained_card: Card) -> None:
+        """Allow Royal Seal to topdeck newly gained cards."""
+
+        if not any(card.name == "Royal Seal" for card in player.in_play):
+            return
+
+        if not player.ai.should_topdeck_with_royal_seal(self, player, gained_card):
+            return
+
+        if self._remove_gained_card_from_zones(player, gained_card):
+            player.deck.append(gained_card)
+
+    @staticmethod
+    def _remove_gained_card_from_zones(player: PlayerState, card: Card) -> bool:
+        """Remove ``card`` from hand, discard, or deck if present."""
+
+        if card in player.discard:
+            player.discard.remove(card)
+            return True
+        if card in player.deck:
+            player.deck.remove(card)
+            return True
+        if card in player.hand:
+            player.hand.remove(card)
+            return True
+        return False
 
     def notify_invest(self, card_name: str, investing_player: PlayerState) -> None:
         """Notify players that an Invest event occurred for ``card_name``."""

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -1,0 +1,222 @@
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from tests.utils import DummyAI, TrashFirstAI
+
+
+def play_action(state: GameState, player: PlayerState, card_name: str) -> None:
+    card = next(card for card in player.hand if card.name == card_name)
+    player.hand.remove(card)
+    player.in_play.append(card)
+    card.on_play(state)
+
+
+class NoTrashAI(DummyAI):
+    def choose_card_to_trash(self, state, choices):
+        return None
+
+
+class BuyNamedCardAI(DummyAI):
+    def __init__(self, target_name: str):
+        super().__init__()
+        self.target_name = target_name
+
+    def choose_buy(self, state, choices):
+        for choice in choices:
+            if choice and choice.name == self.target_name:
+                return choice
+        return None
+
+
+class DeclineTrashAI(DummyAI):
+    def choose_card_to_trash(self, state, choices):
+        return None
+
+
+class VaultPlayerAI(DummyAI):
+    def choose_cards_to_discard(self, state, player, choices, count, *, reason=None):
+        return [card for card in choices if card.name == "Copper"]
+
+
+class VaultResponderAI(DummyAI):
+    def should_discard_for_vault(self, state, player):
+        return True
+
+    def choose_cards_to_discard(self, state, player, choices, count, *, reason=None):
+        return choices[:count]
+
+
+class WatchtowerTrashAI(DummyAI):
+    def choose_watchtower_reaction(self, state, player, gained_card):
+        return "trash"
+
+
+class RoyalSealTopdeckAI(DummyAI):
+    def should_topdeck_with_royal_seal(self, state, player, gained_card):
+        return True
+
+
+class ReverseTopdeckAI(DummyAI):
+    def order_cards_for_topdeck(self, state, player, cards):
+        return list(reversed(cards))
+
+
+def test_bishop_awards_vp_and_optional_trash():
+    trash_ai = TrashFirstAI()
+    skip_ai = NoTrashAI()
+
+    player = PlayerState(trash_ai)
+    other = PlayerState(skip_ai)
+    state = GameState([player, other])
+    state.setup_supply([get_card("Bishop")])
+
+    player.hand = [get_card("Bishop"), get_card("Silver")]
+    other.hand = [get_card("Estate")]
+
+    play_action(state, player, "Bishop")
+
+    assert player.vp_tokens == 2
+    assert any(card.name == "Estate" for card in other.hand)
+
+
+def test_hoard_gains_gold_on_victory_buy():
+    ai = BuyNamedCardAI("Province")
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([get_card("Hoard"), get_card("Province")])
+
+    player.in_play = [get_card("Hoard")]
+    player.coins = 8
+    player.buys = 1
+
+    state.handle_buy_phase()
+
+    gained_golds = [card for card in player.discard if card.name == "Gold"]
+    assert len(gained_golds) == 1
+
+
+def test_talisman_gains_copy_for_non_victory_purchase():
+    ai = BuyNamedCardAI("Village")
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([get_card("Talisman"), get_card("Village")])
+
+    player.in_play = [get_card("Talisman")]
+    player.coins = 3
+    player.buys = 1
+
+    state.handle_buy_phase()
+
+    villages = [card for card in player.discard if card.name == "Village"]
+    assert len(villages) == 2
+
+
+def test_loan_allows_declining_trash():
+    ai = DeclineTrashAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([get_card("Loan")])
+
+    player.deck = [get_card("Copper"), get_card("Estate")]
+    loan = get_card("Loan")
+    player.hand = [loan]
+
+    play_action(state, player, "Loan")
+
+    assert all(card.name != "Copper" for card in state.trash)
+    assert any(card.name == "Copper" for card in player.discard)
+
+
+def test_rabble_allows_reordering_revealed_cards():
+    attacker_ai = DummyAI()
+    defender_ai = ReverseTopdeckAI()
+
+    attacker = PlayerState(attacker_ai)
+    defender = PlayerState(defender_ai)
+    state = GameState([attacker, defender])
+    state.setup_supply([get_card("Rabble")])
+
+    defender.deck = [get_card("Estate"), get_card("Copper"), get_card("Duchy"), get_card("Estate")]
+
+    attacker.hand = [get_card("Rabble")]
+    play_action(state, attacker, "Rabble")
+
+    assert defender.deck[-1].name == "Duchy"
+    assert defender.deck[-2].name == "Estate"
+
+
+def test_royal_seal_can_topdeck_gains():
+    ai = RoyalSealTopdeckAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([get_card("Royal Seal"), get_card("Silver")])
+
+    player.in_play = [get_card("Royal Seal")]
+
+    state.supply["Silver"] -= 1
+    state.gain_card(player, get_card("Silver"))
+
+    assert any(card.name == "Silver" for card in player.deck)
+    assert all(card.name != "Silver" for card in player.discard)
+
+
+def test_trade_route_tracks_tokens_and_mat_value():
+    ai = DummyAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([get_card("Trade Route")])
+
+    state.supply["Estate"] -= 1
+    state.gain_card(player, get_card("Estate"))
+    state.supply["Duchy"] -= 1
+    state.gain_card(player, get_card("Duchy"))
+
+    assert state.trade_route_mat_tokens == 2
+
+    player.hand = [get_card("Trade Route")]
+    play_action(state, player, "Trade Route")
+
+    assert player.coins == 2
+
+
+def test_vault_discard_choices_and_reaction():
+    player_ai = VaultPlayerAI()
+    responder_ai = VaultResponderAI()
+
+    player = PlayerState(player_ai)
+    responder = PlayerState(responder_ai)
+    state = GameState([player, responder])
+    state.setup_supply([get_card("Vault")])
+
+    player.hand = [get_card("Vault"), get_card("Copper"), get_card("Estate")]
+    responder.hand = [get_card("Copper"), get_card("Estate"), get_card("Silver")]
+    responder.deck = [get_card("Estate")]
+
+    play_action(state, player, "Vault")
+
+    assert player.coins == 1
+    assert all(card.name != "Copper" for card in player.hand)
+    assert len(responder.hand) == 2
+
+
+def test_watchtower_draws_to_six_and_can_trash_gains():
+    draw_ai = DummyAI()
+    reaction_ai = WatchtowerTrashAI()
+
+    player = PlayerState(draw_ai)
+    reactor = PlayerState(reaction_ai)
+    state = GameState([player, reactor])
+    state.setup_supply([get_card("Watchtower"), get_card("Estate")])
+
+    player.deck = [get_card("Copper") for _ in range(6)]
+    player.hand = [get_card("Watchtower")]
+    play_action(state, player, "Watchtower")
+
+    assert len(player.hand) == 6
+
+    reactor.hand = [get_card("Watchtower")]
+    state.supply["Estate"] -= 1
+    state.gain_card(reactor, get_card("Estate"))
+
+    assert any(card.name == "Estate" for card in state.trash)
+

--- a/tests/test_trashing_cards.py
+++ b/tests/test_trashing_cards.py
@@ -30,7 +30,7 @@ def test_expand_trashes_card_and_triggers_on_trash():
     assert len(player.hand) == 1  # drew back up to one card
 
 
-def test_mint_on_gain_trashes_treasures_in_play():
+def test_mint_on_buy_trashes_treasures_in_play():
     ai = TrashFirstAI()
     player = PlayerState(ai)
     state = GameState([player])
@@ -38,7 +38,7 @@ def test_mint_on_gain_trashes_treasures_in_play():
 
     player.in_play = [get_card("Copper"), get_card("Silver")]
     mint = get_card("Mint")
-    mint.on_gain(state, player)
+    mint.on_buy(state)
 
     assert len(state.trash) == 2
     assert not player.in_play


### PR DESCRIPTION
## Summary
- correct the implementations of key Prosperity kingdom cards and related reactions
- add support methods in the base AI and game state to handle new choices and triggers
- cover the updated behaviours with dedicated prosperity-focused unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc097100fc832788b6dccb8a9b9f62