### PR TITLE
Fix Charm card type

### DIFF
--- a/dominion/cards/empires/charm.py
+++ b/dominion/cards/empires/charm.py
@@ -14,7 +14,12 @@ class Charm(Card):
             name="Charm",
             cost=CardCost(coins=5),
             stats=CardStats(buys=1),
-            types=[CardType.ACTION],
+            # Charm is a Treasure card that gives +1 Buy while offering one of its
+            # three options. The implementation previously (incorrectly) labeled
+            # it as an Action, which caused type checks to fail and prevented the
+            # card from interacting with treasure-specific effects. Mark it with
+            # the correct type.
+            types=[CardType.TREASURE],
 
         )
 


### PR DESCRIPTION
## Summary
- correct Charm's card type to be a Treasure instead of an Action
- document the reason in the card definition

## Testing
- pytest tests/test_empires_card_types.py

------
https://chatgpt.com/codex/tasks/task_e_68dea853e3488327a3152125643d32a3