### PR TITLE
Fix victory pile supply counts

### DIFF
--- a/dominion/cards/empires/castles.py
+++ b/dominion/cards/empires/castles.py
@@ -13,4 +13,5 @@ class Castle(Card):
         )
 
     def starting_supply(self, game_state) -> int:
-        return 8 if len(game_state.players) <= 2 else 12
+        # The Castles pile always contains the fixed stack of eight Castle cards
+        return 8

--- a/dominion/cards/prosperity/colony.py
+++ b/dominion/cards/prosperity/colony.py
@@ -11,4 +11,9 @@ class Colony(Card):
         )
 
     def starting_supply(self, game_state) -> int:
-        return 12
+        n_players = len(game_state.players)
+        if n_players <= 2:
+            return 8
+        if n_players <= 4:
+            return 12
+        return 12 + 3 * (n_players - 4)

--- a/dominion/cards/victory.py
+++ b/dominion/cards/victory.py
@@ -37,9 +37,10 @@ class Province(Card):
         n_players = len(game_state.players)
         if n_players <= 2:
             return 8
-        elif n_players <= 4:
+        if n_players <= 4:
             return 12
-        return 15
+        # Official rules add three Provinces for each player beyond four
+        return 12 + 3 * (n_players - 4)
 
 
 class Curse(Card):
@@ -47,4 +48,7 @@ class Curse(Card):
         super().__init__(name="Curse", cost=CardCost(coins=0), stats=CardStats(vp=-1), types=[CardType.CURSE])
 
     def starting_supply(self, game_state) -> int:
-        return 10 * (len(game_state.players) - 1)
+        n_players = len(game_state.players)
+        if n_players <= 1:
+            return 10
+        return 10 * (n_players - 1)

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -116,14 +116,24 @@ class GameState:
     def setup_supply(self, kingdom_cards: list[Card]):
         """Set up the initial supply piles."""
         # Add basic cards with proper counts
+        copper_card = get_card("Copper")
+        silver_card = get_card("Silver")
+        gold_card = get_card("Gold")
+        estate_card = get_card("Estate")
+        duchy_card = get_card("Duchy")
+        province_card = get_card("Province")
+        curse_card = get_card("Curse")
+
+        copper_supply = copper_card.starting_supply(self) - (7 * len(self.players))
+
         basic_cards = {
-            "Copper": 60 - (7 * len(self.players)),
-            "Silver": 40,
-            "Gold": 30,
-            "Estate": 12 if len(self.players) > 2 else 8,
-            "Duchy": 12 if len(self.players) > 2 else 8,
-            "Province": 12 if len(self.players) > 2 else 8,
-            "Curse": 10 * (len(self.players) - 1) if len(self.players) > 1 else 10,
+            "Copper": max(0, copper_supply),
+            "Silver": silver_card.starting_supply(self),
+            "Gold": gold_card.starting_supply(self),
+            "Estate": estate_card.starting_supply(self),
+            "Duchy": duchy_card.starting_supply(self),
+            "Province": province_card.starting_supply(self),
+            "Curse": max(0, curse_card.starting_supply(self)),
         }
 
         self.supply = dict(basic_cards)

--- a/tests/test_victory_card_supply.py
+++ b/tests/test_victory_card_supply.py
@@ -1,0 +1,52 @@
+"""Tests covering supply counts for core victory piles."""
+
+from dominion.cards.empires.castles import Castle
+from dominion.cards.prosperity.colony import Colony
+from dominion.cards.victory import Province
+from dominion.game.game_state import GameState
+
+
+def make_state(player_count: int) -> GameState:
+    """Create a simple ``GameState`` stub with the requested player count."""
+
+    return GameState(players=[None] * player_count)
+
+
+def test_province_starting_supply_scales_with_players():
+    province = Province()
+
+    assert province.starting_supply(make_state(2)) == 8
+    assert province.starting_supply(make_state(3)) == 12
+    assert province.starting_supply(make_state(4)) == 12
+    assert province.starting_supply(make_state(5)) == 15
+    assert province.starting_supply(make_state(6)) == 18
+
+
+def test_colony_starting_supply_matches_province_rules():
+    colony = Colony()
+
+    assert colony.starting_supply(make_state(2)) == 8
+    assert colony.starting_supply(make_state(3)) == 12
+    assert colony.starting_supply(make_state(4)) == 12
+    assert colony.starting_supply(make_state(5)) == 15
+    assert colony.starting_supply(make_state(6)) == 18
+
+
+def test_castle_pile_has_fixed_count():
+    castle = Castle()
+
+    assert castle.starting_supply(make_state(2)) == 8
+    assert castle.starting_supply(make_state(4)) == 8
+
+
+def test_setup_supply_uses_victory_scaling():
+    state = make_state(5)
+    state.setup_supply([])
+
+    assert state.supply["Province"] == 15
+
+    state_with_colonies = make_state(6)
+    state_with_colonies.setup_supply([Colony()])
+
+    assert state_with_colonies.supply["Province"] == 18
+    assert state_with_colonies.supply["Colony"] == 18


### PR DESCRIPTION
## Summary
- align Province and Colony supply counts with the official scaling for larger player counts and keep Castles at eight cards
- derive basic supply piles from their card definitions, including maintaining a default Curse stack for single-player simulations
- add regression tests covering the victory pile supply rules

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dee130f12083279c1031321e79d07e