### PR TITLE
Adjust Crown card action refund behavior

### DIFF
--- a/dominion/cards/empires/crown.py
+++ b/dominion/cards/empires/crown.py
@@ -8,7 +8,7 @@ class Crown(Card):
         super().__init__(
             name="Crown",
             cost=CardCost(coins=5),
-            stats=CardStats(actions=1, coins=1),
+            stats=CardStats(),
             types=[CardType.ACTION, CardType.TREASURE],
         )
 
@@ -31,6 +31,8 @@ class Crown(Card):
 
             for _ in range(2):
                 choice.on_play(game_state)
+
+            player.actions += 1
         else:
             treasures = [card for card in player.hand if card.is_treasure]
             if not treasures:


### PR DESCRIPTION
## Summary
- remove Crown's automatic coin and action bonuses by using default stats
- refund an action only when Crown doubles another Action card
- keep the treasure branch unchanged while still double-playing the selected Treasure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff20ae1988327a6182a67059b6eaf