### PR TITLE
Improve Sextant discard selection and tests

### DIFF
--- a/dominion/cards/plunder/loot_cards.py
+++ b/dominion/cards/plunder/loot_cards.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 from ..base_card import Card, CardCost, CardStats, CardType
 
 
@@ -181,16 +183,45 @@ class Sextant(Loot):
 
     def play_effect(self, game_state):
         player = game_state.current_player
-        peek = []
+        revealed_cards: list[Card] = []
         for _ in range(min(5, len(player.deck))):
-            peek.append(player.deck.pop())
-        to_keep = []
-        for card in peek:
-            if card.is_victory or card.name == "Curse":
-                game_state.discard_card(player, card)
-            else:
-                to_keep.append(card)
-        player.deck.extend(reversed(to_keep))
+            revealed_cards.append(player.deck.pop())
+
+        if not revealed_cards:
+            return
+
+        to_discard = player.ai.choose_cards_to_discard(
+            game_state,
+            player,
+            list(revealed_cards),
+            len(revealed_cards),
+            reason="sextant",
+        )
+        if not to_discard:
+            to_discard = []
+
+        remaining_cards = list(revealed_cards)
+        discarded_cards: list[Card] = []
+        for card in to_discard:
+            if card in remaining_cards and card not in discarded_cards:
+                remaining_cards.remove(card)
+                discarded_cards.append(card)
+
+        for card in discarded_cards:
+            game_state.discard_card(player, card)
+
+        if not remaining_cards:
+            return
+
+        ordered = player.ai.order_cards_for_topdeck(
+            game_state, player, list(remaining_cards)
+        )
+
+        if Counter(ordered) != Counter(remaining_cards):
+            ordered = remaining_cards
+
+        for card in reversed(ordered):
+            player.deck.append(card)
 
 
 class Shield(Loot):

--- a/tests/test_loot_cards.py
+++ b/tests/test_loot_cards.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dominion.cards.registry import get_card
 from dominion.cards.plunder import LOOT_CARD_NAMES
 from dominion.cards.base_card import CardType
@@ -33,3 +35,84 @@ def test_shield_blocks_witch_attack():
     state.handle_action_phase()
 
     assert not any(c.name == "Curse" for c in p2.discard)
+
+
+class SextantDecisionAI(ChooseFirstActionAI):
+    def __init__(self, discard_plan, order_plan):
+        super().__init__()
+        self.discard_plan = list(discard_plan)
+        self.order_plan = list(order_plan)
+
+    def choose_cards_to_discard(self, state, player, choices, count, *, reason=None):
+        available = list(choices)
+        selected = []
+        for name in self.discard_plan:
+            if len(selected) >= count:
+                break
+            for card in list(available):
+                if card.name == name:
+                    selected.append(card)
+                    available.remove(card)
+                    break
+        return selected
+
+    def order_cards_for_topdeck(self, state, player, cards):
+        ordered = []
+        remaining = list(cards)
+        for name in self.order_plan:
+            for card in list(remaining):
+                if card.name == name:
+                    ordered.append(card)
+                    remaining.remove(card)
+                    break
+        ordered.extend(remaining)
+        return ordered
+
+
+@pytest.mark.parametrize(
+    "discard_plan, order_plan, expected_deck, expected_discard",
+    [
+        (
+            [],
+            ["Estate", "Copper", "Gold", "Silver", "Duchy"],
+            ["Province", "Duchy", "Silver", "Gold", "Copper", "Estate"],
+            [],
+        ),
+        (
+            ["Gold", "Estate"],
+            ["Silver", "Copper", "Duchy"],
+            ["Province", "Duchy", "Copper", "Silver"],
+            ["Gold", "Estate"],
+        ),
+        (
+            ["Gold", "Duchy", "Silver", "Estate", "Copper"],
+            [],
+            ["Province"],
+            ["Gold", "Duchy", "Silver", "Estate", "Copper"],
+        ),
+    ],
+)
+def test_sextant_respects_ai_discard_and_order(
+    discard_plan, order_plan, expected_deck, expected_discard
+):
+    ai = SextantDecisionAI(discard_plan, order_plan)
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Sextant")])
+
+    player = state.players[0]
+    player.hand = []
+    player.discard = []
+    player.deck = [
+        get_card("Province"),
+        get_card("Copper"),
+        get_card("Estate"),
+        get_card("Silver"),
+        get_card("Duchy"),
+        get_card("Gold"),
+    ]
+
+    sextant = get_card("Sextant")
+    sextant.play_effect(state)
+
+    assert [card.name for card in player.deck] == expected_deck
+    assert [card.name for card in player.discard] == expected_discard


### PR DESCRIPTION
## Summary
- update Sextant to reveal up to five cards, delegate discard choices to the AI, and order the remaining cards before topdecking
- add parametrized tests that cover keeping, partially discarding, or discarding all revealed cards while validating the reordered survivors

## Testing
- pytest tests/test_loot_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68dea0230b788327bf08c4c153d9696f