### PR TITLE
Adjust Villa coin output

### DIFF
--- a/dominion/cards/empires/villa.py
+++ b/dominion/cards/empires/villa.py
@@ -6,7 +6,7 @@ class Villa(Card):
         super().__init__(
             name="Villa",
             cost=CardCost(coins=4),
-            stats=CardStats(actions=2, coins=2, buys=1),
+            stats=CardStats(actions=2, coins=1, buys=1),
             types=[CardType.ACTION],
         )
 


### PR DESCRIPTION
## Summary
- reduce Villa's on-play coin bonus from +$2 to +$1 to match intended behavior

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e02b193e1c8327b27bde218e3288c1