### PR TITLE
Implement full Charm card behavior

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -34,6 +34,15 @@ class AI(ABC):
         """Choose a card to trash from available choices."""
         pass
 
+    def choose_charm_option(self, state: GameState, player: PlayerState, options: list[str]) -> str:
+        """Select which of Charm's modes to use when played."""
+
+        if "gain" in options:
+            return "gain"
+        if "coins" in options:
+            return "coins"
+        return options[0] if options else "coins"
+
     def should_reveal_moat(self, state: GameState, player: PlayerState) -> bool:
         """Decide whether to reveal Moat in response to an attack."""
 

--- a/dominion/cards/empires/charm.py
+++ b/dominion/cards/empires/charm.py
@@ -2,12 +2,51 @@ from ..base_card import Card, CardCost, CardStats, CardType
 
 
 class Charm(Card):
-    """Simplified Charm providing flexible economy."""
+    """Full implementation of Charm's flexible choices."""
+
+    COIN_OPTION = "coins"
+    GAIN_OPTION = "gain"
+    COPY_NEXT_BUY_OPTION = "copy_next_buy"
 
     def __init__(self):
         super().__init__(
             name="Charm",
             cost=CardCost(coins=5),
-            stats=CardStats(coins=2, buys=1),
+            stats=CardStats(buys=1),
             types=[CardType.ACTION],
         )
+
+    def play_effect(self, game_state):
+        """Offer Charm's choice of coin, gain, or duplicating the next buy."""
+
+        player = game_state.current_player
+
+        from ..registry import get_card  # Local import to avoid circular dependency
+
+        gainable_cards = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            card = get_card(name)
+            if card.is_victory or card.cost.coins > 4 or card.cost.potions > 0:
+                continue
+            gainable_cards.append(card)
+
+        options = [self.COIN_OPTION]
+        if gainable_cards:
+            options.append(self.GAIN_OPTION)
+        options.append(self.COPY_NEXT_BUY_OPTION)
+
+        choice = player.ai.choose_charm_option(game_state, player, options)
+        if choice not in options:
+            choice = options[0]
+
+        if choice == self.GAIN_OPTION and gainable_cards:
+            gain_choice = player.ai.choose_buy(game_state, gainable_cards + [None])
+            if gain_choice:
+                game_state.supply[gain_choice.name] -= 1
+                game_state.gain_card(player, gain_choice)
+        elif choice == self.COPY_NEXT_BUY_OPTION:
+            player.charm_next_buy_copies = getattr(player, "charm_next_buy_copies", 0) + 1
+        else:
+            player.coins += 2

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -198,6 +198,7 @@ class GameState:
         player.coins_spent_this_turn = 0
         player.banned_buys = []
         player.topdeck_gains = False
+        player.charm_next_buy_copies = 0
         player.cannot_buy_actions = False
         player.envious_effect_active = False
 
@@ -460,6 +461,15 @@ class GameState:
                     player.vp_tokens += player.goons_played
 
                 self._trigger_haggler_bonus(player, choice)
+
+                if getattr(player, "charm_next_buy_copies", 0):
+                    copies_to_gain = min(
+                        player.charm_next_buy_copies, self.supply.get(choice.name, 0)
+                    )
+                    for _ in range(copies_to_gain):
+                        self.supply[choice.name] -= 1
+                        self.gain_card(player, get_card(choice.name))
+                    player.charm_next_buy_copies = 0
 
         self.phase = "cleanup"
 

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -52,6 +52,7 @@ class PlayerState:
     cauldron_triggered: bool = False
     trickster_uses_remaining: int = 0
     trickster_set_aside: list[Card] = field(default_factory=list)
+    charm_next_buy_copies: int = 0
 
     # Turn tracking
     turns_taken: int = 0
@@ -123,6 +124,7 @@ class PlayerState:
         self.cauldron_triggered = False
         self.trickster_uses_remaining = 0
         self.trickster_set_aside = []
+        self.charm_next_buy_copies = 0
         self.turns_taken = 0
         self.actions_played = 0
         self.actions_this_turn = 0

--- a/tests/test_charm_card.py
+++ b/tests/test_charm_card.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from dominion.cards.base_card import Card
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from tests.utils import DummyAI
+
+
+def make_state(ai: DummyAI) -> tuple[GameState, PlayerState]:
+    player = PlayerState(ai)
+    state = GameState(players=[player])
+    state.log_callback = lambda *args, **kwargs: None
+    return state, player
+
+
+class CharmCoinsAI(DummyAI):
+    def choose_charm_option(self, state: GameState, player: PlayerState, options: list[str]) -> str:
+        return "coins"
+
+
+def test_charm_coin_option_adds_two_coins():
+    state, player = make_state(CharmCoinsAI())
+    charm = get_card("Charm")
+
+    player.coins = 0
+
+    charm.play_effect(state)
+
+    assert player.coins == 2
+
+
+class CharmGainAI(DummyAI):
+    def choose_charm_option(self, state: GameState, player: PlayerState, options: list[str]) -> str:
+        return "gain"
+
+    def choose_buy(self, state: GameState, choices: list[Optional[Card]]):
+        for choice in choices:
+            if choice is not None:
+                return choice
+        return None
+
+
+def test_charm_gain_option_only_allows_non_victory_cards():
+    state, player = make_state(CharmGainAI())
+    charm = get_card("Charm")
+
+    state.supply = {"Silver": 5, "Estate": 5}
+
+    charm.play_effect(state)
+
+    assert state.supply["Silver"] == 4
+    assert state.supply["Estate"] == 5
+    assert any(card.name == "Silver" for card in player.discard)
+
+
+class CharmCopyAI(DummyAI):
+    def __init__(self):
+        super().__init__()
+        self._buy_used = False
+
+    def choose_charm_option(self, state: GameState, player: PlayerState, options: list[str]) -> str:
+        return "copy_next_buy"
+
+    def choose_buy(self, state: GameState, choices: list[Optional[Card]]):
+        if not self._buy_used:
+            for choice in choices:
+                if choice is not None and getattr(choice, "is_event", False) is False:
+                    if choice.name == "Silver":
+                        self._buy_used = True
+                        return choice
+        return None
+
+
+def test_charm_copy_option_duplicates_next_purchase():
+    state, player = make_state(CharmCopyAI())
+    charm = get_card("Charm")
+
+    state.supply = {"Silver": 5}
+    player.coins = 3
+    player.buys = 1
+
+    charm.play_effect(state)
+
+    state.handle_buy_phase()
+
+    assert player.charm_next_buy_copies == 0
+    assert state.supply["Silver"] == 3
+    gained_silvers = [card for card in player.discard if card.name == "Silver"]
+    assert len(gained_silvers) == 2


### PR DESCRIPTION
## Summary
- implement Charm's choice-driven behavior including gaining, coin, and copy effects
- track pending Charm gains through the buy phase and expose an AI hook for the decision
- add regression tests covering each Charm option

## Testing
- pytest tests/test_charm_card.py

------
https://chatgpt.com/codex/tasks/task_e_68de9c1bcdcc8327aace064d07479cea