### PR TITLE
Implement Temple gathering pile mechanics

### DIFF
--- a/dominion/cards/empires/temple.py
+++ b/dominion/cards/empires/temple.py
@@ -6,7 +6,7 @@ class Temple(Card):
         super().__init__(
             name="Temple",
             cost=CardCost(coins=4),
-            stats=CardStats(coins=2),
+            stats=CardStats(vp=1),
             types=[CardType.ACTION],
         )
 
@@ -23,4 +23,16 @@ class Temple(Card):
             game_state.trash_card(player, choice)
             trashed += 1
         if trashed:
-            player.vp_tokens += trashed
+            game_state.temple_pile_tokens += trashed
+            if game_state.temple_pile_tokens >= 3:
+                player.vp_tokens += game_state.temple_pile_tokens
+                game_state.temple_pile_tokens = 0
+                if self in player.in_play:
+                    player.in_play.remove(self)
+                game_state.trash_card(player, self)
+
+    def on_gain(self, game_state, player):
+        super().on_gain(game_state, player)
+        if game_state.temple_pile_tokens:
+            player.vp_tokens += game_state.temple_pile_tokens
+            game_state.temple_pile_tokens = 0

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -29,6 +29,7 @@ class GameState:
     hex_discard: list[str] = field(default_factory=list)
     wild_hunt_pile_tokens: int = 0
     farmers_market_pile_tokens: int = 0
+    temple_pile_tokens: int = 0
       
 
     def __post_init__(self):


### PR DESCRIPTION
## Summary
- update Temple to store trashed-card VP tokens on a shared pile and trash itself when the pile is claimed
- move stored Temple Gathering tokens to the gaining player and persist the pile state on the game state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e296eeec488327b42f7e6a66cde11b