### PR TITLE
Implement Fortune per-turn doubling safeguards

### DIFF
--- a/dominion/cards/empires/fortune.py
+++ b/dominion/cards/empires/fortune.py
@@ -1,4 +1,5 @@
 from ..base_card import Card, CardCost, CardStats, CardType
+from ..registry import get_card
 
 
 class Fortune(Card):
@@ -12,4 +13,20 @@ class Fortune(Card):
 
     def play_effect(self, game_state):
         player = game_state.current_player
-        player.coins *= 2
+        if not getattr(player, "fortune_doubled_this_turn", False):
+            player.coins *= 2
+            player.fortune_doubled_this_turn = True
+
+    def on_gain(self, game_state, player):
+        super().on_gain(game_state, player)
+
+        if game_state.supply.get("Gold", 0) <= 0:
+            return
+
+        for card in list(player.in_play):
+            if card.name != "Gladiator":
+                continue
+            if game_state.supply.get("Gold", 0) <= 0:
+                break
+            game_state.supply["Gold"] -= 1
+            game_state.gain_card(player, get_card("Gold"))

--- a/dominion/cards/empires/fortune.py
+++ b/dominion/cards/empires/fortune.py
@@ -1,5 +1,4 @@
 from ..base_card import Card, CardCost, CardStats, CardType
-from ..registry import get_card
 
 
 class Fortune(Card):
@@ -18,6 +17,8 @@ class Fortune(Card):
             player.fortune_doubled_this_turn = True
 
     def on_gain(self, game_state, player):
+        from ..registry import get_card
+
         super().on_gain(game_state, player)
 
         if game_state.supply.get("Gold", 0) <= 0:

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -251,6 +251,7 @@ class GameState:
         player.cannot_buy_actions = False
         player.envious_effect_active = False
         player.insignia_active = False
+        player.fortune_doubled_this_turn = False
 
         # Return any cards delayed by the Delay event
         if self.current_player.delayed_cards:

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -57,6 +57,7 @@ class PlayerState:
     trickster_set_aside: list[Card] = field(default_factory=list)
     charm_next_buy_copies: int = 0
     walled_villages_played: int = 0
+    fortune_doubled_this_turn: bool = False
 
     # Turn tracking
     turns_taken: int = 0
@@ -135,6 +136,7 @@ class PlayerState:
         self.trickster_set_aside = []
         self.charm_next_buy_copies = 0
         self.walled_villages_played = 0
+        self.fortune_doubled_this_turn = False
         self.turns_taken = 0
         self.actions_played = 0
         self.actions_this_turn = 0


### PR DESCRIPTION
## Summary
- prevent Fortune from doubling coins more than once per turn by tracking a player flag
- reset the Fortune doubling flag each turn and initialize it on player state
- grant a Gold per Gladiator in play when gaining Fortune, respecting Gold supply limits

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e061dcc4b8832792f6944e3274ab33