### PR TITLE
Fix Empires treasure card classifications

### DIFF
--- a/dominion/cards/empires/capital.py
+++ b/dominion/cards/empires/capital.py
@@ -2,16 +2,15 @@ from ..base_card import Card, CardCost, CardStats, CardType
 
 
 class Capital(Card):
-    """Simplified Capital that provides a burst of coins."""
+    """Simplified Capital Treasure that ignores debt effects."""
 
     def __init__(self):
         super().__init__(
             name="Capital",
             cost=CardCost(coins=5),
             stats=CardStats(coins=6, buys=1),
-            types=[CardType.ACTION],
+            types=[CardType.TREASURE],
         )
 
     def play_effect(self, game_state):
-        # Debt mechanics are not modelled; no extra handling required.
         pass

--- a/dominion/cards/empires/charm.py
+++ b/dominion/cards/empires/charm.py
@@ -2,12 +2,12 @@ from ..base_card import Card, CardCost, CardStats, CardType
 
 
 class Charm(Card):
-    """Simplified Charm providing flexible economy."""
+    """Simplified Charm implemented as a Treasure providing economy."""
 
     def __init__(self):
         super().__init__(
             name="Charm",
             cost=CardCost(coins=5),
             stats=CardStats(coins=2, buys=1),
-            types=[CardType.ACTION],
+            types=[CardType.TREASURE],
         )

--- a/tests/test_empires_card_types.py
+++ b/tests/test_empires_card_types.py
@@ -1,0 +1,14 @@
+from dominion.cards.base_card import CardType
+from dominion.cards.registry import get_card
+
+
+def test_charm_is_treasure_not_action():
+    charm = get_card("Charm")
+    assert CardType.TREASURE in charm.types
+    assert CardType.ACTION not in charm.types
+
+
+def test_capital_is_treasure_not_action():
+    capital = get_card("Capital")
+    assert CardType.TREASURE in capital.types
+    assert CardType.ACTION not in capital.types


### PR DESCRIPTION
## Summary
- correct Empires' Capital and Charm cards to be treated as Treasures instead of Actions
- add regression tests that assert the corrected type assignments

## Testing
- pytest tests/test_empires_card_types.py

------
https://chatgpt.com/codex/tasks/task_e_68de9a4f89d08327a1fbb6c3b8b3604d