### PR TITLE
Adjust Legionary attack to respect Gold reveal and discard rules

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -60,6 +60,13 @@ class AI(ABC):
 
         return True
 
+    def should_reveal_gold_for_legionary(
+        self, state: GameState, player: PlayerState
+    ) -> bool:
+        """Decide whether to reveal a Gold when playing Legionary."""
+
+        return any(card.name == "Gold" for card in player.hand)
+
     def choose_gladiator_reveal_target(
         self, state: GameState, player: PlayerState
     ) -> Optional[Card]:

--- a/dominion/cards/empires/legionary.py
+++ b/dominion/cards/empires/legionary.py
@@ -12,13 +12,54 @@ class Legionary(Card):
 
     def play_effect(self, game_state):
         player = game_state.current_player
+        has_gold = any(card.name == "Gold" for card in player.hand)
+        if not has_gold:
+            return
+
+        if not player.ai.should_reveal_gold_for_legionary(game_state, player):
+            return
+
         def attack(target):
-            if any(card.name == "Gold" for card in target.hand):
+            if len(target.hand) <= 2:
                 return
+
+            discard_needed = len(target.hand) - 2
+            selected = target.ai.choose_cards_to_discard(
+                game_state,
+                target,
+                list(target.hand),
+                discard_needed,
+                reason="legionary",
+            )
+
+            discarded = []
+
+            for card in selected[:discard_needed]:
+                if card in target.hand:
+                    target.hand.remove(card)
+                    game_state.discard_card(target, card)
+                    discarded.append(card)
+
             while len(target.hand) > 2:
-                game_state.discard_card(target, target.hand.pop())
+                card = min(target.hand, key=self._discard_priority)
+                target.hand.remove(card)
+                game_state.discard_card(target, card)
+                discarded.append(card)
+
+            if discarded:
+                game_state.draw_cards(target, 1)
 
         for other in game_state.players:
             if other is player:
                 continue
             game_state.attack_player(other, attack)
+
+    @staticmethod
+    def _discard_priority(card):
+        if card.name == "Curse":
+            return (0, card.cost.coins, card.name)
+        if card.is_victory and not card.is_action:
+            return (1, card.cost.coins, card.name)
+        if card.name == "Copper":
+            return (2, card.cost.coins, card.name)
+        return (3, card.cost.coins, card.name)


### PR DESCRIPTION
## Summary
- add an AI hook that decides whether to reveal Gold for Legionary
- update Legionary so the attacker reveals Gold before the attack and defenders discard down to two then draw a card

## Testing
- pytest tests/test_empires_card_types.py

------
https://chatgpt.com/codex/tasks/task_e_68e296f5224083279dded69e924b89a7