### PR TITLE
Fix Taskmaster duration trigger

### DIFF
--- a/dominion/cards/allies/taskmaster.py
+++ b/dominion/cards/allies/taskmaster.py
@@ -17,8 +17,14 @@ class Taskmaster(Card):
 
     def on_duration(self, game_state):
         player = game_state.current_player
+
+        if not getattr(player, "gained_five_last_turn", False):
+            self.duration_persistent = False
+            return
+
         if not player.ignore_action_bonuses:
             player.actions += 1
         player.coins += 1
 
-        self.duration_persistent = getattr(player, "gained_five_last_turn", False)
+        # Keep Taskmaster in play to potentially trigger again next turn.
+        self.duration_persistent = True

--- a/tests/test_taskmaster.py
+++ b/tests/test_taskmaster.py
@@ -23,8 +23,8 @@ def test_taskmaster_leaves_without_five_cost_gain():
 
     state.do_duration_phase()
 
-    assert player.actions == 1
-    assert player.coins == 1
+    assert player.actions == 0
+    assert player.coins == 0
     assert taskmaster not in player.duration
     assert taskmaster in player.discard
 
@@ -55,7 +55,7 @@ def test_taskmaster_persists_across_consecutive_five_cost_gains():
     player.gained_five_last_turn = False
     state.do_duration_phase()
 
-    assert player.actions == 3
-    assert player.coins == 3
+    assert player.actions == 2
+    assert player.coins == 2
     assert taskmaster not in player.duration
     assert player.discard == [taskmaster]


### PR DESCRIPTION
## Summary
- update Taskmaster so its duration effect only resolves when a $5-cost card was gained on the previous turn
- keep Taskmaster in play only when the condition is met so it can repeat correctly on later turns
- adjust Taskmaster tests to cover the corrected behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddf47108e48327a8dad2ab09399901