### PR TITLE
Allow Archive to choose which set-aside card to draw

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -199,6 +199,16 @@ class AI(ABC):
                     return card
         return None
 
+    def choose_archive_card(
+        self, state: GameState, player: PlayerState, choices: list[Card]
+    ) -> Optional[Card]:
+        """Select which set-aside Archive card to add to hand at the start of turn."""
+
+        if not choices:
+            return None
+
+        return choices[0]
+
     def choose_cards_to_discard(
         self,
         state: GameState,

--- a/dominion/cards/empires/archive.py
+++ b/dominion/cards/empires/archive.py
@@ -34,7 +34,14 @@ class Archive(Card):
     def on_duration(self, game_state):
         player = game_state.current_player
         if self.set_aside:
-            player.hand.append(self.set_aside.pop(0))
+            choice = player.ai.choose_archive_card(
+                game_state, player, list(self.set_aside)
+            )
+            if choice not in self.set_aside:
+                choice = self.set_aside[0]
+
+            self.set_aside.remove(choice)
+            player.hand.append(choice)
 
         if not self.set_aside:
             self.duration_persistent = False


### PR DESCRIPTION
## Summary
- add an Archive-specific selection hook to the base AI
- update Archive's duration effect to use the AI's choice when returning a card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1266ec5448327856fc73b6225b1d6