### PR TITLE
Fix Chariot Race opponent comparison logic

### DIFF
--- a/dominion/cards/base_card.py
+++ b/dominion/cards/base_card.py
@@ -8,6 +8,10 @@ class CardCost:
     potions: int = 0
     debt: int = 0
 
+    def comparison_tuple(self) -> tuple[int, int, int]:
+        """Return a tuple representation for comparing card costs."""
+        return (self.coins, self.potions, self.debt)
+
 
 @dataclass
 class CardStats:

--- a/dominion/cards/empires/chariot_race.py
+++ b/dominion/cards/empires/chariot_race.py
@@ -17,15 +17,21 @@ class ChariotRace(Card):
         if not player.deck:
             return
         revealed = player.deck.pop()
-        opponent_card_cost = 0
-        for opponent in game_state.players:
-            if opponent is player:
-                continue
-            if not opponent.deck and opponent.discard:
-                opponent.shuffle_discard_into_deck()
-            if opponent.deck:
-                opponent_card_cost = max(opponent_card_cost, opponent.deck[-1].cost.coins)
         player.hand.append(revealed)
-        if revealed.cost.coins > opponent_card_cost:
+
+        if len(game_state.players) <= 1:
+            return
+
+        opponent_index = (game_state.current_player_index + 1) % len(game_state.players)
+        opponent = game_state.players[opponent_index]
+
+        if not opponent.deck and opponent.discard:
+            opponent.shuffle_discard_into_deck()
+
+        opponent_cost = (0, 0, 0)
+        if opponent.deck:
+            opponent_cost = opponent.deck[-1].cost.comparison_tuple()
+
+        if revealed.cost.comparison_tuple() > opponent_cost:
             player.coins += 1
             player.vp_tokens += 1


### PR DESCRIPTION
## Summary
- add a comparison helper on `CardCost` so potion and debt values affect ordering
- update Chariot Race to contest only the next opponent and compare full cost tuples
- ensure the opponent card stays on top and rewards are only given on a strict win

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e296efef7c8327bde639c47fde0172