### PR TITLE
Fix Quarry and Talisman treasure stats

### DIFF
--- a/dominion/cards/prosperity/quarry.py
+++ b/dominion/cards/prosperity/quarry.py
@@ -6,7 +6,7 @@ class Quarry(Card):
         super().__init__(
             name="Quarry",
             cost=CardCost(coins=4),
-            stats=CardStats(coins=1, buys=1),
+            stats=CardStats(coins=1),
             types=[CardType.TREASURE],
         )
 

--- a/dominion/cards/prosperity/talisman.py
+++ b/dominion/cards/prosperity/talisman.py
@@ -6,7 +6,7 @@ class Talisman(Card):
         super().__init__(
             name="Talisman",
             cost=CardCost(coins=4),
-            stats=CardStats(coins=1, buys=1),
+            stats=CardStats(coins=1),
             types=[CardType.TREASURE],
         )
 


### PR DESCRIPTION
## Summary
- correct Quarry to only provide +$1 while in play
- correct Talisman to no longer grant an extra buy when played

## Testing
- pytest tests/test_prosperity_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68ddfa699b308327a05fd88bb8b3f648