### PR TITLE
Implement Wild Hunt choice flow

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -122,6 +122,15 @@ class AI(ABC):
             return "gold"
         return options[0] if options else "cards"
 
+    def choose_wild_hunt_option(
+        self, state: GameState, player: PlayerState, options: list[str]
+    ) -> str:
+        """Select which Wild Hunt mode to use when played."""
+
+        if "draw" in options:
+            return "draw"
+        return options[0] if options else "draw"
+
     def choose_prince_target(
         self, state: GameState, player: PlayerState, choices: list[Optional[Card]]
     ) -> Optional[Card]:

--- a/dominion/cards/empires/wild_hunt.py
+++ b/dominion/cards/empires/wild_hunt.py
@@ -6,9 +6,34 @@ class WildHunt(Card):
         super().__init__(
             name="Wild Hunt",
             cost=CardCost(coins=5),
-            stats=CardStats(cards=3),
+            stats=CardStats(),
             types=[CardType.ACTION],
         )
 
     def play_effect(self, game_state):
-        game_state.current_player.vp_tokens += 1
+        from ..registry import get_card
+
+        player = game_state.current_player
+        options = ["draw", "estate"]
+        choice = player.ai.choose_wild_hunt_option(game_state, player, options)
+        if choice not in options:
+            choice = "draw"
+
+        if choice == "draw":
+            game_state.draw_cards(player, 3)
+            game_state.wild_hunt_pile_tokens += 1
+            return
+
+        gained = None
+        if game_state.supply.get("Estate", 0) > 0:
+            game_state.supply["Estate"] -= 1
+            gained = game_state.gain_card(player, get_card("Estate"))
+        elif any(card.name == "Estate" for card in player.exile):
+            gained = game_state.gain_card(player, get_card("Estate"))
+
+        if not gained:
+            return
+
+        if gained and gained.name == "Estate":
+            player.vp_tokens += game_state.wild_hunt_pile_tokens
+            game_state.wild_hunt_pile_tokens = 0

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -27,6 +27,7 @@ class GameState:
     baker_in_supply: bool = False
     hex_deck: list[str] = field(default_factory=list)
     hex_discard: list[str] = field(default_factory=list)
+    wild_hunt_pile_tokens: int = 0
       
 
     def __post_init__(self):

--- a/tests/test_wild_hunt.py
+++ b/tests/test_wild_hunt.py
@@ -1,0 +1,61 @@
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from tests.utils import DummyAI
+
+
+def make_state(ai: DummyAI) -> tuple[GameState, PlayerState]:
+    player = PlayerState(ai)
+    state = GameState(players=[player])
+    state.log_callback = lambda *args, **kwargs: None
+    state.supply = {}
+    return state, player
+
+
+class WildHuntChoiceAI(DummyAI):
+    def __init__(self, choices: list[str]):
+        super().__init__()
+        self._choices = list(choices)
+
+    def choose_wild_hunt_option(self, state, player, options):
+        if self._choices:
+            return self._choices.pop(0)
+        return "draw"
+
+
+def test_wild_hunt_draw_option_builds_pile_tokens():
+    ai = WildHuntChoiceAI(["draw", "draw"])
+    state, player = make_state(ai)
+    wild_hunt = get_card("Wild Hunt")
+
+    player.deck = [get_card("Copper") for _ in range(6)]
+
+    wild_hunt.play_effect(state)
+    assert state.wild_hunt_pile_tokens == 1
+    assert len(player.hand) == 3
+
+    wild_hunt.play_effect(state)
+    assert state.wild_hunt_pile_tokens == 2
+    assert len(player.hand) == 6
+
+
+def test_wild_hunt_estate_option_gains_estate_and_scores_tokens():
+    ai = WildHuntChoiceAI(["draw", "draw", "estate"])
+    state, player = make_state(ai)
+    wild_hunt = get_card("Wild Hunt")
+
+    state.supply = {"Estate": 8}
+    player.deck = [get_card("Copper") for _ in range(9)]
+
+    wild_hunt.play_effect(state)
+    wild_hunt.play_effect(state)
+
+    assert state.wild_hunt_pile_tokens == 2
+
+    previous_vp = player.vp_tokens
+    wild_hunt.play_effect(state)
+
+    assert state.supply["Estate"] == 7
+    assert any(card.name == "Estate" for card in player.discard)
+    assert player.vp_tokens == previous_vp + 2
+    assert state.wild_hunt_pile_tokens == 0


### PR DESCRIPTION
## Summary
- add a default AI hook for deciding Wild Hunt's mode
- rework Wild Hunt to queue VP tokens on draws and pay them out on Estate gains
- track the pile VP tokens in GameState and cover the behaviour with regression tests

## Testing
- pytest tests/test_wild_hunt.py

------
https://chatgpt.com/codex/tasks/task_e_68e0581fd89883279e23b46202c2f680