### PR TITLE
Fix Engineer gain logic and add tests

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -34,6 +34,18 @@ class AI(ABC):
         """Choose a card to trash from available choices."""
         pass
 
+    def should_trash_engineer_for_extra_gains(
+        self, state: GameState, player: PlayerState, engineer: Card
+    ) -> bool:
+        """Decide whether to trash Engineer to gain two additional cards.
+
+        The default behaviour is conservative and keeps the Engineer in play,
+        ensuring existing AIs retain their previous behaviour unless they
+        explicitly opt in to the extra gains.
+        """
+
+        return False
+
     def should_reveal_moat(self, state: GameState, player: PlayerState) -> bool:
         """Decide whether to reveal Moat in response to an attack."""
 

--- a/dominion/cards/empires/engineer.py
+++ b/dominion/cards/empires/engineer.py
@@ -14,14 +14,45 @@ class Engineer(Card):
         player = game_state.current_player
         from ..registry import get_card
 
-        affordable = [
-            name
-            for name, count in game_state.supply.items()
-            if count > 0 and get_card(name).cost.coins <= 4
-        ]
-        if not affordable:
+        def affordable_cards() -> list[Card]:
+            cards: list[Card] = []
+            for name, count in game_state.supply.items():
+                if count <= 0:
+                    continue
+                candidate = get_card(name)
+                if candidate.cost.coins <= 4:
+                    cards.append(candidate)
+            cards.sort(key=lambda c: (c.cost.coins, c.name), reverse=True)
+            return cards
+
+        def gain_from_choices(choices: list[Card]):
+            if not choices:
+                return None
+            choice = player.ai.choose_buy(game_state, choices)
+            if choice not in choices:
+                choice = choices[0]
+            game_state.supply[choice.name] -= 1
+            game_state.gain_card(player, choice)
+            return choice
+
+        choices = affordable_cards()
+        if not choices:
             return
-        gain_name = affordable[0]
-        gain = get_card(gain_name)
-        game_state.supply[gain_name] -= 1
-        game_state.gain_card(player, gain)
+        gain_from_choices(choices)
+
+        if self not in player.in_play:
+            return
+
+        if not player.ai.should_trash_engineer_for_extra_gains(
+            game_state, player, self
+        ):
+            return
+
+        player.in_play.remove(self)
+        game_state.trash_card(player, self)
+
+        for _ in range(2):
+            extra_choices = affordable_cards()
+            if not extra_choices:
+                break
+            gain_from_choices(extra_choices)

--- a/tests/test_engineer_card.py
+++ b/tests/test_engineer_card.py
@@ -1,0 +1,91 @@
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+from tests.utils import DummyAI
+
+
+class EngineerTestAI(DummyAI):
+    """Test double that scripts Engineer gain choices."""
+
+    def __init__(self, gain_queue: list[str], *, trash_engineer: bool):
+        super().__init__()
+        self._gain_queue = list(gain_queue)
+        self._trash_engineer = trash_engineer
+
+    def choose_buy(self, state: GameState, choices):
+        while self._gain_queue:
+            target = self._gain_queue.pop(0)
+            for card in choices:
+                if card and card.name == target:
+                    return card
+        return choices[0] if choices else None
+
+    def should_trash_engineer_for_extra_gains(self, state, player, engineer):
+        return self._trash_engineer
+
+
+class NullChoiceAI(DummyAI):
+    """AI stub that never makes an explicit gain choice."""
+
+    def choose_buy(self, state: GameState, choices):
+        return None
+
+
+def _make_state(ai: DummyAI) -> tuple[GameState, PlayerState]:
+    player = PlayerState(ai)
+    state = GameState(players=[player])
+    state.log_callback = lambda msg: None
+    state.supply = {}
+    return state, player
+
+
+def test_engineer_gains_selected_card_without_trashing():
+    ai = EngineerTestAI(["Silver"], trash_engineer=False)
+    state, player = _make_state(ai)
+
+    state.supply.update({"Silver": 5, "Estate": 8})
+
+    engineer = get_card("Engineer")
+    player.in_play = [engineer]
+
+    engineer.play_effect(state)
+
+    assert [card.name for card in player.discard] == ["Silver"]
+    assert state.supply["Silver"] == 4
+    assert engineer in player.in_play
+    assert engineer not in state.trash
+
+
+def test_engineer_can_trash_for_two_additional_gains():
+    ai = EngineerTestAI(["Silver", "Village", "Workshop"], trash_engineer=True)
+    state, player = _make_state(ai)
+
+    state.supply.update({"Silver": 5, "Village": 5, "Workshop": 5})
+
+    engineer = get_card("Engineer")
+    player.in_play = [engineer]
+
+    engineer.play_effect(state)
+
+    assert [card.name for card in player.discard] == ["Silver", "Village", "Workshop"]
+    assert state.supply["Silver"] == 4
+    assert state.supply["Village"] == 4
+    assert state.supply["Workshop"] == 4
+    assert engineer not in player.in_play
+    assert state.trash and state.trash[-1] is engineer
+
+
+def test_engineer_defaults_to_best_available_gain_when_ai_abstains():
+    ai = NullChoiceAI()
+    state, player = _make_state(ai)
+
+    state.supply.update({"Silver": 5, "Estate": 8, "Copper": 46})
+
+    engineer = get_card("Engineer")
+    player.in_play = [engineer]
+
+    engineer.play_effect(state)
+
+    assert [card.name for card in player.discard] == ["Silver"]
+    assert state.supply["Silver"] == 4


### PR DESCRIPTION
## Summary
- implement the Engineer card's gain logic so it respects player choice and its optional trash-for-more ability
- add an AI hook to decide when to trash Engineer for the extra gains
- cover the corrected behaviour with new unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de9a33ac008327a68a261d176de73d