### PR TITLE
Fix Plunder treasure behavior

### DIFF
--- a/dominion/cards/empires/plunder.py
+++ b/dominion/cards/empires/plunder.py
@@ -14,7 +14,17 @@ class Plunder(BottomSplitPileCard):
         )
 
     def play_effect(self, game_state):
-        pass
+        player = game_state.current_player
+
+        if game_state.supply.get("Gold", 0) <= 0:
+            return
+
+        game_state.supply["Gold"] -= 1
+
+        from ..registry import get_card
+
+        gold = get_card("Gold")
+        game_state.gain_card(player, gold, to_deck=True)
 
     def on_gain(self, game_state, player):
         super().on_gain(game_state, player)

--- a/tests/test_plunder_card.py
+++ b/tests/test_plunder_card.py
@@ -1,0 +1,53 @@
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+from tests.utils import DummyAI
+
+
+def _make_state_with_player() -> tuple[GameState, PlayerState]:
+    player = PlayerState(DummyAI())
+    state = GameState(players=[player])
+    return state, player
+
+
+def test_plunder_gain_also_gains_gold():
+    state, player = _make_state_with_player()
+    plunder = get_card("Plunder")
+
+    state.supply[plunder.name] = 1
+    state.supply["Gold"] = 5
+
+    state.supply[plunder.name] -= 1
+    state.gain_card(player, plunder)
+
+    assert any(card.name == "Gold" for card in player.discard)
+    assert state.supply["Gold"] == 4
+
+
+def test_plunder_play_topdecks_gold():
+    state, player = _make_state_with_player()
+    plunder = get_card("Plunder")
+
+    state.supply["Gold"] = 5
+    player.deck = [get_card("Estate")]
+
+    plunder.on_play(state)
+
+    assert player.deck[0].name == "Gold"
+    assert len(player.deck) == 2
+    assert player.deck[1].name == "Estate"
+    assert state.supply["Gold"] == 4
+
+
+def test_plunder_play_does_nothing_when_gold_empty():
+    state, player = _make_state_with_player()
+    plunder = get_card("Plunder")
+
+    state.supply["Gold"] = 0
+    player.deck = []
+
+    plunder.on_play(state)
+
+    assert player.deck == []
+    assert state.supply["Gold"] == 0


### PR DESCRIPTION
## Summary
- implement Plunder's on-play effect so it gains a Gold to the top of your deck when available
- add focused tests covering Plunder's on-play and on-gain Gold interactions, including supply exhaustion

## Testing
- pytest tests/test_plunder_card.py

------
https://chatgpt.com/codex/tasks/task_e_68dc1ebb8c1c83279faa41daefbab05b