### PR TITLE
Refine Sword discard targeting

### DIFF
--- a/dominion/cards/plunder/loot_cards.py
+++ b/dominion/cards/plunder/loot_cards.py
@@ -255,9 +255,34 @@ class Sword(Loot):
         player = game_state.current_player
 
         def discard_to_four(target):
-            while len(target.hand) > 4:
-                discard = target.hand.pop(0)
-                game_state.discard_card(target, discard)
+            if len(target.hand) <= 4:
+                return
+
+            discard_count = len(target.hand) - 4
+            choices = list(target.hand)
+            selected = target.ai.choose_cards_to_discard(
+                game_state,
+                target,
+                choices,
+                discard_count,
+                reason="sword",
+            )
+
+            remaining_choices = list(choices)
+            selected_cards = []
+
+            for card in selected:
+                if card in remaining_choices:
+                    remaining_choices.remove(card)
+                    selected_cards.append(card)
+
+            while len(selected_cards) < discard_count and remaining_choices:
+                selected_cards.append(remaining_choices.pop(0))
+
+            for card in selected_cards:
+                if card in target.hand:
+                    target.hand.remove(card)
+                    game_state.discard_card(target, card)
 
         for other in game_state.players:
             if other is player:

--- a/tests/test_loot_cards.py
+++ b/tests/test_loot_cards.py
@@ -33,3 +33,30 @@ def test_shield_blocks_witch_attack():
     state.handle_action_phase()
 
     assert not any(c.name == "Curse" for c in p2.discard)
+
+
+def test_sword_attack_discards_low_value_cards_first():
+    attacker = ChooseFirstActionAI()
+    defender = ChooseFirstActionAI()
+    state = GameState(players=[])
+    state.initialize_game([attacker, defender], [get_card("Sword")])
+
+    sword = get_card("Sword")
+    gold = get_card("Gold")
+    province = get_card("Province")
+    silver = get_card("Silver")
+    estate = get_card("Estate")
+    copper = get_card("Copper")
+
+    attacker_state, defender_state = state.players
+    state.current_player_index = 0
+    attacker_state.hand = [sword]
+    defender_state.hand = [gold, province, silver, estate, copper]
+    defender_state.discard = []
+
+    sword.play_effect(state)
+
+    assert len(defender_state.hand) == 4
+    assert any(card.name == "Estate" for card in defender_state.discard)
+    assert all(card.name != "Gold" for card in defender_state.discard)
+    assert any(card.name == "Gold" for card in defender_state.hand)


### PR DESCRIPTION
## Summary
- update Sword attack to ask the defender AI which cards to discard down to four cards in hand
- ensure only the chosen cards are discarded, falling back to the remaining hand if needed
- add a loot card test showing Sword discards low-value cards instead of the earliest ones

## Testing
- pytest tests/test_loot_cards.py


------
https://chatgpt.com/codex/tasks/task_e_68dea023ef148327992e2921bf708f6c