### PR TITLE
Add Messenger Adventures card

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -136,6 +136,13 @@ class AI(ABC):
 
         return False
 
+    def should_discard_deck_with_messenger(
+        self, state: GameState, player: PlayerState
+    ) -> bool:
+        """Decide whether to discard the deck when playing Messenger."""
+
+        return False
+
     def order_cards_for_topdeck(
         self, state: GameState, player: PlayerState, cards: list[Card]
     ) -> list[Card]:

--- a/dominion/cards/adventures/__init__.py
+++ b/dominion/cards/adventures/__init__.py
@@ -1,5 +1,6 @@
 from .miser import Miser
 from .giant import Giant
 from .artificer import Artificer
+from .messenger import Messenger
 
-__all__ = ['Miser', 'Giant', 'Artificer']
+__all__ = ["Miser", "Giant", "Artificer", "Messenger"]

--- a/dominion/cards/adventures/messenger.py
+++ b/dominion/cards/adventures/messenger.py
@@ -1,0 +1,71 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Messenger(Card):
+    """Implements the Adventures card Messenger."""
+
+    def __init__(self):
+        super().__init__(
+            name="Messenger",
+            cost=CardCost(coins=4),
+            stats=CardStats(coins=2, buys=1),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        """Allow the current player to discard their deck."""
+
+        player = game_state.current_player
+
+        if not player.deck:
+            return
+
+        if player.ai.should_discard_deck_with_messenger(game_state, player):
+            player.discard.extend(player.deck)
+            player.deck.clear()
+
+    def on_gain(self, game_state, player):
+        """Distribute a chosen card when Messenger is first gained in the buy phase."""
+
+        super().on_gain(game_state, player)
+
+        if (
+            player is not game_state.current_player
+            or game_state.phase != "buy"
+            or getattr(player, "cards_gained_this_buy_phase", 0) != 0
+        ):
+            return
+
+        from ..registry import get_card  # Local import to avoid circular dependency
+
+        gain_options = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            card = get_card(name)
+            if card.cost.coins <= 4:
+                gain_options.append(card)
+
+        if not gain_options:
+            return
+
+        choice = player.ai.choose_buy(game_state, gain_options)
+        if (
+            choice is None
+            or choice.name not in game_state.supply
+            or game_state.supply[choice.name] <= 0
+            or choice.cost.coins > 4
+        ):
+            choice = gain_options[0]
+
+        game_state.supply[choice.name] -= 1
+        game_state.gain_card(player, choice)
+
+        choice_name = choice.name
+        for other in game_state.players:
+            if other is player:
+                continue
+            if game_state.supply.get(choice_name, 0) <= 0:
+                break
+            game_state.supply[choice_name] -= 1
+            game_state.gain_card(other, get_card(choice_name))

--- a/dominion/cards/registry.py
+++ b/dominion/cards/registry.py
@@ -181,7 +181,7 @@ from dominion.cards.intrigue import (
 from dominion.cards.plunder import Barbarian, FirstMate, Flagship, Highwayman, Trickster
 from dominion.cards.dark_ages import Armory, Count, Ironmonger, Marauder, PoorHouse, Spoils, Ruins
 from dominion.cards.seaside import Bazaar, Lookout, NativeVillage, TradingPost, Wharf
-from dominion.cards.adventures import Artificer, Giant
+from dominion.cards.adventures import Artificer, Giant, Messenger
 from dominion.cards.nocturne import TragicHero
 from dominion.cards.menagerie import Destrier, Horse, Mastermind, Paddock
 
@@ -398,6 +398,7 @@ CARD_TYPES: dict[str, Type[Card]] = {
     "Ruins": Ruins,
     "Giant": Giant,
     "Artificer": Artificer,
+    "Messenger": Messenger,
     "Tragic Hero": TragicHero,
     "Horse": Horse,
     "Destrier": Destrier,

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -356,6 +356,7 @@ class GameState:
         player = self.current_player
         player.cannot_buy_actions = False
         player.envious_effect_active = False
+        player.cards_gained_this_buy_phase = 0
 
         if player.deluded:
             player.deluded = False
@@ -651,6 +652,7 @@ class GameState:
         player.cost_reduction = 0
         player.innovation_used = False
         player.cards_gained_this_turn = 0
+        player.cards_gained_this_buy_phase = 0
         player.flagship_pending = [
             card for card in player.flagship_pending if card in player.duration
         ]
@@ -907,6 +909,13 @@ class GameState:
         self._trigger_invest_draw(actual_card.name, player)
         self._handle_fools_gold_reactions(player, actual_card)
         self._track_action_gain(player, actual_card)
+
+        if (
+            hasattr(player, "cards_gained_this_buy_phase")
+            and player is self.current_player
+            and self.phase == "buy"
+        ):
+            player.cards_gained_this_buy_phase += 1
 
         if hasattr(player, "cards_gained_this_turn"):
             player.cards_gained_this_turn += 1

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -68,6 +68,7 @@ class PlayerState:
     gained_five_this_turn: bool = False
     gained_five_last_turn: bool = False
     cards_gained_this_turn: int = 0
+    cards_gained_this_buy_phase: int = 0
     flagship_pending: list[Card] = field(default_factory=list)
     highwayman_attacks: int = 0
     highwayman_blocked_this_turn: bool = False
@@ -139,6 +140,7 @@ class PlayerState:
         self.gained_five_this_turn = False
         self.gained_five_last_turn = False
         self.cards_gained_this_turn = 0
+        self.cards_gained_this_buy_phase = 0
         self.flagship_pending = []
         self.highwayman_attacks = 0
         self.highwayman_blocked_this_turn = False

--- a/tests/test_new_cards.py
+++ b/tests/test_new_cards.py
@@ -3,6 +3,27 @@ from dominion.game.game_state import GameState
 from tests.utils import ChooseFirstActionAI
 
 
+class MessengerTestAI(ChooseFirstActionAI):
+    def __init__(self, *, discard_deck: bool, gain_choice: str):
+        super().__init__()
+        self.discard_deck = discard_deck
+        self.gain_choice = gain_choice
+
+    def choose_buy(self, state, choices):
+        for choice in choices:
+            if choice is None:
+                continue
+            if choice.name == self.gain_choice:
+                return choice
+        for choice in choices:
+            if choice is not None:
+                return choice
+        return None
+
+    def should_discard_deck_with_messenger(self, state, player):
+        return self.discard_deck
+
+
 class StopAfterOneVillageAI(ChooseFirstActionAI):
     """AI that stops First Mate after playing a single copy of the named card."""
 
@@ -32,10 +53,53 @@ def test_new_card_registry():
         "Patrol",
         "Inn",
         "First Mate",
+        "Messenger",
     ]
     for name in names:
         card = get_card(name)
         assert card.name == name
+
+
+def test_messenger_effects():
+    ai = MessengerTestAI(discard_deck=True, gain_choice="Silver")
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Messenger")])
+
+    player = state.players[0]
+    player.hand = [get_card("Messenger")]
+    player.deck = [get_card("Copper"), get_card("Estate")]
+    player.discard = []
+    player.actions = 1
+
+    state.phase = "action"
+    state.handle_action_phase()
+
+    assert player.deck == []
+    assert [card.name for card in player.discard] == ["Copper", "Estate"]
+    assert player.buys == 2
+    assert player.coins == 2
+
+    other_ai = ChooseFirstActionAI()
+    state2 = GameState(players=[])
+    state2.initialize_game([MessengerTestAI(discard_deck=False, gain_choice="Silver"), other_ai], [get_card("Messenger")])
+
+    current = state2.players[0]
+    opponent = state2.players[1]
+    current.discard = []
+    opponent.discard = []
+    state2.phase = "buy"
+    state2.current_player_index = 0
+    current.cards_gained_this_buy_phase = 0
+
+    initial_silver = state2.supply["Silver"]
+    state2.supply["Messenger"] -= 1
+    state2.gain_card(current, get_card("Messenger"))
+
+    assert [card.name for card in current.discard].count("Messenger") == 1
+    assert [card.name for card in current.discard].count("Silver") == 1
+    assert [card.name for card in opponent.discard].count("Silver") == 1
+    assert state2.supply["Silver"] == initial_silver - 2
+    assert current.cards_gained_this_buy_phase == 2
 
 
 def test_first_mate_effect():


### PR DESCRIPTION
## Summary
- implement the Messenger Adventures card, including its on-play deck discard option and on-gain distribution effect
- track buy-phase gains so Messenger can detect the first gain, and expose the card in the adventures package and registry
- add regression coverage that exercises Messenger registration, play, and gain behaviors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dea016d9c88327a11714488e909639