### PR TITLE
Allow Prize Goat to skip trashing

### DIFF
--- a/dominion/cards/plunder/loot_cards.py
+++ b/dominion/cards/plunder/loot_cards.py
@@ -155,7 +155,9 @@ class PrizeGoat(Loot):
     def play_effect(self, game_state):
         player = game_state.current_player
         if player.hand:
-            card = player.ai.choose_card_to_trash(game_state, player.hand)
+            card = player.ai.choose_card_to_trash(
+                game_state, list(player.hand) + [None]
+            )
             if card:
                 player.hand.remove(card)
                 game_state.trash_card(player, card)

--- a/tests/test_loot_cards.py
+++ b/tests/test_loot_cards.py
@@ -2,7 +2,8 @@ from dominion.cards.registry import get_card
 from dominion.cards.plunder import LOOT_CARD_NAMES
 from dominion.cards.base_card import CardType
 from dominion.game.game_state import GameState
-from tests.utils import ChooseFirstActionAI
+from dominion.game.player_state import PlayerState
+from tests.utils import ChooseFirstActionAI, DummyAI, TrashFirstAI
 
 
 def test_loot_cards_all_defined():
@@ -33,3 +34,42 @@ def test_shield_blocks_witch_attack():
     state.handle_action_phase()
 
     assert not any(c.name == "Curse" for c in p2.discard)
+
+
+def test_prize_goat_trash_and_decline():
+    # Trashing scenario - AI trashes the first available card
+    trashing_ai = TrashFirstAI()
+    trashing_player = PlayerState(ai=trashing_ai)
+    state_trash = GameState(players=[trashing_player])
+    trashed_card = get_card("Copper")
+    trashing_player.hand = [trashed_card]
+
+    prize_goat = get_card("Prize Goat")
+    prize_goat.play_effect(state_trash)
+
+    assert trashed_card not in trashing_player.hand
+    assert trashed_card in state_trash.trash
+
+    # Decline scenario - AI chooses the None option to skip trashing
+    class DeclineTrashAI(DummyAI):
+        def __init__(self):
+            super().__init__()
+            self.last_choices = None
+
+        def choose_card_to_trash(self, state, choices):
+            self.last_choices = list(choices)
+            return choices[-1] if choices else None
+
+    decline_ai = DeclineTrashAI()
+    decline_player = PlayerState(ai=decline_ai)
+    state_decline = GameState(players=[decline_player])
+    keep_card = get_card("Estate")
+    decline_player.hand = [keep_card]
+
+    prize_goat_skip = get_card("Prize Goat")
+    prize_goat_skip.play_effect(state_decline)
+
+    assert keep_card in decline_player.hand
+    assert keep_card not in state_decline.trash
+    assert decline_ai.last_choices is not None
+    assert None in decline_ai.last_choices


### PR DESCRIPTION
## Summary
- allow Prize Goat to offer a skip option when choosing a card to trash
- add a focused test covering both trashing and declining scenarios for Prize Goat

## Testing
- `pytest tests/test_loot_cards.py::test_prize_goat_trash_and_decline`


------
https://chatgpt.com/codex/tasks/task_e_68dea02103a08327b04307c997a6f737