### PR TITLE
Fix Dark Ages card supply handling

### DIFF
--- a/dominion/cards/dark_ages/marauder.py
+++ b/dominion/cards/dark_ages/marauder.py
@@ -19,9 +19,16 @@ class Marauder(Card):
         from ..registry import get_card
 
         player = game_state.current_player
-        player.hand.append(get_card("Spoils"))
+
+        if game_state.supply.get("Spoils", 0) > 0:
+            game_state.supply["Spoils"] -= 1
+            game_state.gain_card(player, get_card("Spoils"))
 
         def attack_target(target):
+            if game_state.supply.get("Ruins", 0) <= 0:
+                return
+
+            game_state.supply["Ruins"] -= 1
             ruin = get_card("Ruins")
             game_state.gain_card(target, ruin)
 

--- a/dominion/cards/dark_ages/rats.py
+++ b/dominion/cards/dark_ages/rats.py
@@ -14,9 +14,10 @@ class Rats(Card):
         player = game_state.current_player
         # Gain another Rats if available
         if game_state.supply.get("Rats", 0) > 0:
-            gained = Rats()
             game_state.supply["Rats"] -= 1
-            game_state.gain_card(player, gained)
+            from ..registry import get_card
+
+            game_state.gain_card(player, get_card("Rats"))
         # Trash a non-Rats card from hand if possible
         choices = [c for c in player.hand if c.name != "Rats"]
         if choices:

--- a/tests/test_iron_barbarian_cards.py
+++ b/tests/test_iron_barbarian_cards.py
@@ -25,9 +25,15 @@ def test_marauder_gives_spoils_and_ruins():
     state = make_state(num_players=2, kingdom=[get_card("Marauder")])
     player, opponent = state.players
     marauder = get_card("Marauder")
+    spoils_before = state.supply["Spoils"]
+    ruins_before = state.supply["Ruins"]
+
     marauder.on_play(state)
-    assert any(card.name == "Spoils" for card in player.hand)
+
+    assert any(card.name == "Spoils" for card in player.discard)
     assert any(card.name == "Ruins" for card in opponent.discard)
+    assert state.supply["Spoils"] == spoils_before - 1
+    assert state.supply["Ruins"] == ruins_before - 1
 
 
 def test_innovation_plays_first_gained_action():

--- a/tests/test_trashing_cards.py
+++ b/tests/test_trashing_cards.py
@@ -74,3 +74,37 @@ def test_forager_trashes_card():
 
     assert any(c.name == "Rats" for c in state.trash)
     assert len(player.hand) == 1  # Rats drew a card on trash
+
+
+def test_rats_gains_respect_supply():
+    ai = TrashFirstAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([get_card("Rats")])
+
+    player.deck = []
+    player.discard = []
+    player.in_play = []
+    player.hand = [get_card("Rats")]
+
+    rats_supply_before = state.supply["Rats"]
+    play_action(state, player, player.hand[0])
+
+    assert state.supply["Rats"] == rats_supply_before - 1
+    assert player.count("Rats") == 2  # original copy plus the gained one
+
+    other_ai = TrashFirstAI()
+    other_player = PlayerState(other_ai)
+    empty_state = GameState([other_player])
+    empty_state.setup_supply([get_card("Rats")])
+    empty_state.supply["Rats"] = 0
+
+    other_player.deck = []
+    other_player.discard = []
+    other_player.in_play = []
+    other_player.hand = [get_card("Rats")]
+
+    play_action(empty_state, other_player, other_player.hand[0])
+
+    assert empty_state.supply["Rats"] == 0
+    assert other_player.count("Rats") == 1  # only the original copy remains


### PR DESCRIPTION
## Summary
- ensure Marauder and Rats gain cards from their supply piles and attack piles correctly
- add coverage for the new supply-sensitive behaviour in Marauder and Rats tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc1ea4568c8327ab8b324f0521697f