### PR TITLE
Implement Gladiator duel interactions

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -60,6 +60,30 @@ class AI(ABC):
 
         return True
 
+    def choose_gladiator_reveal_target(
+        self, state: GameState, player: PlayerState
+    ) -> Optional[Card]:
+        """Select which card to reveal when playing Gladiator."""
+
+        if not player.hand:
+            return None
+
+        return max(
+            player.hand,
+            key=lambda card: (card.cost.coins, card.stats.coins, card.name),
+        )
+
+    def should_reveal_matching_gladiator(
+        self,
+        state: GameState,
+        player: PlayerState,
+        card_name: str,
+        opponent: PlayerState,
+    ) -> bool:
+        """Decide whether to reveal a matching card during a Gladiator duel."""
+
+        return True
+
     def should_keep_library_action(self, state: GameState, player: PlayerState, card: Card) -> bool:
         """Decide whether to keep a drawn Action card while resolving Library."""
 

--- a/dominion/cards/empires/gladiator.py
+++ b/dominion/cards/empires/gladiator.py
@@ -8,6 +8,60 @@ class Gladiator(Card):
         super().__init__(
             name="Gladiator",
             cost=CardCost(coins=3),
-            stats=CardStats(coins=2, buys=1),
+            stats=CardStats(coins=2),
             types=[CardType.ACTION],
         )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        reveal_target = player.ai.choose_gladiator_reveal_target(game_state, player)
+        if not reveal_target:
+            return
+
+        if reveal_target not in player.hand:
+            if not player.hand:
+                return
+            reveal_target = max(
+                player.hand,
+                key=lambda card: (card.cost.coins, card.stats.coins, card.name),
+            )
+
+        game_state.log_callback(
+            (
+                "action",
+                player.ai.name,
+                f"reveals {reveal_target.name}",
+                {"card": reveal_target.name},
+            )
+        )
+
+        if len(game_state.players) <= 1:
+            self._award_duel(player, game_state)
+            return
+
+        opponent_index = (game_state.current_player_index + 1) % len(game_state.players)
+        opponent = game_state.players[opponent_index]
+
+        matching_cards = [card for card in opponent.hand if card.name == reveal_target.name]
+        if matching_cards:
+            if opponent.ai.should_reveal_matching_gladiator(
+                game_state, opponent, reveal_target.name, player
+            ):
+                game_state.log_callback(
+                    (
+                        "action",
+                        opponent.ai.name,
+                        f"reveals {reveal_target.name}",
+                        {"card": reveal_target.name},
+                    )
+                )
+                return
+
+        self._award_duel(player, game_state)
+
+    @staticmethod
+    def _award_duel(player, game_state):
+        player.coins += 1
+        if game_state.supply.get("Gladiator", 0) > 0:
+            game_state.supply["Gladiator"] -= 1


### PR DESCRIPTION
## Summary
- remove the extra +Buy from Gladiator and wire up its reveal duel resolution
- add AI helper hooks so players can choose reveal targets and decide when to respond

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e061decbf88327ae8fe0087f6fd2df