### PR TITLE
Fix Jewels duration bottom deck behavior

### DIFF
--- a/dominion/cards/plunder/loot_cards.py
+++ b/dominion/cards/plunder/loot_cards.py
@@ -123,7 +123,7 @@ class Jewels(Loot):
         player = game_state.current_player
         if self in player.duration:
             player.duration.remove(self)
-        player.deck.insert(0, self)
+        player.deck.append(self)
 
 
 class Orb(Loot):

--- a/tests/test_loot_cards.py
+++ b/tests/test_loot_cards.py
@@ -33,3 +33,20 @@ def test_shield_blocks_witch_attack():
     state.handle_action_phase()
 
     assert not any(c.name == "Curse" for c in p2.discard)
+
+
+def test_jewels_returns_to_bottom_of_deck_after_duration():
+    state = GameState(players=[])
+    state.initialize_game([ChooseFirstActionAI()], [get_card("Village")])
+
+    player = state.players[0]
+    jewels = get_card("Jewels")
+    existing = [get_card("Copper"), get_card("Estate")]
+
+    player.deck = existing.copy()
+    player.duration = [jewels]
+
+    jewels.on_duration(state)
+
+    assert jewels not in player.duration
+    assert player.deck == existing + [jewels]


### PR DESCRIPTION
## Summary
- update Jewels to return itself to the bottom of the deck at the end of its duration
- add a regression test ensuring Jewels is placed beneath existing cards when the duration resolves

## Testing
- pytest tests/test_loot_cards.py::test_jewels_returns_to_bottom_of_deck_after_duration

------
https://chatgpt.com/codex/tasks/task_e_68dea0203a2c83279795e0e891b16833