### PR TITLE
Implement Farmers' Market gather token logic

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -155,6 +155,29 @@ class AI(ABC):
             return "draw"
         return options[0] if options else "draw"
 
+    def choose_farmers_market_option(
+        self,
+        state: GameState,
+        player: PlayerState,
+        options: list[str],
+        pile_tokens: int,
+    ) -> str:
+        """Choose which Farmers' Market mode to use when played."""
+
+        if not options:
+            return "coins"
+
+        if "coins" not in options:
+            return options[0]
+
+        if pile_tokens <= 0:
+            return "coins"
+
+        if "vp" in options and pile_tokens >= 4:
+            return "vp"
+
+        return "coins"
+
     def choose_prince_target(
         self, state: GameState, player: PlayerState, choices: list[Optional[Card]]
     ) -> Optional[Card]:

--- a/dominion/cards/empires/farmers_market.py
+++ b/dominion/cards/empires/farmers_market.py
@@ -6,10 +6,28 @@ class FarmersMarket(Card):
         super().__init__(
             name="Farmers' Market",
             cost=CardCost(coins=3),
-            stats=CardStats(coins=2, buys=1),
+            stats=CardStats(buys=1),
             types=[CardType.ACTION],
         )
 
     def play_effect(self, game_state):
         player = game_state.current_player
-        player.vp_tokens += 1
+        pile_tokens = game_state.farmers_market_pile_tokens
+        options = ["coins", "vp"]
+        choice = player.ai.choose_farmers_market_option(
+            game_state, player, options, pile_tokens
+        )
+        if choice not in options:
+            choice = "coins"
+
+        if choice == "vp":
+            if pile_tokens > 0:
+                player.vp_tokens += pile_tokens
+                if self in player.in_play:
+                    player.in_play.remove(self)
+                game_state.trash_card(player, self)
+            game_state.farmers_market_pile_tokens = 0
+        else:
+            player.coins += pile_tokens
+
+        game_state.farmers_market_pile_tokens += 1

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -28,6 +28,7 @@ class GameState:
     hex_deck: list[str] = field(default_factory=list)
     hex_discard: list[str] = field(default_factory=list)
     wild_hunt_pile_tokens: int = 0
+    farmers_market_pile_tokens: int = 0
       
 
     def __post_init__(self):

--- a/tests/test_farmers_market.py
+++ b/tests/test_farmers_market.py
@@ -1,0 +1,60 @@
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from tests.utils import DummyAI
+
+
+def make_state(ai: DummyAI) -> tuple[GameState, PlayerState]:
+    player = PlayerState(ai)
+    state = GameState(players=[player])
+    state.log_callback = lambda *args, **kwargs: None
+    state.supply = {}
+    return state, player
+
+
+class FarmersMarketChoiceAI(DummyAI):
+    def __init__(self, choices: list[str]):
+        super().__init__()
+        self._choices = list(choices)
+
+    def choose_farmers_market_option(self, state, player, options, pile_tokens):
+        if self._choices:
+            return self._choices.pop(0)
+        return super().choose_farmers_market_option(state, player, options, pile_tokens)
+
+
+def test_farmers_market_coin_option_builds_pile_tokens():
+    ai = FarmersMarketChoiceAI(["coins", "coins"])
+    state, player = make_state(ai)
+    farmers_market = get_card("Farmers' Market")
+
+    farmers_market.play_effect(state)
+    assert player.coins == 0
+    assert state.farmers_market_pile_tokens == 1
+
+    farmers_market.play_effect(state)
+    assert player.coins == 1
+    assert state.farmers_market_pile_tokens == 2
+
+
+def test_farmers_market_vp_option_trashes_and_awards_tokens():
+    ai = FarmersMarketChoiceAI(["coins", "coins", "vp"])
+    state, player = make_state(ai)
+    farmers_market = get_card("Farmers' Market")
+
+    farmers_market.play_effect(state)
+    farmers_market.play_effect(state)
+
+    assert state.farmers_market_pile_tokens == 2
+    assert player.coins == 1
+
+    player.in_play.append(farmers_market)
+    previous_vp = player.vp_tokens
+
+    farmers_market.play_effect(state)
+
+    assert player.vp_tokens == previous_vp + 2
+    assert player.coins == 1
+    assert farmers_market not in player.in_play
+    assert farmers_market in state.trash
+    assert state.farmers_market_pile_tokens == 1


### PR DESCRIPTION
## Summary
- update Farmers' Market to use AI-driven mode selection, gather tokens, and proper coin/VP handling
- add a farmers_market_pile_tokens counter to the game state and base AI helper for the choice logic
- cover the new behaviour with unit tests for coin accumulation and VP token payout

## Testing
- pytest tests/test_farmers_market.py

------
https://chatgpt.com/codex/tasks/task_e_68e086456288832793287ffaadcec5c2