### PR TITLE
Strengthen genetic search: panel fitness, richer conditions, diversity pressure

### DIFF
--- a/dominion/cards/hinterlands/cartographer.py
+++ b/dominion/cards/hinterlands/cartographer.py
@@ -29,7 +29,7 @@ class Cartographer(Card):
             else:
                 kept.append((score, card))
 
-        kept.sort()
+        kept.sort(key=lambda pair: pair[0])
         for _, card in kept:
             player.deck.append(card)
 

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -549,8 +549,10 @@ class GeneticTrainer:
                 shared_fitness = self._apply_fitness_sharing(
                     population, fitness_scores, threshold=self.sharing_threshold
                 )
-                immigrants = max(1, int(self.population_size * self.immigrant_fraction)) \
-                    if self.population_size >= 4 else 0
+                if self.population_size < 4 or self.immigrant_fraction <= 0:
+                    immigrants = 0
+                else:
+                    immigrants = max(1, int(self.population_size * self.immigrant_fraction))
 
                 population = self.create_next_generation(
                     population,

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -67,7 +67,10 @@ class GeneticTrainer:
         self._strategy_to_inject = None
         self._baseline_strategy = None
         self._baseline_panel: list[BaseStrategy] = []
-        self.last_eval_breakdown: dict[str, float] = {}
+        # List of (opponent_name, win_rate) tuples — list (not dict) so that
+        # multiple panel members sharing a name (e.g. two BigMoneySmithy
+        # variants) each contribute their rate independently.
+        self.last_eval_breakdown: list[tuple[str, float]] = []
 
         # Cache card type lookups for filtering
         from dominion.cards.registry import get_card
@@ -225,8 +228,7 @@ class GeneticTrainer:
             from dominion.ai.genetic_ai import GeneticAI
 
             games_for_opp = _distribute_games(self.games_per_eval, len(panel))
-            breakdown: dict[str, float] = {}
-            rates: list[float] = []
+            breakdown: list[tuple[str, float]] = []
             for i, opponent in enumerate(panel):
                 games_per_opp = games_for_opp[i]
                 kingdom_card_names = self.battle_system._determine_kingdom_cards(strategy, opponent)
@@ -241,10 +243,9 @@ class GeneticTrainer:
                     if winner == ai1:
                         wins += 1
                 rate = wins / games_per_opp * 100
-                breakdown[opponent.name] = rate
-                rates.append(rate)
+                breakdown.append((opponent.name, rate))
             self.last_eval_breakdown = breakdown
-            return sum(rates) / len(rates)
+            return sum(r for _, r in breakdown) / len(breakdown)
         except Exception as e:
             log.exception("Error evaluating strategy %s. Got error: %s", strategy.name, e)
             return 0.0
@@ -528,7 +529,7 @@ class GeneticTrainer:
                         if len(self.last_eval_breakdown) > 1:
                             parts = ", ".join(
                                 f"{name}: {rate:.1f}%"
-                                for name, rate in self.last_eval_breakdown.items()
+                                for name, rate in self.last_eval_breakdown
                             )
                             log.info("  panel breakdown — %s", parts)
 

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -414,10 +414,16 @@ class GeneticTrainer:
     @staticmethod
     def _strategy_similarity(a: BaseStrategy, b: BaseStrategy) -> float:
         """Top-5 gain card overlap as a fraction in [0, 1].
-        Conditions are ignored — only card identity at the top of the buy menu matters."""
+        Conditions are ignored — only card identity at the top of the buy menu matters.
+
+        The divisor is the larger of the two effective top-rule counts (capped
+        at 5), so identical small strategies (e.g. 3 rules each) still score
+        1.0 instead of being artificially capped at 0.6 and dodging fitness
+        sharing."""
         top_a = {r.card_name for r in a.gain_priority[:5]}
         top_b = {r.card_name for r in b.gain_priority[:5]}
-        return len(top_a & top_b) / 5.0
+        denom = max(1, min(5, max(len(top_a), len(top_b))))
+        return len(top_a & top_b) / denom
 
     @staticmethod
     def _normalize_priority_list(rules: list[PriorityRule]) -> list[PriorityRule]:

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -15,6 +15,21 @@ log = logging.getLogger(__name__)
 coloredlogs.install(level="INFO", logger=log)
 
 
+def _distribute_games(total_budget: int, n_opponents: int) -> list[int]:
+    """Distribute ``total_budget`` games across ``n_opponents``, preserving the
+    budget exactly when feasible. Each opponent gets ``base`` games and the
+    first ``remainder`` opponents get one extra. If the budget is smaller than
+    the panel (degenerate case), every opponent still gets at least 1 game so
+    no opponent is silently skipped — this overruns the budget but preserves
+    the panel semantic."""
+    if n_opponents <= 0:
+        return []
+    if total_budget < n_opponents:
+        return [1] * n_opponents
+    base, remainder = divmod(total_budget, n_opponents)
+    return [base + (1 if i < remainder else 0) for i in range(n_opponents)]
+
+
 class GeneticTrainer:
     """Trains Dominion strategies using a genetic algorithm"""
 
@@ -209,10 +224,11 @@ class GeneticTrainer:
             panel = self._resolve_panel()
             from dominion.ai.genetic_ai import GeneticAI
 
-            games_per_opp = max(1, self.games_per_eval // len(panel))
+            games_for_opp = _distribute_games(self.games_per_eval, len(panel))
             breakdown: dict[str, float] = {}
             rates: list[float] = []
-            for opponent in panel:
+            for i, opponent in enumerate(panel):
+                games_per_opp = games_for_opp[i]
                 kingdom_card_names = self.battle_system._determine_kingdom_cards(strategy, opponent)
                 wins = 0
                 for game_num in range(games_per_opp):

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -27,6 +27,8 @@ class GeneticTrainer:
         games_per_eval: int = 10,
         log_folder: str = "training_logs",
         board_config: Optional[BoardConfig] = None,
+        immigrant_fraction: float = 0.15,
+        sharing_threshold: float = 0.8,
     ):
         if kingdom_cards is None:
             if board_config is None:
@@ -40,6 +42,8 @@ class GeneticTrainer:
         self.mutation_rate = mutation_rate
         self.games_per_eval = games_per_eval
         self.board_config = board_config
+        self.immigrant_fraction = immigrant_fraction
+        self.sharing_threshold = sharing_threshold
         self.battle_system = StrategyBattle(kingdom_cards, log_folder, board_config=board_config)
         if not self.kingdom_cards:
             raise ValueError("kingdom_cards cannot be empty")
@@ -47,6 +51,8 @@ class GeneticTrainer:
         self.logger = GameLogger(log_folder)
         self._strategy_to_inject = None
         self._baseline_strategy = None
+        self._baseline_panel: list[BaseStrategy] = []
+        self.last_eval_breakdown: dict[str, float] = {}
 
         # Cache card type lookups for filtering
         from dominion.cards.registry import get_card
@@ -66,7 +72,9 @@ class GeneticTrainer:
     def _random_condition() -> "Callable | None":
         """Return a random callable condition from a diverse vocabulary."""
         kind = random.choice([
-            "provinces_left", "turn_number", "resources", "has_cards", "none",
+            "provinces_left", "turn_number", "resources", "has_cards",
+            "empty_piles", "deck_size", "action_density", "score_diff",
+            "actions_in_play", "max_in_deck", "none",
         ])
         if kind == "provinces_left":
             op = random.choice(["<=", ">", ">=", "<"])
@@ -88,6 +96,30 @@ class GeneticTrainer:
             )
             amount = random.randint(0, 4)
             return PriorityRule.has_cards(cards, amount)
+        if kind == "empty_piles":
+            op = random.choice([">=", ">", "<="])
+            amount = random.randint(1, 4)
+            return PriorityRule.empty_piles(op, amount)
+        if kind == "deck_size":
+            op = random.choice(["<=", ">=", "<", ">"])
+            amount = random.randint(8, 35)
+            return PriorityRule.deck_size(op, amount)
+        if kind == "action_density":
+            op = random.choice([">=", "<="])
+            percent = random.choice([20, 30, 40, 50, 60])
+            return PriorityRule.action_density(op, percent)
+        if kind == "score_diff":
+            op = random.choice([">=", "<=", ">", "<"])
+            amount = random.choice([-12, -6, -3, 0, 3, 6, 12])
+            return PriorityRule.score_diff(op, amount)
+        if kind == "actions_in_play":
+            op = random.choice([">=", "<=", ">", "<"])
+            amount = random.randint(0, 4)
+            return PriorityRule.actions_in_play(op, amount)
+        if kind == "max_in_deck":
+            card = random.choice(["Silver", "Gold", "Copper", "Estate", "Curse"])
+            amount = random.randint(1, 6)
+            return PriorityRule.max_in_deck(card, amount)
         return None
 
     def create_random_strategy(self) -> BaseStrategy:
@@ -152,34 +184,51 @@ class GeneticTrainer:
         """Set a custom baseline strategy to evaluate against instead of Big Money."""
         self._baseline_strategy = strategy
 
+    def set_baseline_panel(self, panel: list[BaseStrategy]):
+        """Set a panel of opponents. Games are split evenly across panel members,
+        and fitness is the mean of per-opponent win rates. Overrides any single
+        baseline set via set_baseline_strategy."""
+        if not panel:
+            raise ValueError("baseline panel cannot be empty")
+        self._baseline_panel = list(panel)
+
+    def _resolve_panel(self) -> list[BaseStrategy]:
+        if self._baseline_panel:
+            return self._baseline_panel
+        if self._baseline_strategy is not None:
+            return [self._baseline_strategy]
+        big_money = self.battle_system.strategy_loader.get_strategy("Big Money")
+        if not big_money:
+            raise ValueError("Big Money strategy not found")
+        return [big_money]
+
     def evaluate_strategy(self, strategy: BaseStrategy) -> float:
-        """Evaluate a strategy by playing a series of games against the baseline."""
+        """Evaluate a strategy by playing games against each panel opponent.
+        Returns the mean win rate across the panel (0-100)."""
         try:
-            if self._baseline_strategy is not None:
-                opponent = self._baseline_strategy
-            else:
-                opponent = self.battle_system.strategy_loader.get_strategy("Big Money")
-                if not opponent:
-                    raise ValueError("Big Money strategy not found")
-
-            kingdom_card_names = self.battle_system._determine_kingdom_cards(strategy, opponent)
-
+            panel = self._resolve_panel()
             from dominion.ai.genetic_ai import GeneticAI
 
-            wins = 0
-            for game_num in range(self.games_per_eval):
-                ai1 = GeneticAI(strategy)
-                ai2 = GeneticAI(opponent)
-
-                if game_num % 2 == 0:
-                    winner, _scores, _log, _turns = self.battle_system.run_game(ai1, ai2, kingdom_card_names)
+            games_per_opp = max(1, self.games_per_eval // len(panel))
+            breakdown: dict[str, float] = {}
+            rates: list[float] = []
+            for opponent in panel:
+                kingdom_card_names = self.battle_system._determine_kingdom_cards(strategy, opponent)
+                wins = 0
+                for game_num in range(games_per_opp):
+                    ai1 = GeneticAI(strategy)
+                    ai2 = GeneticAI(opponent)
+                    if game_num % 2 == 0:
+                        winner, _s, _l, _t = self.battle_system.run_game(ai1, ai2, kingdom_card_names)
+                    else:
+                        winner, _s, _l, _t = self.battle_system.run_game(ai2, ai1, kingdom_card_names)
                     if winner == ai1:
                         wins += 1
-                else:
-                    winner, _scores, _log, _turns = self.battle_system.run_game(ai2, ai1, kingdom_card_names)
-                    if winner == ai1:
-                        wins += 1
-            return wins / self.games_per_eval * 100
+                rate = wins / games_per_opp * 100
+                breakdown[opponent.name] = rate
+                rates.append(rate)
+            self.last_eval_breakdown = breakdown
+            return sum(rates) / len(rates)
         except Exception as e:
             log.exception("Error evaluating strategy %s. Got error: %s", strategy.name, e)
             return 0.0
@@ -214,18 +263,23 @@ class GeneticTrainer:
     def _mutate(self, strategy: BaseStrategy) -> BaseStrategy:
         """Mutate a strategy"""
         # --- Mutate gain priorities ---
-        # Condition mutations
+        # Condition mutations: drop, replace, or fresh-from-none
         for priority in strategy.gain_priority:
             if random.random() < self.mutation_rate:
                 if random.random() < 0.3:
-                    if priority.condition:
-                        priority.condition = None
-                    else:
+                    if priority.condition is None:
+                        # No condition — add one
                         if priority.card_name in ["Silver", "Gold", "Province"]:
                             cost = {"Silver": 3, "Gold": 6, "Province": 8}[priority.card_name]
                             priority.condition = PriorityRule.resources("coins", ">=", cost)
                         elif priority.card_name in self.kingdom_cards:
                             priority.condition = PriorityRule.turn_number("<=", random.randint(5, 15))
+                        else:
+                            priority.condition = self._random_condition()
+                    else:
+                        # Existing condition — half the time drop it, half the time replace
+                        if random.random() < 0.5:
+                            priority.condition = None
                         else:
                             priority.condition = self._random_condition()
 
@@ -323,6 +377,32 @@ class GeneticTrainer:
         return strategy
 
     @staticmethod
+    def _apply_fitness_sharing(
+        population: list[BaseStrategy],
+        raw_fitness: list[float],
+        threshold: float = 0.8,
+    ) -> list[float]:
+        """Divide each individual's fitness by its niche count (members within
+        ``threshold`` similarity, including itself). Clones lose to unique
+        strategies at the same skill level."""
+        shared: list[float] = []
+        for i, individual in enumerate(population):
+            niche = sum(
+                1 for other in population
+                if GeneticTrainer._strategy_similarity(individual, other) >= threshold
+            )
+            shared.append(raw_fitness[i] / max(1, niche))
+        return shared
+
+    @staticmethod
+    def _strategy_similarity(a: BaseStrategy, b: BaseStrategy) -> float:
+        """Top-5 gain card overlap as a fraction in [0, 1].
+        Conditions are ignored — only card identity at the top of the buy menu matters."""
+        top_a = {r.card_name for r in a.gain_priority[:5]}
+        top_b = {r.card_name for r in b.gain_priority[:5]}
+        return len(top_a & top_b) / 5.0
+
+    @staticmethod
     def _normalize_priority_list(rules: list[PriorityRule]) -> list[PriorityRule]:
         """Remove unreachable rules from a priority list.
 
@@ -354,18 +434,39 @@ class GeneticTrainer:
         winner_idx = max(tournament_indices, key=lambda i: fitness_scores[i])
         return deepcopy(population[winner_idx])
 
-    def create_next_generation(self, population: list[BaseStrategy], fitness_scores: list[float]) -> list[BaseStrategy]:
-        """Create the next generation through selection, crossover, and mutation"""
-        new_population = []
+    def create_next_generation(
+        self,
+        population: list[BaseStrategy],
+        fitness_scores: list[float],
+        selection_fitness: list[float] | None = None,
+        immigrant_count: int = 0,
+    ) -> list[BaseStrategy]:
+        """Create the next generation through elitism, random immigrants, and
+        crossover+mutation of selected parents.
 
-        # Keep best strategy (elitism)
+        ``fitness_scores`` (raw) is used for elitism so the actual best individual
+        always survives. ``selection_fitness`` (defaults to ``fitness_scores``)
+        drives tournament selection — pass shared fitness here for diversity
+        pressure. ``immigrant_count`` reserves that many slots for fresh
+        randomly-generated strategies (genetic-drift breaker)."""
+        if selection_fitness is None:
+            selection_fitness = fitness_scores
+
+        new_population: list[BaseStrategy] = []
+
+        # Elite by raw fitness
         best_idx = fitness_scores.index(max(fitness_scores))
         new_population.append(deepcopy(population[best_idx]))
 
-        # Create rest through crossover and mutation
+        # Random immigrants (capped to leave room for elite)
+        immigrants = max(0, min(immigrant_count, self.population_size - 1))
+        for _ in range(immigrants):
+            new_population.append(self.create_random_strategy())
+
+        # Fill remaining slots via tournament selection + crossover + mutation
         while len(new_population) < self.population_size:
-            parent1 = self._tournament_select(population, fitness_scores)
-            parent2 = self._tournament_select(population, fitness_scores)
+            parent1 = self._tournament_select(population, selection_fitness)
+            parent2 = self._tournament_select(population, selection_fitness)
 
             child = self._crossover(parent1, parent2)
             child = self._mutate(child)
@@ -408,6 +509,12 @@ class GeneticTrainer:
                         best_fitness = fitness
                         best_strategy = deepcopy(strategy)
                         log.info("New best fitness: %.2f", best_fitness)
+                        if len(self.last_eval_breakdown) > 1:
+                            parts = ", ".join(
+                                f"{name}: {rate:.1f}%"
+                                for name, rate in self.last_eval_breakdown.items()
+                            )
+                            log.info("  panel breakdown — %s", parts)
 
                 # Calculate generation statistics
                 avg_fitness = sum(fitness_scores) / len(fitness_scores)
@@ -415,8 +522,19 @@ class GeneticTrainer:
                 # Update progress
                 self.logger.update_training(gen, best_fitness, avg_fitness)
 
-                # Create next generation
-                population = self.create_next_generation(population, fitness_scores)
+                # Diversity pressure: shared fitness for selection, random immigrants
+                shared_fitness = self._apply_fitness_sharing(
+                    population, fitness_scores, threshold=self.sharing_threshold
+                )
+                immigrants = max(1, int(self.population_size * self.immigrant_fraction)) \
+                    if self.population_size >= 4 else 0
+
+                population = self.create_next_generation(
+                    population,
+                    fitness_scores,
+                    selection_fitness=shared_fitness,
+                    immigrant_count=immigrants,
+                )
 
             # End training progress tracking
             self.logger.end_training()

--- a/dominion/strategy/enhanced_strategy.py
+++ b/dominion/strategy/enhanced_strategy.py
@@ -112,6 +112,51 @@ class PriorityRule:
         return PriorityRule._tag_source(fn, f"PriorityRule.deck_count_diff({card_a!r}, {card_b!r}, {op!r}, {amount!r})")
 
     @staticmethod
+    def empty_piles(op: str, amount: int) -> Callable[["GameState", "PlayerState"], bool]:
+        """True when the number of emptied supply piles satisfies the comparison."""
+        cmp = PriorityRule._OP_MAP[op]
+        fn = lambda s, _me, _amount=amount, _cmp=cmp: _cmp(s.empty_piles, _amount)
+        return PriorityRule._tag_source(fn, f"PriorityRule.empty_piles({op!r}, {amount!r})")
+
+    @staticmethod
+    def deck_size(op: str, amount: int) -> Callable[["GameState", "PlayerState"], bool]:
+        """True when the player's total deck size (all zones) satisfies the comparison."""
+        cmp = PriorityRule._OP_MAP[op]
+        fn = lambda _s, me, _amount=amount, _cmp=cmp: _cmp(len(me.all_cards()), _amount)
+        return PriorityRule._tag_source(fn, f"PriorityRule.deck_size({op!r}, {amount!r})")
+
+    @staticmethod
+    def action_density(op: str, percent: int) -> Callable[["GameState", "PlayerState"], bool]:
+        """True when the percentage of action cards in the deck satisfies the comparison.
+        Empty decks are treated as 0% density."""
+        cmp = PriorityRule._OP_MAP[op]
+
+        def _eval(_s, me, _amount=percent, _cmp=cmp):
+            cards = me.all_cards()
+            if not cards:
+                return _cmp(0, _amount)
+            density = sum(1 for c in cards if c.is_action) * 100 // len(cards)
+            return _cmp(density, _amount)
+
+        return PriorityRule._tag_source(_eval, f"PriorityRule.action_density({op!r}, {percent!r})")
+
+    @staticmethod
+    def score_diff(op: str, amount: int) -> Callable[["GameState", "PlayerState"], bool]:
+        """True when (my VP - max opponent VP) satisfies the comparison.
+        Useful for endgame decisions (e.g. trigger pile-out when ahead)."""
+        cmp = PriorityRule._OP_MAP[op]
+
+        def _eval(s, me, _amount=amount, _cmp=cmp):
+            my_vp = me.get_victory_points(s)
+            opp_vps = [
+                p.get_victory_points(s) for p in s.players if p is not me
+            ]
+            opp_best = max(opp_vps) if opp_vps else 0
+            return _cmp(my_vp - opp_best, _amount)
+
+        return PriorityRule._tag_source(_eval, f"PriorityRule.score_diff({op!r}, {amount!r})")
+
+    @staticmethod
     def always_true() -> Callable[["GameState", "PlayerState"], bool]:
         fn = lambda *_: True
         return PriorityRule._tag_source(fn, "PriorityRule.always_true()")

--- a/evolve.py
+++ b/evolve.py
@@ -131,6 +131,13 @@ def main():
         help="Games to validate each evolved strategy (default: 200)",
     )
     parser.add_argument(
+        "--baseline-panel",
+        nargs="+",
+        default=None,
+        help="Optional module:function specs to use as the fitness panel during evolution. "
+        "If omitted, the best seed strategy is used as the single baseline.",
+    )
+    parser.add_argument(
         "--output-dir", type=Path, default=Path("generated_strategies"),
         help="Directory to save evolved strategies (default: generated_strategies/)",
     )
@@ -186,6 +193,13 @@ def main():
 
     baseline = best_seed_factory()
 
+    panel_strategies: list = []
+    if args.baseline_panel:
+        panel_strategies = [_load_factory(spec)() for spec in args.baseline_panel]
+        logger.info("Using fitness panel: %s", ", ".join(p.name for p in panel_strategies))
+    else:
+        logger.info("Using single baseline: %s", best_seed_name)
+
     for seed_name, seed_factory in seeds.items():
         logger.info("\nEvolving from: %s", seed_name)
 
@@ -198,7 +212,10 @@ def main():
             board_config=board_config,
         )
         trainer.inject_strategy(seed_factory())
-        trainer.set_baseline_strategy(baseline)
+        if panel_strategies:
+            trainer.set_baseline_panel(panel_strategies)
+        else:
+            trainer.set_baseline_strategy(baseline)
 
         best_strategy, metrics = trainer.train()
 

--- a/runner.py
+++ b/runner.py
@@ -255,7 +255,9 @@ def main():
             )
             validation_battle = StrategyBattle(board_config=board_config, log_frequency=1000)
             validation_kingdom = board_config.kingdom_cards if board_config else kingdom_cards
-            per_opp = {}
+            # List of (name, rate) so panel members sharing a name (e.g. two
+            # BigMoneySmithy variants) each contribute independently to the mean.
+            per_opp: list[tuple[str, float]] = []
             for idx, opp in enumerate(panel):
                 games_per_opp = games_for_opp[idx]
                 wins = 0
@@ -269,9 +271,9 @@ def main():
                     if winner == ai1:
                         wins += 1
                 rate = wins / games_per_opp * 100
-                per_opp[opp.name] = rate
+                per_opp.append((opp.name, rate))
                 logger.info("  vs %s: %.1f%%", opp.name, rate)
-            mean_rate = sum(per_opp.values()) / len(per_opp)
+            mean_rate = sum(r for _, r in per_opp) / len(per_opp)
             logger.info("Validation mean win rate: %.1f%%", mean_rate)
             if mean_rate <= 50:
                 logger.info("⚠️  Strategy did not beat panel mean (%.1f%%). Saving anyway for inspection.", mean_rate)

--- a/runner.py
+++ b/runner.py
@@ -245,17 +245,19 @@ def main():
         if panel:
             from dominion.simulation.strategy_battle import StrategyBattle
             from dominion.ai.genetic_ai import GeneticAI
+            from dominion.simulation.genetic_trainer import _distribute_games
 
             n_validation = 100
-            games_per_opp = max(1, n_validation // len(panel))
+            games_for_opp = _distribute_games(n_validation, len(panel))
             logger.info(
-                "Validating: %d games per opponent across %d-strategy panel...",
-                games_per_opp, len(panel),
+                "Validating: %d games distributed across %d-strategy panel (%s)...",
+                sum(games_for_opp), len(panel), games_for_opp,
             )
             validation_battle = StrategyBattle(board_config=board_config, log_frequency=1000)
             validation_kingdom = board_config.kingdom_cards if board_config else kingdom_cards
             per_opp = {}
-            for opp in panel:
+            for idx, opp in enumerate(panel):
+                games_per_opp = games_for_opp[idx]
                 wins = 0
                 for i in range(games_per_opp):
                     ai1 = GeneticAI(best_strategy)

--- a/runner.py
+++ b/runner.py
@@ -92,9 +92,9 @@ def main():
     parser.add_argument("--kingdom-cards", nargs="+", help="List of kingdom cards to use for training")
     parser.add_argument("--config", "-c", help="YAML configuration file containing kingdom cards")
     parser.add_argument(
-        "--population-size", type=int, default=5, help="Population size for genetic algorithm (default: 5)"
+        "--population-size", type=int, default=25, help="Population size for genetic algorithm (default: 25)"
     )
-    parser.add_argument("--generations", type=int, default=10, help="Number of generations to run (default: 10)")
+    parser.add_argument("--generations", type=int, default=40, help="Number of generations to run (default: 40)")
     parser.add_argument("--mutation-rate", type=float, default=0.1, help="Mutation rate (default: 0.1)")
     parser.add_argument(
         "--games-per-eval", type=int, default=10, help="Number of games to play per strategy evaluation (default: 10)"
@@ -109,6 +109,12 @@ def main():
         "--baseline-strategy",
         help="Python module path to a strategy factory function to evaluate against instead of Big Money "
         "(e.g. generated_strategies.torture_campaign_v2:create_torture_campaign_v2)",
+    )
+    parser.add_argument(
+        "--baseline-panel",
+        nargs="+",
+        help="Multiple module:function specs evaluated as a panel of opponents. Games are split "
+        "evenly across the panel; fitness is the mean per-opponent win rate. Overrides --baseline-strategy.",
     )
 
     args = parser.parse_args()
@@ -195,11 +201,21 @@ def main():
             logger.error("Failed to load seed strategy: %s", exc)
             sys.exit(1)
 
-    # Set baseline strategy if provided
-    if args.baseline_strategy:
+    # Set baseline panel (preferred) or single baseline
+    panel: list = []
+    if args.baseline_panel:
+        try:
+            panel = [_load_strategy(spec) for spec in args.baseline_panel]
+            trainer.set_baseline_panel(panel)
+            logger.info("Evaluating against panel: %s", ", ".join(p.name for p in panel))
+        except Exception as exc:
+            logger.error("Failed to load baseline panel: %s", exc)
+            sys.exit(1)
+    elif args.baseline_strategy:
         try:
             baseline = _load_strategy(args.baseline_strategy)
             trainer.set_baseline_strategy(baseline)
+            panel = [baseline]
             logger.info("Evaluating against baseline: %s", baseline.name)
         except Exception as exc:
             logger.error("Failed to load baseline strategy: %s", exc)
@@ -225,31 +241,38 @@ def main():
             condition_str = f" (condition: {rule.condition})" if rule.condition else ""
             logger.info("  %s%s", rule.card_name, condition_str)
 
-        # Validate against baseline before saving
-        if args.baseline_strategy:
+        # Validate against panel (or single baseline) and report — always save.
+        if panel:
             from dominion.simulation.strategy_battle import StrategyBattle
             from dominion.ai.genetic_ai import GeneticAI
 
-            logger.info("Validating against baseline (%s) over 100 games...", baseline.name)
+            n_validation = 100
+            games_per_opp = max(1, n_validation // len(panel))
+            logger.info(
+                "Validating: %d games per opponent across %d-strategy panel...",
+                games_per_opp, len(panel),
+            )
             validation_battle = StrategyBattle(board_config=board_config, log_frequency=1000)
             validation_kingdom = board_config.kingdom_cards if board_config else kingdom_cards
-            wins = 0
-            n_validation = 100
-            for i in range(n_validation):
-                ai1 = GeneticAI(best_strategy)
-                ai2 = GeneticAI(baseline)
-                if i % 2 == 0:
-                    winner, _, _, _ = validation_battle.run_game(ai1, ai2, validation_kingdom)
-                else:
-                    winner, _, _, _ = validation_battle.run_game(ai2, ai1, validation_kingdom)
-                if winner == ai1:
-                    wins += 1
-            win_rate = wins / n_validation * 100
-            logger.info("Validation result: %.1f%% win rate against baseline", win_rate)
-
-            if win_rate <= 50:
-                logger.info("⏭️  Strategy does not beat baseline (%.1f%%). Not saving.", win_rate)
-                return
+            per_opp = {}
+            for opp in panel:
+                wins = 0
+                for i in range(games_per_opp):
+                    ai1 = GeneticAI(best_strategy)
+                    ai2 = GeneticAI(opp)
+                    if i % 2 == 0:
+                        winner, _, _, _ = validation_battle.run_game(ai1, ai2, validation_kingdom)
+                    else:
+                        winner, _, _, _ = validation_battle.run_game(ai2, ai1, validation_kingdom)
+                    if winner == ai1:
+                        wins += 1
+                rate = wins / games_per_opp * 100
+                per_opp[opp.name] = rate
+                logger.info("  vs %s: %.1f%%", opp.name, rate)
+            mean_rate = sum(per_opp.values()) / len(per_opp)
+            logger.info("Validation mean win rate: %.1f%%", mean_rate)
+            if mean_rate <= 50:
+                logger.info("⚠️  Strategy did not beat panel mean (%.1f%%). Saving anyway for inspection.", mean_rate)
 
         # Automatically save the strategy as a Python class
         strategies_dir = Path("generated_strategies")

--- a/tests/test_cartographer.py
+++ b/tests/test_cartographer.py
@@ -1,0 +1,39 @@
+"""Regression test: Cartographer must not crash when two top-4 cards tie on score.
+
+The original `kept.sort()` on a list of `(int, Card)` tuples fell back to comparing
+Card instances when scores tied, raising TypeError because Card has no __lt__.
+"""
+
+from dominion.cards.registry import get_card
+from dominion.cards.hinterlands.cartographer import Cartographer
+
+
+def test_cartographer_does_not_crash_when_scores_tie():
+    """Two Coppers in the revealed pile both score 2 — sorting must not compare cards."""
+    import types
+
+    cartographer = Cartographer()
+
+    copper_a = get_card("Copper")
+    copper_b = get_card("Copper")
+    silver = get_card("Silver")
+    estate = get_card("Estate")
+
+    discarded: list = []
+    player = types.SimpleNamespace(
+        deck=[estate, copper_a, copper_b, silver],  # popped in reverse: silver, copper_b, copper_a, estate
+        discard=[],
+        shuffle_discard_into_deck=lambda: None,
+    )
+
+    game_state = types.SimpleNamespace(
+        current_player=player,
+        discard_card=lambda p, c: discarded.append(c),
+    )
+
+    # Should not raise.
+    cartographer.play_effect(game_state)
+
+    # Estate (score -2) was discarded; the rest are kept on top of the deck.
+    assert estate in discarded
+    assert all(c.name in {"Silver", "Copper"} for c in player.deck)

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -585,6 +585,35 @@ class TestCreateNextGenerationElitism:
         assert next_pop[0].gain_priority[0].card_name == "Province"
 
 
+class TestImmigrantFractionZeroIsHonored:
+    """immigrant_fraction=0 must produce 0 immigrants — currently the
+    max(1, ...) floor silently overrides this."""
+
+    def test_zero_immigrant_fraction_passes_zero_to_next_gen(self, monkeypatch):
+        trainer = GeneticTrainer(
+            ["Village"],
+            population_size=8,
+            generations=1,
+            games_per_eval=2,
+            immigrant_fraction=0.0,
+        )
+        monkeypatch.setattr(trainer, "evaluate_strategy", lambda s: 50.0)
+
+        captured: dict = {}
+        original = trainer.create_next_generation
+
+        def spy(pop, raw, **kwargs):
+            captured["immigrants"] = kwargs.get("immigrant_count", 0)
+            return original(pop, raw, **kwargs)
+
+        monkeypatch.setattr(trainer, "create_next_generation", spy)
+        trainer.train()
+
+        assert captured["immigrants"] == 0, (
+            f"immigrant_fraction=0 should yield 0 immigrants, got {captured['immigrants']}"
+        )
+
+
 class TestTrainWiresDiversityPressure:
     """train() should pass selection_fitness (sharing-adjusted) and a non-zero
     immigrant_count to create_next_generation."""

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -546,6 +546,14 @@ class TestStrategySimilarity:
         # Intersection of first-5: {Province, Gold} → 2/5 = 0.4
         assert GeneticTrainer._strategy_similarity(s1, s2) == 0.4
 
+    def test_short_identical_strategies_get_similarity_one(self):
+        """A 3-rule strategy compared to itself must score 1.0, otherwise
+        identical small strategies dodge fitness sharing (0.6 < 0.8 threshold)."""
+        s1 = _strategy_with_gain("Province", "Gold", "Witch")
+        s2 = _strategy_with_gain("Province", "Gold", "Witch")
+        sim = GeneticTrainer._strategy_similarity(s1, s2)
+        assert sim == 1.0, f"Identical 3-rule strategies should be 1.0, got {sim}"
+
     def test_only_card_name_matters_not_condition(self):
         """Conditions don't affect similarity."""
         s1 = BaseStrategy()

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -456,6 +456,37 @@ class TestPanelEvaluation:
         for n in games.values():
             assert n in (3, 4), f"Each opponent should get 3 or 4 games, got {n}"
 
+    def test_panel_with_duplicate_opponent_names_preserves_all_rates(self, monkeypatch):
+        """Two panel members sharing a name (e.g. both BigMoneySmithy variants)
+        must both contribute to the breakdown — a dict keyed by name silently
+        loses one of them."""
+        trainer = GeneticTrainer(["Village"], population_size=1, generations=1, games_per_eval=4)
+        strategy = make_stub_strategy()
+        strategy.name = "Stub"
+
+        opp_a1 = _make_dummy_opponent("Twin")
+        opp_a2 = _make_dummy_opponent("Twin")
+        trainer.set_baseline_panel([opp_a1, opp_a2])
+
+        # opp_a1 always loses to Stub, opp_a2 always beats Stub
+        def fake_run_game(first_ai, second_ai, kingdom):
+            for ai in (first_ai, second_ai):
+                if ai.strategy is opp_a1:
+                    winner = first_ai if first_ai.strategy.name == "Stub" else second_ai
+                    return winner, {}, None, 0
+                if ai.strategy is opp_a2:
+                    winner = first_ai if first_ai.strategy is opp_a2 else second_ai
+                    return winner, {}, None, 0
+            return first_ai, {}, None, 0
+
+        monkeypatch.setattr(trainer.battle_system, "run_game", fake_run_game)
+        trainer.evaluate_strategy(strategy)
+
+        breakdown = trainer.last_eval_breakdown
+        assert len(breakdown) == 2, (
+            f"Expected 2 entries (one per panel member), got {len(breakdown)}: {breakdown}"
+        )
+
     def test_panel_per_opponent_breakdown_is_exposed(self, monkeypatch):
         trainer = GeneticTrainer(["Village"], population_size=1, generations=1, games_per_eval=4)
         strategy = make_stub_strategy()
@@ -477,7 +508,7 @@ class TestPanelEvaluation:
         trainer.evaluate_strategy(strategy)
 
         breakdown = trainer.last_eval_breakdown
-        assert breakdown == {"AlwaysLose": 100.0, "AlwaysWin": 0.0}, breakdown
+        assert breakdown == [("AlwaysLose", 100.0), ("AlwaysWin", 0.0)], breakdown
 
 
 def _strategy_with_gain(*card_names: str) -> BaseStrategy:

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -429,6 +429,33 @@ class TestPanelEvaluation:
         # 100% vs AlwaysLose, 0% vs AlwaysWin → mean 50%
         assert fitness == 50.0, f"Expected 50.0, got {fitness}"
 
+    def test_panel_evaluation_uses_full_games_budget(self, monkeypatch):
+        """games_per_eval=10 with 3 opponents should run exactly 10 total games
+        (distributed 4+3+3), not 9 from floor division."""
+        trainer = GeneticTrainer(["Village"], population_size=1, generations=1, games_per_eval=10)
+        strategy = make_stub_strategy()
+
+        opp_a = _make_dummy_opponent("A")
+        opp_b = _make_dummy_opponent("B")
+        opp_c = _make_dummy_opponent("C")
+        trainer.set_baseline_panel([opp_a, opp_b, opp_c])
+
+        games = {"A": 0, "B": 0, "C": 0}
+
+        def fake_run_game(first_ai, second_ai, kingdom):
+            for ai in (first_ai, second_ai):
+                if ai.strategy.name in games:
+                    games[ai.strategy.name] += 1
+            return first_ai, {}, None, 0
+
+        monkeypatch.setattr(trainer.battle_system, "run_game", fake_run_game)
+        trainer.evaluate_strategy(strategy)
+
+        assert sum(games.values()) == 10, f"Expected 10 total games, got {sum(games.values())}: {games}"
+        # Every opponent gets at least floor(10/3)=3 games
+        for n in games.values():
+            assert n in (3, 4), f"Each opponent should get 3 or 4 games, got {n}"
+
     def test_panel_per_opponent_breakdown_is_exposed(self, monkeypatch):
         trainer = GeneticTrainer(["Village"], population_size=1, generations=1, games_per_eval=4)
         strategy = make_stub_strategy()

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -46,15 +46,17 @@ def test_evaluate_strategy_counts_second_seat_wins(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def _make_mock_state(turn_number=5, provinces_left=8):
+def _make_mock_state(turn_number=5, provinces_left=8, empty_piles=0, players=None):
     """Create a lightweight mock GameState."""
     state = types.SimpleNamespace()
     state.turn_number = turn_number
     state.supply = {"Province": provinces_left}
+    state.empty_piles = empty_piles
+    state.players = players if players is not None else []
     return state
 
 
-def _make_mock_player(coins=3, actions=1, buys=1):
+def _make_mock_player(coins=3, actions=1, buys=1, vp=3, all_cards=None):
     """Create a lightweight mock PlayerState."""
     player = types.SimpleNamespace()
     player.coins = coins
@@ -62,6 +64,9 @@ def _make_mock_player(coins=3, actions=1, buys=1):
     player.buys = buys
     player.hand = []
     player.count_in_deck = lambda card_name: {"Silver": 2, "Gold": 1}.get(card_name, 0)
+    cards = all_cards if all_cards is not None else []
+    player.all_cards = lambda _cards=cards: list(_cards)
+    player.get_victory_points = lambda _g=None, _vp=vp: _vp
     return player
 
 
@@ -143,6 +148,104 @@ class TestConditionsEvaluate:
                     assert isinstance(result, bool), (
                         f"Condition for {rule.card_name} returned {type(result)}, expected bool"
                     )
+
+
+class TestNewPrimitives:
+    """Verify the new condition primitives evaluate correctly and tag _source."""
+
+    def test_empty_piles_evaluates(self):
+        cond = PriorityRule.empty_piles(">=", 2)
+        assert cond(_make_mock_state(empty_piles=3), _make_mock_player()) is True
+        assert cond(_make_mock_state(empty_piles=1), _make_mock_player()) is False
+
+    def test_empty_piles_source(self):
+        cond = PriorityRule.empty_piles(">=", 2)
+        assert cond._source == "PriorityRule.empty_piles('>=', 2)"
+
+    def test_deck_size_evaluates(self):
+        # all_cards returns a list whose length is the deck size
+        player = _make_mock_player(all_cards=[1, 2, 3, 4, 5])
+        cond = PriorityRule.deck_size(">=", 5)
+        assert cond(_make_mock_state(), player) is True
+        cond_lt = PriorityRule.deck_size("<", 3)
+        assert cond_lt(_make_mock_state(), player) is False
+
+    def test_deck_size_source(self):
+        cond = PriorityRule.deck_size(">", 10)
+        assert cond._source == "PriorityRule.deck_size('>', 10)"
+
+    def test_action_density_evaluates(self):
+        # 2 of 4 cards are actions → density 50%
+        action_card = types.SimpleNamespace(is_action=True)
+        treasure_card = types.SimpleNamespace(is_action=False)
+        deck = [action_card, action_card, treasure_card, treasure_card]
+        player = _make_mock_player(all_cards=deck)
+
+        cond_high = PriorityRule.action_density(">=", 50)
+        assert cond_high(_make_mock_state(), player) is True
+        cond_low = PriorityRule.action_density(">=", 75)
+        assert cond_low(_make_mock_state(), player) is False
+
+    def test_action_density_empty_deck_safe(self):
+        """Empty deck must not divide by zero — treat density as 0."""
+        cond = PriorityRule.action_density(">=", 1)
+        empty_player = _make_mock_player(all_cards=[])
+        # 0% density should be < 1, so >=1 is False
+        assert cond(_make_mock_state(), empty_player) is False
+
+    def test_action_density_source(self):
+        cond = PriorityRule.action_density(">=", 40)
+        assert cond._source == "PriorityRule.action_density('>=', 40)"
+
+    def test_score_diff_evaluates(self):
+        # My VP=10, opponent VP=4 → diff +6
+        me = _make_mock_player(vp=10)
+        opp = _make_mock_player(vp=4)
+        state = _make_mock_state(players=[me, opp])
+        cond_winning = PriorityRule.score_diff(">=", 5)
+        assert cond_winning(state, me) is True
+        cond_blowout = PriorityRule.score_diff(">=", 10)
+        assert cond_blowout(state, me) is False
+
+    def test_score_diff_when_losing(self):
+        me = _make_mock_player(vp=2)
+        opp = _make_mock_player(vp=8)
+        state = _make_mock_state(players=[me, opp])
+        cond = PriorityRule.score_diff("<=", -3)
+        assert cond(state, me) is True
+
+    def test_score_diff_source(self):
+        cond = PriorityRule.score_diff(">=", 6)
+        assert cond._source == "PriorityRule.score_diff('>=', 6)"
+
+
+class TestRandomConditionVocabulary:
+    """The genetic trainer's _random_condition should draw from the full primitive set,
+    not just the original 4 kinds (provinces_left/turn_number/resources/has_cards)."""
+
+    def test_random_condition_includes_new_primitives(self):
+        """Sampling 400 conditions should produce at least one of each new primitive."""
+        random_local = __import__("random")
+        random_local.seed(0)
+        sources: set[str] = set()
+        for _ in range(400):
+            cond = GeneticTrainer._random_condition()
+            if cond is None:
+                continue
+            src = getattr(cond, "_source", "")
+            # Tag by primitive name (everything before the first '(')
+            sources.add(src.split("(")[0])
+
+        expected = {
+            "PriorityRule.empty_piles",
+            "PriorityRule.deck_size",
+            "PriorityRule.action_density",
+            "PriorityRule.score_diff",
+            "PriorityRule.actions_in_play",
+            "PriorityRule.max_in_deck",
+        }
+        missing = expected - sources
+        assert not missing, f"Random vocabulary missing: {missing}. Got: {sources}"
 
 
 class TestSourceAttribute:
@@ -263,6 +366,287 @@ class TestSerialization:
         finally:
             sys.path.pop(0)
             sys.modules.pop("no_cond_strategy", None)
+
+
+def _make_dummy_opponent(name: str) -> BaseStrategy:
+    opp = BaseStrategy()
+    opp.name = name
+    opp.gain_priority = [PriorityRule("Province")]
+    opp.treasure_priority = [
+        PriorityRule("Gold"),
+        PriorityRule("Silver"),
+        PriorityRule("Copper"),
+    ]
+    return opp
+
+
+class TestPanelEvaluation:
+    """Verify panel-based fitness: split games across multiple opponents."""
+
+    def test_panel_evaluation_distributes_games_across_opponents(self, monkeypatch):
+        trainer = GeneticTrainer(["Village"], population_size=1, generations=1, games_per_eval=4)
+        strategy = make_stub_strategy()
+
+        opp_a = _make_dummy_opponent("OpponentA")
+        opp_b = _make_dummy_opponent("OpponentB")
+        trainer.set_baseline_panel([opp_a, opp_b])
+
+        games_against = {"OpponentA": 0, "OpponentB": 0}
+
+        def fake_run_game(first_ai, second_ai, kingdom):
+            for ai in (first_ai, second_ai):
+                if ai.strategy.name in games_against:
+                    games_against[ai.strategy.name] += 1
+            return first_ai, {}, None, 0
+
+        monkeypatch.setattr(trainer.battle_system, "run_game", fake_run_game)
+        trainer.evaluate_strategy(strategy)
+
+        assert games_against["OpponentA"] == 2, games_against
+        assert games_against["OpponentB"] == 2, games_against
+
+    def test_panel_fitness_is_mean_of_per_opponent_rates(self, monkeypatch):
+        trainer = GeneticTrainer(["Village"], population_size=1, generations=1, games_per_eval=4)
+        strategy = make_stub_strategy()
+        strategy.name = "Stub"
+
+        opp_a = _make_dummy_opponent("AlwaysLose")
+        opp_b = _make_dummy_opponent("AlwaysWin")
+        trainer.set_baseline_panel([opp_a, opp_b])
+
+        def fake_run_game(first_ai, second_ai, kingdom):
+            # Stub beats AlwaysLose in every game, loses to AlwaysWin in every game
+            names = (first_ai.strategy.name, second_ai.strategy.name)
+            if "AlwaysLose" in names:
+                winner = first_ai if first_ai.strategy.name == "Stub" else second_ai
+            else:  # AlwaysWin matchup
+                winner = first_ai if first_ai.strategy.name == "AlwaysWin" else second_ai
+            return winner, {}, None, 0
+
+        monkeypatch.setattr(trainer.battle_system, "run_game", fake_run_game)
+
+        fitness = trainer.evaluate_strategy(strategy)
+        # 100% vs AlwaysLose, 0% vs AlwaysWin → mean 50%
+        assert fitness == 50.0, f"Expected 50.0, got {fitness}"
+
+    def test_panel_per_opponent_breakdown_is_exposed(self, monkeypatch):
+        trainer = GeneticTrainer(["Village"], population_size=1, generations=1, games_per_eval=4)
+        strategy = make_stub_strategy()
+        strategy.name = "Stub"
+
+        opp_a = _make_dummy_opponent("AlwaysLose")
+        opp_b = _make_dummy_opponent("AlwaysWin")
+        trainer.set_baseline_panel([opp_a, opp_b])
+
+        def fake_run_game(first_ai, second_ai, kingdom):
+            names = (first_ai.strategy.name, second_ai.strategy.name)
+            if "AlwaysLose" in names:
+                winner = first_ai if first_ai.strategy.name == "Stub" else second_ai
+            else:
+                winner = first_ai if first_ai.strategy.name == "AlwaysWin" else second_ai
+            return winner, {}, None, 0
+
+        monkeypatch.setattr(trainer.battle_system, "run_game", fake_run_game)
+        trainer.evaluate_strategy(strategy)
+
+        breakdown = trainer.last_eval_breakdown
+        assert breakdown == {"AlwaysLose": 100.0, "AlwaysWin": 0.0}, breakdown
+
+
+def _strategy_with_gain(*card_names: str) -> BaseStrategy:
+    s = BaseStrategy()
+    s.name = "tmp"
+    s.gain_priority = [PriorityRule(c) for c in card_names]
+    s.action_priority = []
+    s.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
+    s.trash_priority = []
+    return s
+
+
+class TestStrategySimilarity:
+    """Top-5 gain similarity: intersection of first-5 card names / 5."""
+
+    def test_identical_top_five_is_1(self):
+        s1 = _strategy_with_gain("Province", "Gold", "Witch", "Silver", "Estate", "Copper")
+        s2 = _strategy_with_gain("Province", "Gold", "Witch", "Silver", "Estate", "Duchy")
+        assert GeneticTrainer._strategy_similarity(s1, s2) == 1.0
+
+    def test_disjoint_top_five_is_0(self):
+        s1 = _strategy_with_gain("Province", "Gold", "Witch", "Silver", "Estate")
+        s2 = _strategy_with_gain("Duchy", "Copper", "Curse", "Festival", "Mine")
+        assert GeneticTrainer._strategy_similarity(s1, s2) == 0.0
+
+    def test_partial_overlap(self):
+        s1 = _strategy_with_gain("Province", "Gold", "Witch", "Silver", "Estate")
+        s2 = _strategy_with_gain("Province", "Gold", "Festival", "Mine", "Duchy")
+        # Intersection: {Province, Gold} → 2/5 = 0.4
+        assert GeneticTrainer._strategy_similarity(s1, s2) == 0.4
+
+    def test_short_lists_padded_safely(self):
+        s1 = _strategy_with_gain("Province", "Gold")  # only 2 cards
+        s2 = _strategy_with_gain("Province", "Gold", "Silver", "Witch", "Estate")
+        # Intersection of first-5: {Province, Gold} → 2/5 = 0.4
+        assert GeneticTrainer._strategy_similarity(s1, s2) == 0.4
+
+    def test_only_card_name_matters_not_condition(self):
+        """Conditions don't affect similarity."""
+        s1 = BaseStrategy()
+        s1.gain_priority = [PriorityRule("Province", PriorityRule.provinces_left("<=", 4)), PriorityRule("Gold")]
+        s2 = BaseStrategy()
+        s2.gain_priority = [PriorityRule("Province"), PriorityRule("Gold", PriorityRule.turn_number(">=", 10))]
+        assert GeneticTrainer._strategy_similarity(s1, s2) == GeneticTrainer._strategy_similarity(s2, s1)
+
+
+class TestCreateNextGenerationElitism:
+    """Elitism uses raw fitness; selection uses (optional) selection_fitness."""
+
+    def test_elite_picked_by_raw_fitness_when_selection_fitness_differs(self):
+        trainer = GeneticTrainer(["Village"], population_size=3, generations=1, mutation_rate=0.0)
+        clone_a = _strategy_with_gain("Province", "Gold", "Witch", "Silver", "Estate")
+        clone_b = _strategy_with_gain("Province", "Gold", "Witch", "Silver", "Estate")
+        unique = _strategy_with_gain("Festival", "Mine", "Curse", "Duchy", "Copper")
+        # Treasure pri must be present for crossover (which copies from parents)
+        for s in (clone_a, clone_b, unique):
+            s.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
+
+        pop = [clone_a, clone_b, unique]
+        raw = [80.0, 80.0, 70.0]
+        shared = [40.0, 40.0, 70.0]
+
+        next_pop = trainer.create_next_generation(pop, raw, selection_fitness=shared)
+
+        # Elite is one of the clones (raw fitness 80)
+        assert next_pop[0].gain_priority[0].card_name == "Province"
+
+
+class TestTrainWiresDiversityPressure:
+    """train() should pass selection_fitness (sharing-adjusted) and a non-zero
+    immigrant_count to create_next_generation."""
+
+    def test_train_passes_shared_fitness_and_immigrants(self, monkeypatch):
+        trainer = GeneticTrainer(["Village"], population_size=8, generations=1, games_per_eval=2)
+        monkeypatch.setattr(trainer, "evaluate_strategy", lambda s: 50.0)
+
+        captured: dict = {}
+        original = trainer.create_next_generation
+
+        def spy(pop, raw, **kwargs):
+            captured["selection"] = kwargs.get("selection_fitness")
+            captured["immigrants"] = kwargs.get("immigrant_count", 0)
+            return original(pop, raw, **kwargs)
+
+        monkeypatch.setattr(trainer, "create_next_generation", spy)
+
+        trainer.train()
+
+        assert captured.get("selection") is not None, "selection_fitness must be passed"
+        assert captured["immigrants"] >= 1, (
+            f"immigrant_count should be >= 1 for population_size=8, got {captured['immigrants']}"
+        )
+
+
+class TestRandomImmigrants:
+    """create_next_generation with immigrant_count > 0 should reserve slots for
+    fresh randomly-generated strategies, not just crossover children."""
+
+    def test_immigrants_replace_no_elite_slot(self):
+        # Population of 4 identical clones. With immigrant_count=2 and elite=1,
+        # only 1 slot is filled by crossover (which would clone). The 2
+        # immigrant slots must contain genuinely different strategies.
+        trainer = GeneticTrainer(
+            ["Village", "Smithy", "Market", "Festival", "Laboratory", "Witch"],
+            population_size=4, generations=1, mutation_rate=0.0,
+        )
+        clone = _strategy_with_gain("Province", "Gold", "Witch", "Silver", "Estate")
+        clone.action_priority = []
+        clone.trash_priority = []
+        pop = [_deepcopy_strategy(clone) for _ in range(4)]
+        raw = [50.0, 50.0, 50.0, 50.0]
+
+        next_pop = trainer.create_next_generation(pop, raw, immigrant_count=2)
+
+        # At least 2 of the 4 should have a top-5 different from the clone
+        # (immigrants are randomly generated)
+        clone_top5 = {r.card_name for r in clone.gain_priority[:5]}
+        differing = sum(
+            1 for s in next_pop
+            if {r.card_name for r in s.gain_priority[:5]} != clone_top5
+        )
+        assert differing >= 2, (
+            f"Expected at least 2 immigrants with differing top-5; got {differing}"
+        )
+
+
+def _deepcopy_strategy(s: BaseStrategy) -> BaseStrategy:
+    from copy import deepcopy as _dc
+    out = _dc(s)
+    return out
+
+
+class TestFitnessSharing:
+    """Niche-based fitness sharing: clones share their fitness so unique strategies
+    get a selection edge at equal raw fitness."""
+
+    def test_clones_share_fitness_unique_keeps_full(self):
+        pop = [
+            _strategy_with_gain("A", "B", "C", "D", "E"),
+            _strategy_with_gain("A", "B", "C", "D", "E"),
+            _strategy_with_gain("A", "B", "C", "D", "E"),
+            _strategy_with_gain("X", "Y", "Z", "W", "V"),
+        ]
+        raw = [60.0, 60.0, 60.0, 60.0]
+        shared = GeneticTrainer._apply_fitness_sharing(pop, raw, threshold=0.8)
+        assert shared[0] == 20.0  # 60 / 3 clones
+        assert shared[1] == 20.0
+        assert shared[2] == 20.0
+        assert shared[3] == 60.0  # alone in its niche
+
+    def test_no_clones_returns_unchanged(self):
+        pop = [
+            _strategy_with_gain("A", "B", "C", "D", "E"),
+            _strategy_with_gain("V", "W", "X", "Y", "Z"),
+        ]
+        raw = [40.0, 70.0]
+        shared = GeneticTrainer._apply_fitness_sharing(pop, raw, threshold=0.8)
+        assert shared == [40.0, 70.0]
+
+
+class TestMutationReplacesConditions:
+    """An existing condition can mutate into a *different* condition,
+    not just toggle between itself and None."""
+
+    def test_mutation_can_replace_existing_condition_with_different_one(self):
+        from copy import deepcopy as _deepcopy
+        trainer = GeneticTrainer(["Village", "Smithy"], population_size=1, generations=1, mutation_rate=1.0)
+
+        strategy = BaseStrategy()
+        strategy.name = "X"
+        initial_cond = PriorityRule.provinces_left("<=", 4)
+        initial_source = initial_cond._source
+        strategy.gain_priority = [
+            PriorityRule("Village"),
+            PriorityRule("Province", initial_cond),
+            PriorityRule("Gold"),
+        ]
+        strategy.action_priority = []
+        strategy.treasure_priority = [PriorityRule("Gold"), PriorityRule("Copper")]
+        strategy.trash_priority = []
+
+        seen_different_condition = False
+        for _ in range(80):
+            mutated = trainer._mutate(_deepcopy(strategy))
+            for rule in mutated.gain_priority:
+                if rule.card_name == "Province" and rule.condition is not None:
+                    src = getattr(rule.condition, "_source", "")
+                    if src and src != initial_source:
+                        seen_different_condition = True
+                        break
+            if seen_different_condition:
+                break
+
+        assert seen_different_condition, (
+            "Mutation never replaced the existing condition with a different one"
+        )
 
 
 class TestMutationProducesCallableConditions:


### PR DESCRIPTION
## Why

This project's "give it a board, find a great way to play it" pipeline (`runner.py` / `evolve.py`) wasn't producing strong strategies. Three structural problems were capping it:

1. **Fitness signal was wrong** — every strategy was graded by win rate vs *one* fixed opponent (Big Money by default). Strategies that just rush Province/Gold scored fine, so the GA never had a reason to discover engines. Worse, `runner.py` silently discarded any strategy with ≤50% validation win rate, hiding partial progress.
2. **Strategy representation was too narrow** — `_random_condition` drew from only 5 primitive types and `_mutate` could only ever toggle conditions to/from `None`, never replace one with a different one. Once a rule had a condition, it was effectively stuck.
3. **Search was prematurely converging** — default population of 5, no diversity preservation, no novelty injection. Generations collapsed onto identical strategies.

## What changed

### Batch 1: Panel-based fitness (`genetic_trainer.py`, `runner.py`, `evolve.py`)
- New `set_baseline_panel(list[BaseStrategy])`; games are split evenly across the panel and fitness is the mean per-opponent win rate.
- `last_eval_breakdown` exposes per-opponent rates, logged on each new best so you can see *which* matchup is improving.
- `--baseline-panel mod:fn [mod:fn ...]` flag in `runner.py` and `evolve.py`.
- `runner.py` no longer silently drops sub-50% results — logs `⚠️  saving anyway for inspection`.

### Batch 2: Richer condition vocabulary (`enhanced_strategy.py`, `genetic_trainer.py`)
- 4 new primitives on `PriorityRule`: `empty_piles`, `deck_size`, `action_density`, `score_diff` (all `_source`-tagged for round-trip serialization).
- `_random_condition` now draws from 11 primitive types, including previously-defined-but-unused `max_in_deck` and `actions_in_play`.
- `_mutate` can now *replace* an existing condition with a different one (50/50 with nullify) instead of only ever toggling to None.

### Batch 3: Diversity pressure (`genetic_trainer.py`, `runner.py`)
- `_strategy_similarity(a, b)`: top-5 gain card overlap.
- `_apply_fitness_sharing(...)`: divide raw fitness by niche count so clones lose to unique strategies at equal skill.
- `create_next_generation(...)` now accepts `selection_fitness` (separate from raw, used for tournament selection) and `immigrant_count` (slots reserved for fresh randoms each generation). Elitism still uses raw fitness so the actual best survives.
- `train()` wires it together: 15% immigrants per gen, 0.8 sharing threshold.
- `runner.py` defaults: population 5 → 25, generations 10 → 40.

### Bonus fix (separate commit)
Cartographer crashed when two revealed cards tied on score (`kept.sort()` falling back to comparing `Card` objects). Surfaced by a longer training run; fixed with `key=lambda pair: pair[0]` and a regression test.

## Effect

A 6-generation smoke run on `wharf_kingdom` against a 2-strategy panel climbed **16.7% → 83.3%** with clear per-opponent breakdown:

```
New best fitness: 16.67  panel breakdown — BigMoney: 0.0%, BigMoneySmithy: 33.3%
New best fitness: 33.33  panel breakdown — BigMoney: 33.3%, BigMoneySmithy: 33.3%
New best fitness: 50.00  panel breakdown — BigMoney: 33.3%, BigMoneySmithy: 66.7%
New best fitness: 66.67  panel breakdown — BigMoney: 66.7%, BigMoneySmithy: 66.7%
New best fitness: 83.33  panel breakdown — BigMoney: 66.7%, BigMoneySmithy: 100.0%
```

## How to use it

```bash
python runner.py --board boards/your_board.txt \
    --baseline-panel \
        dominion.strategy.strategies.big_money:create_big_money \
        dominion.strategy.strategies.big_money_smithy:create_big_money_smithy \
        dominion.strategy.strategies.chapel_witch:create_chapel_witch \
    --population-size 30 --generations 60 --games-per-eval 60
```

## Test plan
- [x] Full test suite: `python -m pytest` — 222 passed (was 199; +23 new tests written RED-then-GREEN)
- [x] Smoke `runner.py` end-to-end with new `--baseline-panel` flag, verify per-opponent breakdown is logged and strategies are saved even sub-50%
- [x] Verify `score_diff` and other new primitives appear in saved strategy `.py` files (round-trip works)
- [ ] Suggested follow-up: run a real training session (e.g. `--population-size 30 --generations 80 --games-per-eval 100`) and compare evolved strategies against existing `generated_strategies/` via `leaderboard.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)