### PR TITLE
Use AI selection when Hammer gains cards

### DIFF
--- a/dominion/cards/plunder/loot_cards.py
+++ b/dominion/cards/plunder/loot_cards.py
@@ -91,15 +91,23 @@ class Hammer(Loot):
         player = game_state.current_player
         from ..registry import get_card
 
-        affordable = [
-            name
-            for name, count in game_state.supply.items()
-            if count > 0 and get_card(name).cost.coins <= 4
-        ]
-        if affordable:
-            gain = get_card(affordable[0])
-            game_state.supply[gain.name] -= 1
-            game_state.gain_card(player, gain)
+        affordable_cards = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            card = get_card(name)
+            if card.cost.coins <= 4:
+                affordable_cards.append(card)
+
+        if not affordable_cards:
+            return
+
+        gain = player.ai.choose_buy(game_state, affordable_cards + [None])
+        if gain not in affordable_cards:
+            gain = affordable_cards[0]
+
+        game_state.supply[gain.name] -= 1
+        game_state.gain_card(player, gain)
 
 
 class Insignia(Loot):

--- a/tests/test_hammer_loot.py
+++ b/tests/test_hammer_loot.py
@@ -1,0 +1,38 @@
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+from tests.utils import DummyAI
+
+
+class HammerChoiceAI(DummyAI):
+    def __init__(self, target: str):
+        super().__init__()
+        self._target = target
+
+    def choose_buy(self, state, choices):
+        for card in choices:
+            if card is not None and card.name == self._target:
+                return card
+        return None
+
+
+def _make_state(ai: DummyAI):
+    player = PlayerState(ai)
+    state = GameState(players=[player])
+    state.log_callback = lambda msg: None
+    state.supply = {}
+    return state, player
+
+
+def test_hammer_gains_card_selected_by_ai():
+    ai = HammerChoiceAI("Village")
+    state, player = _make_state(ai)
+
+    state.supply.update({"Village": 5, "Silver": 5})
+
+    hammer = get_card("Hammer")
+    hammer.play_effect(state)
+
+    assert [card.name for card in player.discard] == ["Village"]
+    assert state.supply["Village"] == 4


### PR DESCRIPTION
## Summary
- update Hammer loot to gather affordable piles, consult the AI's buy choice, and fall back to a default when needed
- add a regression test that ensures Hammer gains the pile chosen by the AI

## Testing
- pytest tests/test_hammer_loot.py

------
https://chatgpt.com/codex/tasks/task_e_68dea01e00088327b984723a7ffa363b