### PR TITLE
Implement missing Base and Intrigue cards

### DIFF
--- a/dominion/cards/base_set/__init__.py
+++ b/dominion/cards/base_set/__init__.py
@@ -1,30 +1,40 @@
 # dominion/cards/base_set/__init__.py
-from .village import Village
-from .smithy import Smithy
-from .market import Market
-from .festival import Festival
-from .laboratory import Laboratory
-from .mine import Mine
-from .witch import Witch
-from .moat import Moat
-from .workshop import Workshop
+from .adventurer import Adventurer
 from .chapel import Chapel
 from .council_room import CouncilRoom
+from .festival import Festival
 from .gardens import Gardens
+from .laboratory import Laboratory
 from .library import Library
+from .market import Market
+from .militia import Militia
+from .mine import Mine
+from .moat import Moat
+from .remodel import Remodel
+from .sentry import Sentry
+from .smithy import Smithy
+from .throne_room import ThroneRoom
+from .village import Village
+from .witch import Witch
+from .workshop import Workshop
 
 __all__ = [
-    'Village',
-    'Smithy',
-    'Market',
-    'Festival', 
-    'Laboratory', 
-    'Mine',
-    'Witch',
-    'Moat',
-    'Workshop',
+    'Adventurer',
     'Chapel',
     'CouncilRoom',
+    'Festival',
     'Gardens',
-    'Library'
+    'Laboratory',
+    'Library',
+    'Market',
+    'Militia',
+    'Mine',
+    'Moat',
+    'Remodel',
+    'Sentry',
+    'Smithy',
+    'ThroneRoom',
+    'Village',
+    'Witch',
+    'Workshop'
 ]

--- a/dominion/cards/base_set/adventurer.py
+++ b/dominion/cards/base_set/adventurer.py
@@ -1,0 +1,31 @@
+"""Implementation of the Adventurer treasure hunter."""
+
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Adventurer(Card):
+    def __init__(self):
+        super().__init__(
+            name="Adventurer",
+            cost=CardCost(coins=6),
+            stats=CardStats(),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        treasures_found = 0
+        while treasures_found < 2:
+            if not player.deck and player.discard:
+                player.shuffle_discard_into_deck()
+
+            if not player.deck:
+                break
+
+            card = player.deck.pop()
+            if card.is_treasure:
+                player.hand.append(card)
+                treasures_found += 1
+            else:
+                game_state.discard_card(player, card)

--- a/dominion/cards/base_set/militia.py
+++ b/dominion/cards/base_set/militia.py
@@ -1,0 +1,62 @@
+"""Implementation of the Militia attack."""
+
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Militia(Card):
+    def __init__(self):
+        super().__init__(
+            name="Militia",
+            cost=CardCost(coins=4),
+            stats=CardStats(coins=2),
+            types=[CardType.ACTION, CardType.ATTACK],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        def attack_target(target):
+            if len(target.hand) <= 3:
+                return
+
+            discard_needed = len(target.hand) - 3
+            selected = target.ai.choose_cards_to_discard(
+                game_state, target, list(target.hand), discard_needed, reason="militia"
+            )
+
+            discarded: list = []
+            for card in selected[:discard_needed]:
+                if card in target.hand:
+                    target.hand.remove(card)
+                    game_state.discard_card(target, card)
+                    discarded.append(card)
+
+            while len(target.hand) > 3:
+                card = min(target.hand, key=self._discard_priority)
+                target.hand.remove(card)
+                game_state.discard_card(target, card)
+                discarded.append(card)
+
+            if discarded:
+                context = {
+                    "discarded_cards": [c.name for c in discarded],
+                    "remaining_hand": [c.name for c in target.hand],
+                }
+                game_state.log_callback(
+                    ("action", target.ai.name, "discards to 3 cards due to Militia", context)
+                )
+
+        for other in game_state.players:
+            if other is player:
+                continue
+            game_state.attack_player(other, attack_target)
+
+    @staticmethod
+    def _discard_priority(card):
+        if card.name == "Curse":
+            return (0, card.cost.coins, card.name)
+        if card.is_victory and not card.is_action:
+            return (1, card.cost.coins, card.name)
+        if card.name == "Copper":
+            return (2, card.cost.coins, card.name)
+        return (3, card.cost.coins, card.name)

--- a/dominion/cards/base_set/remodel.py
+++ b/dominion/cards/base_set/remodel.py
@@ -1,0 +1,74 @@
+"""Implementation of the Remodel trasher."""
+
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Remodel(Card):
+    def __init__(self):
+        super().__init__(
+            name="Remodel",
+            cost=CardCost(coins=4),
+            stats=CardStats(),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+        if not player.hand:
+            return
+
+        trash_choice = player.ai.choose_card_to_trash(game_state, list(player.hand))
+        if trash_choice not in player.hand:
+            trash_choice = min(player.hand, key=self._trash_priority)
+
+        if trash_choice not in player.hand:
+            return
+
+        player.hand.remove(trash_choice)
+        game_state.trash_card(player, trash_choice)
+
+        self._gain_replacement(game_state, player, trash_choice)
+
+    def _gain_replacement(self, game_state, player, trashed):
+        max_coins = trashed.cost.coins + 2
+        max_potions = trashed.cost.potions
+
+        from ..registry import get_card
+
+        options = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            candidate = get_card(name)
+            if candidate.cost.potions > max_potions:
+                continue
+            if candidate.cost.coins > max_coins:
+                continue
+            options.append(candidate)
+
+        if not options:
+            return
+
+        choice = player.ai.choose_buy(game_state, options + [None])
+        if choice not in options:
+            options.sort(
+                key=lambda c: (c.cost.coins, c.cost.potions, c.stats.cards, c.name),
+                reverse=True,
+            )
+            choice = options[0]
+
+        if game_state.supply.get(choice.name, 0) <= 0:
+            return
+
+        game_state.supply[choice.name] -= 1
+        game_state.gain_card(player, choice)
+
+    @staticmethod
+    def _trash_priority(card):
+        if card.name == "Curse":
+            return (0, card.cost.coins, card.name)
+        if card.is_victory and not card.is_action:
+            return (1, card.cost.coins, card.name)
+        if card.name == "Copper":
+            return (2, card.cost.coins, card.name)
+        return (3, card.cost.coins, card.name)

--- a/dominion/cards/base_set/sentry.py
+++ b/dominion/cards/base_set/sentry.py
@@ -1,0 +1,61 @@
+"""Implementation of the Sentry top-decker."""
+
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Sentry(Card):
+    def __init__(self):
+        super().__init__(
+            name="Sentry",
+            cost=CardCost(coins=5),
+            stats=CardStats(actions=1, cards=1),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        revealed = []
+        for _ in range(2):
+            if not player.deck and player.discard:
+                player.shuffle_discard_into_deck()
+            if not player.deck:
+                break
+            revealed.append(player.deck.pop())
+
+        if not revealed:
+            return
+
+        kept: list = []
+        for card in revealed:
+            if self._should_trash(card):
+                game_state.trash_card(player, card)
+            elif self._should_discard(card):
+                game_state.discard_card(player, card)
+            else:
+                kept.append(card)
+
+        if kept:
+            ordered = player.ai.order_cards_for_topdeck(game_state, player, list(kept))
+            if set(ordered) != set(kept) or len(ordered) != len(kept):
+                ordered = kept
+            for card in reversed(ordered):
+                if card in kept:
+                    kept.remove(card)
+                    player.deck.append(card)
+
+    @staticmethod
+    def _should_trash(card):
+        if card.name == "Curse":
+            return True
+        if card.is_victory and not card.is_action and card.cost.coins <= 2:
+            return True
+        if card.name == "Copper":
+            return True
+        return False
+
+    @staticmethod
+    def _should_discard(card):
+        if card.is_victory and not card.is_action:
+            return True
+        return False

--- a/dominion/cards/base_set/throne_room.py
+++ b/dominion/cards/base_set/throne_room.py
@@ -1,0 +1,30 @@
+"""Implementation of the Throne Room multiplier."""
+
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class ThroneRoom(Card):
+    def __init__(self):
+        super().__init__(
+            name="Throne Room",
+            cost=CardCost(coins=4),
+            stats=CardStats(),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+        actions_in_hand = [card for card in player.hand if card.is_action]
+
+        if not actions_in_hand:
+            return
+
+        choice = player.ai.choose_action(game_state, actions_in_hand + [None])
+        if choice is None or choice not in actions_in_hand:
+            choice = actions_in_hand[0]
+
+        player.hand.remove(choice)
+        player.in_play.append(choice)
+
+        for _ in range(2):
+            choice.on_play(game_state)

--- a/dominion/cards/intrigue/__init__.py
+++ b/dominion/cards/intrigue/__init__.py
@@ -6,5 +6,6 @@ from .wishing_well import WishingWell
 from .conspirator import Conspirator
 from .ironworks import Ironworks
 from .pawn import Pawn
+from .steward import Steward
 
-__all__ = ['Torturer', 'Patrol', 'Bridge', 'Nobles', 'WishingWell', 'Conspirator', 'Ironworks', 'Pawn']
+__all__ = ['Torturer', 'Patrol', 'Bridge', 'Nobles', 'WishingWell', 'Conspirator', 'Ironworks', 'Pawn', 'Steward']

--- a/dominion/cards/intrigue/steward.py
+++ b/dominion/cards/intrigue/steward.py
@@ -1,0 +1,81 @@
+"""Implementation of the Steward choice card."""
+
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Steward(Card):
+    def __init__(self):
+        super().__init__(
+            name="Steward",
+            cost=CardCost(coins=3),
+            stats=CardStats(),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+        choice = self._choose_option(player)
+
+        if choice == "cards":
+            game_state.draw_cards(player, 2)
+        elif choice == "coins":
+            player.coins += 2
+        elif choice == "trash":
+            self._trash_up_to_two_cards(game_state, player)
+
+    def _choose_option(self, player) -> str:
+        junk = [card for card in player.hand if self._is_junk(card)]
+        if junk:
+            return "trash"
+
+        if player.coins < 4:
+            return "coins"
+
+        return "cards"
+
+    def _trash_up_to_two_cards(self, game_state, player):
+        if not player.hand:
+            return
+
+        selections = player.ai.choose_cards_to_trash(game_state, list(player.hand), 2)
+        trashed = 0
+
+        for card in selections[:2]:
+            if card in player.hand:
+                player.hand.remove(card)
+                game_state.trash_card(player, card)
+                trashed += 1
+
+        while trashed < 2:
+            candidate = self._find_trash_candidate(player.hand)
+            if not candidate:
+                break
+            player.hand.remove(candidate)
+            game_state.trash_card(player, candidate)
+            trashed += 1
+
+    @staticmethod
+    def _find_trash_candidate(cards):
+        if not cards:
+            return None
+        return min(cards, key=Steward._trash_priority)
+
+    @staticmethod
+    def _is_junk(card):
+        if card.name == "Curse":
+            return True
+        if card.name == "Copper":
+            return True
+        if card.is_victory and not card.is_action and card.cost.coins <= 2:
+            return True
+        return False
+
+    @staticmethod
+    def _trash_priority(card):
+        if card.name == "Curse":
+            return (0, card.cost.coins, card.name)
+        if card.is_victory and not card.is_action and card.cost.coins <= 2:
+            return (1, card.cost.coins, card.name)
+        if card.name == "Copper":
+            return (2, card.cost.coins, card.name)
+        return (3, card.cost.coins, card.name)

--- a/dominion/cards/registry.py
+++ b/dominion/cards/registry.py
@@ -2,6 +2,7 @@ from typing import Type
 
 from dominion.cards.base_card import Card
 from dominion.cards.base_set import (
+    Adventurer,
     Chapel,
     CouncilRoom,
     Festival,
@@ -9,9 +10,13 @@ from dominion.cards.base_set import (
     Laboratory,
     Library,
     Market,
+    Militia,
     Mine,
     Moat,
+    Remodel,
+    Sentry,
     Smithy,
+    ThroneRoom,
     Village,
     Witch,
     Workshop,
@@ -177,6 +182,7 @@ from dominion.cards.intrigue import (
     Conspirator,
     Ironworks,
     Pawn,
+    Steward,
 )
 from dominion.cards.plunder import Barbarian, FirstMate, Flagship, Highwayman, Trickster
 from dominion.cards.dark_ages import Armory, Count, Ironmonger, Marauder, PoorHouse, Spoils, Ruins
@@ -201,11 +207,13 @@ CARD_TYPES: dict[str, Type[Card]] = {
     "Curse": Curse,
     "Gardens": Gardens,
     # Action cards
+    "Adventurer": Adventurer,
     "Village": Village,
     "Smithy": Smithy,
     "Market": Market,
     "Festival": Festival,
     "Laboratory": Laboratory,
+    "Militia": Militia,
     "Mine": Mine,
     "Witch": Witch,
     "Moat": Moat,
@@ -214,6 +222,10 @@ CARD_TYPES: dict[str, Type[Card]] = {
     "Council Room": CouncilRoom,
     "Council room": CouncilRoom,
     "Library": Library,
+    "Remodel": Remodel,
+    "Sentry": Sentry,
+    "Throne Room": ThroneRoom,
+    "Throne room": ThroneRoom,
     # Expansion cards
     "Advisor": Advisor,
     "Baker": Baker,
@@ -380,6 +392,7 @@ CARD_TYPES: dict[str, Type[Card]] = {
     "Conspirator": Conspirator,
     "Ironworks": Ironworks,
     "Pawn": Pawn,
+    "Steward": Steward,
     "Bazaar": Bazaar,
     "Trading Post": TradingPost,
     "Trading post": TradingPost,

--- a/tests/test_base_intrigue_cards.py
+++ b/tests/test_base_intrigue_cards.py
@@ -1,0 +1,220 @@
+"""Tests for newly implemented Base and Intrigue cards."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+
+from tests.utils import ChooseFirstActionAI
+
+
+def test_militia_forces_discards():
+    attacker_ai = ChooseFirstActionAI()
+    defender_ai = ChooseFirstActionAI()
+    state = GameState(players=[])
+    state.initialize_game([attacker_ai, defender_ai], [get_card("Militia")])
+
+    player = state.players[0]
+    opponent = state.players[1]
+
+    militia = get_card("Militia")
+    player.hand = [militia]
+    player.actions = 1
+
+    opponent.hand = [
+        get_card("Estate"),
+        get_card("Copper"),
+        get_card("Silver"),
+        get_card("Gold"),
+        get_card("Village"),
+    ]
+
+    militia.on_play(state)
+
+    assert player.coins == 2
+    assert len(opponent.hand) == 3
+    assert len(opponent.discard) >= 1
+
+
+def test_adventurer_finds_two_treasures():
+    ai = ChooseFirstActionAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Adventurer")])
+
+    player = state.players[0]
+    adventurer = get_card("Adventurer")
+
+    player.hand = []
+    player.deck = [
+        get_card("Estate"),
+        get_card("Copper"),
+        get_card("Silver"),
+        get_card("Estate"),
+    ]
+    player.discard = []
+
+    adventurer.on_play(state)
+
+    treasures = [card for card in player.hand if card.is_treasure]
+    assert len(treasures) == 2
+    names = {card.name for card in treasures}
+    assert {"Copper", "Silver"} <= names
+    assert any(card.name == "Estate" for card in player.discard)
+
+
+def test_throne_room_plays_action_twice():
+    ai = ChooseFirstActionAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Throne Room"), get_card("Smithy")])
+
+    player = state.players[0]
+    throne_room = get_card("Throne Room")
+    smithy = get_card("Smithy")
+
+    player.hand = [smithy]
+    player.deck = [get_card("Copper") for _ in range(6)]
+    player.discard = []
+
+    throne_room.on_play(state)
+
+    assert sum(1 for card in player.in_play if card.name == "Smithy") == 1
+    assert len(player.deck) == 0
+    assert len([card for card in player.hand if card.name == "Copper"]) == 6
+
+
+def test_sentry_processes_revealed_cards():
+    ai = ChooseFirstActionAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Sentry")])
+
+    player = state.players[0]
+    sentry = get_card("Sentry")
+
+    player.hand = []
+    player.deck = [
+        get_card("Silver"),
+        get_card("Estate"),
+        get_card("Curse"),
+        get_card("Copper"),
+    ]
+    player.discard = []
+    state.trash = []
+
+    sentry.on_play(state)
+
+    assert any(card.name == "Curse" for card in state.trash)
+    assert any(card.name == "Estate" for card in state.trash + player.discard)
+    assert any(card.name == "Copper" for card in player.hand)
+
+
+def test_remodel_trashes_and_gains_upgrade():
+    ai = ChooseFirstActionAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Remodel")])
+
+    player = state.players[0]
+    remodel = get_card("Remodel")
+
+    estate = get_card("Estate")
+    player.hand = [estate]
+    state.trash = []
+
+    remodel.on_play(state)
+
+    assert any(card.name == "Estate" for card in state.trash)
+    assert player.discard
+    gained = player.discard[-1]
+    assert gained.cost.coins <= estate.cost.coins + 2
+    assert gained.name != "Estate"
+
+
+def test_steward_prefers_trashing_junk():
+    ai = ChooseFirstActionAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Steward")])
+
+    player = state.players[0]
+    steward = get_card("Steward")
+
+    player.hand = [get_card("Copper"), get_card("Estate"), get_card("Silver")]
+    state.trash = []
+
+    steward.on_play(state)
+
+    trashed_names = [card.name for card in state.trash]
+    assert "Copper" in trashed_names
+    assert "Estate" in trashed_names
+
+
+def test_steward_adds_coins_when_no_junk():
+    ai = ChooseFirstActionAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Steward")])
+
+    player = state.players[0]
+    steward = get_card("Steward")
+
+    player.hand = [get_card("Silver")]
+    player.coins = 0
+
+    steward.on_play(state)
+
+    assert player.coins == 2
+
+
+def test_kingdom_configurations_initialize():
+    config_path = Path("kingdom_config.yaml")
+    contents = config_path.read_text(encoding="utf-8")
+
+    default_kingdom, alternative_kingdoms = _parse_kingdom_config(contents)
+
+    kingdoms = [default_kingdom] + list(alternative_kingdoms.values())
+    assert kingdoms, "Expected at least one kingdom to test"
+
+    for kingdom in kingdoms:
+        ais = [ChooseFirstActionAI(), ChooseFirstActionAI()]
+        state = GameState(players=[])
+        cards = [get_card(name) for name in kingdom]
+        state.initialize_game(ais, cards)
+
+
+def _parse_kingdom_config(text: str) -> tuple[list[str], dict[str, list[str]]]:
+    default_cards: list[str] = []
+    alternatives: dict[str, list[str]] = {}
+    current_list: list[str] | None = None
+    current_alt: str | None = None
+    in_alternatives = False
+
+    for raw_line in text.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+
+        if not raw_line.startswith(" "):
+            current_list = None
+            current_alt = None
+            in_alternatives = raw_line.strip().startswith("alternative_kingdoms:")
+            if raw_line.strip().startswith("kingdom_cards:"):
+                current_list = default_cards
+                in_alternatives = False
+            continue
+
+        if not in_alternatives and raw_line.strip().startswith("- "):
+            card_name = raw_line.strip()[2:].strip().strip('"')
+            default_cards.append(card_name)
+            continue
+
+        if in_alternatives:
+            if raw_line.startswith("  ") and not raw_line.startswith("    "):
+                # Name of the alternative kingdom
+                current_alt = raw_line.strip()[:-1]
+                alternatives[current_alt] = []
+                current_list = alternatives[current_alt]
+                continue
+
+            if raw_line.strip().startswith("- ") and current_list is not None:
+                card_name = raw_line.strip()[2:].strip().strip('"')
+                current_list.append(card_name)
+
+    return default_cards, alternatives


### PR DESCRIPTION
## Summary
- implement Militia, Adventurer, Throne Room, Sentry, Remodel, and Steward card logic
- export the new cards and register them so they can be used by the card registry
- add unit tests covering the new card behaviors and loading kingdoms from kingdom_config.yaml

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dea0178bf883278a85944126ff84ec