### PR TITLE
Fix Barbarian replacement behavior

### DIFF
--- a/dominion/cards/plunder/barbarian.py
+++ b/dominion/cards/plunder/barbarian.py
@@ -31,7 +31,7 @@ class Barbarian(Card):
 
             if cost >= 3:
                 shared_types = set(revealed.types)
-                candidates = []
+                candidates: list[Card] = []
                 for name, count in game_state.supply.items():
                     if count <= 0:
                         continue
@@ -43,8 +43,6 @@ class Barbarian(Card):
                     gain = candidates[0]
                     game_state.supply[gain.name] -= 1
                     game_state.gain_card(target, gain)
-                else:
-                    game_state.give_curse_to_player(target)
             else:
                 game_state.give_curse_to_player(target)
 

--- a/tests/test_iron_barbarian_cards.py
+++ b/tests/test_iron_barbarian_cards.py
@@ -89,3 +89,21 @@ def test_barbarian_trashes_and_replaces():
     barbarian.on_play(state)
     assert any(card.name == "Copper" for card in opponent.discard)
     assert any(card.name == "Silver" for card in state.trash)
+
+
+def test_barbarian_does_not_curse_without_valid_replacement():
+    state = make_state(num_players=2, kingdom=[get_card("Barbarian")])
+    player, opponent = state.players
+    opponent.deck = [get_card("Gold")]
+    opponent.discard = []
+    barbarian = get_card("Barbarian")
+
+    for name in ["Copper", "Silver", "Gold"]:
+        state.supply[name] = 0
+    state.supply["Curse"] = 10
+
+    barbarian.on_play(state)
+
+    assert not opponent.discard
+    assert state.supply["Curse"] == 10
+    assert any(card.name == "Gold" for card in state.trash)


### PR DESCRIPTION
## Summary
- prevent Barbarian from handing out a Curse when no cheaper shared-type replacement exists
- add coverage ensuring the attack leaves opponents alone when the supply lacks valid targets

## Testing
- pytest tests/test_iron_barbarian_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68de97a922148327b06269ea3c491693