### PR TITLE
Add Wizards/Lich kingdom: Liaison/Ally infra, 6 new cards, evolved strategy

### DIFF
--- a/boards/wizards_lich.txt
+++ b/boards/wizards_lich.txt
@@ -1,0 +1,13 @@
+Beggar
+Lurker
+Settlers
+Wishing Well
+Student
+Mill
+Baker
+Cauldron
+Crew
+Pilgrim
+
+Event: Continue
+Ally: Cave Dwellers

--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -365,6 +365,107 @@ class AI(ABC):
         """Choose a Way to use when playing a card. Default is none."""
         return None
 
+    def should_spend_favor_on_cave_dwellers(
+        self, state: GameState, player: PlayerState
+    ) -> bool:
+        """Decide whether to spend a Favor on Cave Dwellers' discard-then-draw.
+
+        Default: spend whenever the hand contains a junk card (Curse, Copper,
+        cheap Victory, Estate, or any non-Action Victory).
+        """
+        for card in player.hand:
+            if card.name in {"Curse", "Copper", "Estate", "Hovel", "Overgrown Estate"}:
+                return True
+            if card.is_victory and not card.is_action and card.cost.coins <= 2:
+                return True
+        return False
+
+    def choose_card_to_discard_for_cave_dwellers(
+        self, state: GameState, player: PlayerState, choices: list[Card]
+    ) -> Optional[Card]:
+        """Pick a card to discard when activating Cave Dwellers."""
+        if not choices:
+            return None
+        picked = self.choose_cards_to_discard(state, player, choices, 1, reason="cave_dwellers")
+        return picked[0] if picked else None
+
+    def choose_card_to_topdeck_from_hand(
+        self, state: GameState, player: PlayerState, choices: list[Card], reason: Optional[str] = None
+    ) -> Optional[Card]:
+        """Choose which card from hand to put on top of deck (Pilgrim, etc.).
+
+        Default: prefer to top-deck the most valuable Action so it's drawn
+        next turn, otherwise the cheapest junk.
+        """
+        if not choices:
+            return None
+
+        actions = [c for c in choices if c.is_action]
+        if actions:
+            return max(actions, key=lambda c: (c.cost.coins, c.is_duration, c.name))
+
+        treasures = [c for c in choices if c.is_treasure]
+        if treasures:
+            return max(treasures, key=lambda c: (c.cost.coins, c.name))
+
+        return min(choices, key=lambda c: (c.cost.coins, c.name))
+
+    def choose_action_to_trash_from_supply(
+        self, state: GameState, player: PlayerState, choices: list[Card]
+    ) -> Optional[Card]:
+        """Lurker mode 1: pick an Action card in supply to trash.
+
+        Default heuristic: prioritise cards that drain meaningful piles —
+        the top of a split pile (Settlers exposes Bustling Village; Student
+        drains the Wizards pile toward Lich). Ties broken by lowest cost so
+        we don't spend value trashing premium cards.
+        """
+        if not choices:
+            return None
+
+        priority_pile_drainers = {"Settlers", "Student", "Conjurer", "Sorcerer"}
+        for name in ("Student", "Conjurer", "Sorcerer", "Settlers"):
+            for c in choices:
+                if c.name == name:
+                    return c
+        # Otherwise prefer the cheapest Action so we don't waste a high-value pile.
+        return min(choices, key=lambda c: (c.cost.coins, c.name))
+
+    def choose_action_to_gain_from_trash(
+        self, state: GameState, player: PlayerState, choices: list[Card]
+    ) -> Optional[Card]:
+        """Lurker mode 2: pick an Action in the trash to gain."""
+        if not choices:
+            return None
+        return max(choices, key=lambda c: (c.cost.coins, c.name))
+
+    def choose_lurker_mode(
+        self, state: GameState, player: PlayerState, can_trash: bool, can_gain: bool
+    ) -> str:
+        """Return 'trash' or 'gain' for Lurker. Default: gain if any Action sits in trash, else trash."""
+        if can_gain:
+            return "gain"
+        return "trash"
+
+    def choose_continue_target(
+        self, state: GameState, player: PlayerState, choices: list[Card]
+    ) -> Optional[Card]:
+        """Pick which $0-$4 card to gain and play via the Continue event."""
+        if not choices:
+            return None
+        actions = [c for c in choices if c.is_action]
+        if actions:
+            return max(actions, key=lambda c: (c.cost.coins, c.stats.cards, c.stats.actions, c.name))
+        return max(choices, key=lambda c: (c.cost.coins, c.name))
+
+    def choose_card_to_gain_from_trash(
+        self, state: GameState, player: PlayerState, choices: list[Card], max_cost: int
+    ) -> Optional[Card]:
+        """Used by Lich's "+ gain a cheaper Action from trash" clause."""
+        if not choices:
+            return None
+        return max(choices, key=lambda c: (c.cost.coins, c.name))
+
     def use_amphora_now(self, state: GameState) -> bool:
         """Decide whether to take Amphora's bonus immediately."""
         return True

--- a/dominion/allies/__init__.py
+++ b/dominion/allies/__init__.py
@@ -1,0 +1,5 @@
+from .base_ally import Ally
+from .cave_dwellers import CaveDwellers
+from .registry import get_ally
+
+__all__ = ["Ally", "CaveDwellers", "get_ally"]

--- a/dominion/allies/base_ally.py
+++ b/dominion/allies/base_ally.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Ally:
+    """Base class for Allies (from the Allies expansion).
+
+    Allies are revealed once per game when at least one Liaison is in the
+    kingdom. Liaison cards grant the controlling player Favor tokens, which
+    can be spent to activate the Ally's effect.
+    """
+
+    name: str
+
+    def on_turn_start(self, game_state, player) -> None:
+        """Hook fired at the start of every player's turn."""
+
+    @property
+    def is_ally(self) -> bool:
+        return True

--- a/dominion/allies/cave_dwellers.py
+++ b/dominion/allies/cave_dwellers.py
@@ -1,0 +1,38 @@
+from .base_ally import Ally
+
+
+class CaveDwellers(Ally):
+    """Cave Dwellers (Allies).
+
+    Simplified rules used here: at the start of your turn, while you have
+    Favors, you may spend them one at a time to discard a card from your
+    hand and then draw a card. Repeat as the AI desires.
+    """
+
+    def __init__(self):
+        super().__init__("Cave Dwellers")
+
+    def on_turn_start(self, game_state, player) -> None:
+        ai = player.ai
+        while player.favors > 0 and player.hand:
+            if not ai.should_spend_favor_on_cave_dwellers(game_state, player):
+                return
+
+            choice = ai.choose_card_to_discard_for_cave_dwellers(
+                game_state, player, list(player.hand)
+            )
+            if choice is None or choice not in player.hand:
+                return
+
+            player.favors -= 1
+            player.hand.remove(choice)
+            game_state.discard_card(player, choice)
+            game_state.draw_cards(player, 1)
+            game_state.log_callback(
+                (
+                    "action",
+                    ai.name,
+                    f"spends a Favor on Cave Dwellers, discards {choice} and draws a card",
+                    {"favors_remaining": player.favors},
+                )
+            )

--- a/dominion/allies/registry.py
+++ b/dominion/allies/registry.py
@@ -1,0 +1,19 @@
+"""Registry of Dominion Allies."""
+
+from typing import Type
+
+from .base_ally import Ally
+from .cave_dwellers import CaveDwellers
+
+
+ALLY_TYPES: dict[str, Type[Ally]] = {
+    "Cave Dwellers": CaveDwellers,
+}
+
+
+def get_ally(name: str) -> Ally:
+    try:
+        ally_class = ALLY_TYPES[name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown ally: {name}") from exc
+    return ally_class()

--- a/dominion/boards/loader.py
+++ b/dominion/boards/loader.py
@@ -45,8 +45,13 @@ def _parse_special_line(line: str, config: BoardConfig) -> bool:
         config.events.append(value)
     elif key == "project":
         config.projects.append(value)
-    elif key in ("way", "way of the"):
+    elif key == "way":
         config.ways.append(value)
+    elif key.startswith("way of the"):
+        # ``Way of the Mouse: Native Village`` becomes
+        # ``Way of the Mouse (Native Village)`` so the registry's
+        # parametric-Way regex resolves the target.
+        config.ways.append(f"{prefix.strip()} ({value})")
     elif key == "landmark":
         config.landmarks.append(value)
     elif key == "ally":

--- a/dominion/boards/loader.py
+++ b/dominion/boards/loader.py
@@ -45,7 +45,7 @@ def _parse_special_line(line: str, config: BoardConfig) -> bool:
         config.events.append(value)
     elif key == "project":
         config.projects.append(value)
-    elif key == "way":
+    elif key in ("way", "way of the"):
         config.ways.append(value)
     elif key == "landmark":
         config.landmarks.append(value)

--- a/dominion/cards/allies/__init__.py
+++ b/dominion/cards/allies/__init__.py
@@ -1,6 +1,18 @@
 from .collection import Collection
 from .modify import Modify
+from .pilgrim import Pilgrim
 from .taskmaster import Taskmaster
 from .wealthy_village import WealthyVillage
+from .wizards import Conjurer, Lich, Sorcerer, Student
 
-__all__ = ['Collection', 'Modify', 'Taskmaster', 'WealthyVillage']
+__all__ = [
+    'Collection',
+    'Modify',
+    'Pilgrim',
+    'Taskmaster',
+    'WealthyVillage',
+    'Student',
+    'Conjurer',
+    'Sorcerer',
+    'Lich',
+]

--- a/dominion/cards/allies/pilgrim.py
+++ b/dominion/cards/allies/pilgrim.py
@@ -1,0 +1,27 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Pilgrim(Card):
+    """Allies $5 — +4 Cards, then top-deck a card from your hand."""
+
+    def __init__(self):
+        super().__init__(
+            name="Pilgrim",
+            cost=CardCost(coins=5),
+            stats=CardStats(cards=4),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+        if not player.hand:
+            return
+
+        choice = player.ai.choose_card_to_topdeck_from_hand(
+            game_state, player, list(player.hand), reason="pilgrim"
+        )
+        if choice is None or choice not in player.hand:
+            return
+
+        player.hand.remove(choice)
+        player.deck.append(choice)

--- a/dominion/cards/allies/wizards.py
+++ b/dominion/cards/allies/wizards.py
@@ -28,20 +28,12 @@ class WizardsSplitCard(Card):
                 return False
         return super().may_be_bought(game_state)
 
-    def get_additional_piles(self) -> dict[str, int]:
-        """When any single Wizard is added to the kingdom, populate all four piles.
-
-        Returns 4 of each remaining Wizard for 2-player setups; in larger
-        games the supply still works (each Wizard sets its own count via
-        ``starting_supply`` when added directly), and the engine treats this
-        4 as a default fallback.
-        """
-        extras: dict[str, int] = {}
-        for name in WIZARDS_PILE_ORDER:
-            if name == self.name:
-                continue
-            extras[name] = 4
-        return extras
+    # Note: the partner Wizards aren't added via ``get_additional_piles``
+    # because that method has no access to ``game_state`` and so can't size
+    # the piles by player count. Instead, ``GameState.setup_supply`` detects
+    # ``WizardsSplitCard`` and calls ``starting_supply`` on each partner —
+    # the same shape as the existing ``SplitPileMixin`` handling. Keep this
+    # default empty so the supply path stays consistent.
 
 
 def _grant_favor(player) -> None:

--- a/dominion/cards/allies/wizards.py
+++ b/dominion/cards/allies/wizards.py
@@ -1,0 +1,248 @@
+"""Wizards split pile: Student / Conjurer / Sorcerer / Lich.
+
+All four are Liaisons (grant +1 Favor when played). The pile drains in order
+Student → Conjurer → Sorcerer → Lich; only the topmost still-stocked card is
+buyable.
+"""
+
+from typing import Optional
+
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+# Order from top of pile to bottom.
+WIZARDS_PILE_ORDER = ("Student", "Conjurer", "Sorcerer", "Lich")
+
+
+class WizardsSplitCard(Card):
+    """Common base for the Wizards split pile."""
+
+    upper_partners: tuple[str, ...] = ()
+
+    def starting_supply(self, game_state) -> int:
+        return 4 if len(game_state.players) <= 2 else 5
+
+    def may_be_bought(self, game_state) -> bool:
+        for partner in self.upper_partners:
+            if game_state.supply.get(partner, 0) > 0:
+                return False
+        return super().may_be_bought(game_state)
+
+    def get_additional_piles(self) -> dict[str, int]:
+        """When any single Wizard is added to the kingdom, populate all four piles.
+
+        Returns 4 of each remaining Wizard for 2-player setups; in larger
+        games the supply still works (each Wizard sets its own count via
+        ``starting_supply`` when added directly), and the engine treats this
+        4 as a default fallback.
+        """
+        extras: dict[str, int] = {}
+        for name in WIZARDS_PILE_ORDER:
+            if name == self.name:
+                continue
+            extras[name] = 4
+        return extras
+
+
+def _grant_favor(player) -> None:
+    player.favors += 1
+
+
+class Student(WizardsSplitCard):
+    """+1 Action; trash a card from your hand. If a Treasure, +1 Favor."""
+
+    upper_partners = ()
+
+    def __init__(self):
+        super().__init__(
+            name="Student",
+            cost=CardCost(coins=3),
+            stats=CardStats(actions=1),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+        _grant_favor(player)  # Liaison
+
+        if not player.hand:
+            return
+
+        chosen = player.ai.choose_card_to_trash(game_state, player.hand)
+        if chosen is None:
+            return
+        if chosen not in player.hand:
+            return
+
+        player.hand.remove(chosen)
+        game_state.trash_card(player, chosen)
+
+        if chosen.is_treasure:
+            _grant_favor(player)
+
+
+class Conjurer(WizardsSplitCard):
+    """+1 Card, +1 Action. Gain a card costing up to $4. (Liaison)"""
+
+    upper_partners = ("Student",)
+
+    def __init__(self):
+        super().__init__(
+            name="Conjurer",
+            cost=CardCost(coins=4),
+            stats=CardStats(actions=1, cards=1),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        from ..registry import get_card
+
+        player = game_state.current_player
+        _grant_favor(player)
+
+        # Gain a card costing up to $4 (Conjurer-style gainer).
+        candidates: list[Card] = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            card = get_card(name)
+            if card.cost.potions > 0:
+                continue
+            if card.cost.coins > 4:
+                continue
+            if not card.may_be_bought(game_state):
+                continue
+            candidates.append(card)
+
+        if not candidates:
+            return
+
+        chosen = player.ai.choose_buy(game_state, candidates + [None])
+        if chosen is None:
+            return
+        if game_state.supply.get(chosen.name, 0) <= 0:
+            return
+
+        game_state.supply[chosen.name] -= 1
+        game_state.gain_card(player, chosen)
+
+
+class Sorcerer(WizardsSplitCard):
+    """+1 Card, +1 Action. Each other player gains a Curse on top of deck.
+
+    (Simplified: skip the "name a card / reveal top of deck" subgame and treat
+    this as a guaranteed top-decked Curser. In practice the named card almost
+    never matches the top of an unknown deck.)
+    """
+
+    upper_partners = ("Student", "Conjurer")
+
+    def __init__(self):
+        super().__init__(
+            name="Sorcerer",
+            cost=CardCost(coins=5),
+            stats=CardStats(actions=1, cards=1),
+            types=[CardType.ACTION, CardType.ATTACK],
+        )
+
+    def play_effect(self, game_state):
+        from ..registry import get_card
+
+        player = game_state.current_player
+        _grant_favor(player)
+
+        for opponent in game_state.players:
+            if opponent is player:
+                continue
+
+            def attack(target):
+                if game_state.supply.get("Curse", 0) <= 0:
+                    return
+                game_state.supply["Curse"] -= 1
+                curse = get_card("Curse")
+                game_state.gain_card(target, curse, to_deck=True)
+
+            game_state.attack_player(opponent, attack)
+
+
+class Lich(WizardsSplitCard):
+    """+6 Cards, +2 Actions, discard 2 cards. Gain a cheaper Action from trash.
+
+    On trash: gain a non-Lich Action from supply costing up to $5.
+    """
+
+    upper_partners = ("Student", "Conjurer", "Sorcerer")
+
+    def __init__(self):
+        super().__init__(
+            name="Lich",
+            cost=CardCost(coins=6),
+            stats=CardStats(actions=2, cards=6),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+        _grant_favor(player)
+
+        # Discard 2 cards (worst).
+        if player.hand:
+            picks = player.ai.choose_cards_to_discard(
+                game_state, player, list(player.hand), 2, reason="lich"
+            )
+            for card in picks:
+                if card in player.hand:
+                    player.hand.remove(card)
+                    game_state.discard_card(player, card)
+
+        # Gain a cheaper Action from the trash.
+        max_cost = self.cost.coins - 1
+        candidates = [
+            c
+            for c in game_state.trash
+            if c.is_action and c.cost.coins <= max_cost and c.cost.potions == 0
+        ]
+        if not candidates:
+            return
+
+        chosen: Optional[Card] = player.ai.choose_card_to_gain_from_trash(
+            game_state, player, candidates, max_cost
+        )
+        if chosen is None or chosen not in game_state.trash:
+            return
+        game_state.trash.remove(chosen)
+        # Skip supply decrement since the card was in trash.
+        player.discard.append(chosen)
+        chosen.on_gain(game_state, player)
+
+    def on_trash(self, game_state, player) -> None:
+        from ..registry import get_card
+
+        # Gain a non-Lich Action card costing up to $5 from supply.
+        candidates: list[Card] = []
+        for name, count in game_state.supply.items():
+            if count <= 0 or name == "Lich":
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            if not card.is_action:
+                continue
+            if card.cost.coins > 5 or card.cost.potions > 0:
+                continue
+            if not card.may_be_bought(game_state):
+                continue
+            candidates.append(card)
+
+        if not candidates:
+            return
+
+        chosen = player.ai.choose_buy(game_state, candidates + [None])
+        if chosen is None:
+            return
+        if game_state.supply.get(chosen.name, 0) <= 0:
+            return
+
+        game_state.supply[chosen.name] -= 1
+        game_state.gain_card(player, chosen)

--- a/dominion/cards/allies/wizards.py
+++ b/dominion/cards/allies/wizards.py
@@ -212,9 +212,10 @@ class Lich(WizardsSplitCard):
         # Route through gain_card so the gain participates in shared
         # bookkeeping (cards_gained_this_turn, actions_gained_this_turn,
         # Cauldron's third-Action-gain trigger, project on_gain hooks,
-        # Watchtower / Royal Seal / Insignia reactions, …). Supply isn't
-        # decremented because the card came out of the trash, not supply.
-        game_state.gain_card(player, chosen)
+        # Watchtower / Royal Seal / Insignia reactions, …). Pass
+        # from_supply=False since the card came from trash — without that,
+        # Trader's reaction would inflate the original card's supply pile.
+        game_state.gain_card(player, chosen, from_supply=False)
 
     def on_trash(self, game_state, player) -> None:
         from ..registry import get_card

--- a/dominion/cards/allies/wizards.py
+++ b/dominion/cards/allies/wizards.py
@@ -203,9 +203,12 @@ class Lich(WizardsSplitCard):
         if chosen is None or chosen not in game_state.trash:
             return
         game_state.trash.remove(chosen)
-        # Skip supply decrement since the card was in trash.
-        player.discard.append(chosen)
-        chosen.on_gain(game_state, player)
+        # Route through gain_card so the gain participates in shared
+        # bookkeeping (cards_gained_this_turn, actions_gained_this_turn,
+        # Cauldron's third-Action-gain trigger, project on_gain hooks,
+        # Watchtower / Royal Seal / Insignia reactions, …). Supply isn't
+        # decremented because the card came out of the trash, not supply.
+        game_state.gain_card(player, chosen)
 
     def on_trash(self, game_state, player) -> None:
         from ..registry import get_card

--- a/dominion/cards/allies/wizards.py
+++ b/dominion/cards/allies/wizards.py
@@ -71,6 +71,12 @@ class Student(WizardsSplitCard):
 
         if chosen.is_treasure:
             _grant_favor(player)
+            # Student's official text: "If it's a Treasure, put this onto
+            # your deck." Move Student out of in_play so cleanup doesn't
+            # also discard it.
+            if self in player.in_play:
+                player.in_play.remove(self)
+                player.deck.append(self)
 
 
 class Conjurer(WizardsSplitCard):

--- a/dominion/cards/intrigue/__init__.py
+++ b/dominion/cards/intrigue/__init__.py
@@ -1,6 +1,7 @@
 from .torturer import Torturer
 from .patrol import Patrol
 from .bridge import Bridge
+from .lurker import Lurker
 from .nobles import Nobles
 from .wishing_well import WishingWell
 from .conspirator import Conspirator
@@ -9,4 +10,4 @@ from .pawn import Pawn
 from .steward import Steward
 from .swindler import Swindler
 
-__all__ = ['Torturer', 'Patrol', 'Bridge', 'Nobles', 'WishingWell', 'Conspirator', 'Ironworks', 'Pawn', 'Steward', 'Swindler']
+__all__ = ['Torturer', 'Patrol', 'Bridge', 'Lurker', 'Nobles', 'WishingWell', 'Conspirator', 'Ironworks', 'Pawn', 'Steward', 'Swindler']

--- a/dominion/cards/intrigue/lurker.py
+++ b/dominion/cards/intrigue/lurker.py
@@ -71,6 +71,7 @@ class Lurker(Card):
         # Route through gain_card so the gain participates in shared
         # bookkeeping (cards_gained_this_turn, actions_gained_this_turn,
         # Cauldron's third-Action-gain trigger, project on_gain hooks,
-        # Watchtower / Royal Seal / Insignia reactions, …). Supply isn't
-        # decremented because the card came out of the trash, not supply.
-        game_state.gain_card(player, chosen)
+        # Watchtower / Royal Seal / Insignia reactions, …). Pass
+        # from_supply=False since the card came from trash — without that,
+        # Trader's reaction would inflate the original card's supply pile.
+        game_state.gain_card(player, chosen, from_supply=False)

--- a/dominion/cards/intrigue/lurker.py
+++ b/dominion/cards/intrigue/lurker.py
@@ -1,0 +1,72 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Lurker(Card):
+    """+1 Action. Choose: trash an Action from supply, OR gain an Action from trash."""
+
+    def __init__(self):
+        super().__init__(
+            name="Lurker",
+            cost=CardCost(coins=2),
+            stats=CardStats(actions=1),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        from ..registry import get_card
+
+        player = game_state.current_player
+
+        trashable_actions: list[Card] = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            if not card.is_action:
+                continue
+            if not card.may_be_bought(game_state):
+                continue
+            trashable_actions.append(card)
+
+        gainable_actions: list[Card] = [
+            c for c in game_state.trash if c.is_action
+        ]
+
+        can_trash = bool(trashable_actions)
+        can_gain = bool(gainable_actions)
+        if not can_trash and not can_gain:
+            return
+
+        mode = player.ai.choose_lurker_mode(
+            game_state, player, can_trash=can_trash, can_gain=can_gain
+        )
+        if mode == "gain" and not can_gain:
+            mode = "trash"
+        elif mode == "trash" and not can_trash:
+            mode = "gain"
+
+        if mode == "trash":
+            chosen = player.ai.choose_action_to_trash_from_supply(
+                game_state, player, trashable_actions
+            )
+            if chosen is None or game_state.supply.get(chosen.name, 0) <= 0:
+                return
+            game_state.supply[chosen.name] -= 1
+            game_state.log_callback(
+                ("supply_change", chosen.name, -1, game_state.supply[chosen.name])
+            )
+            game_state.trash_card(player, chosen)
+            return
+
+        # mode == "gain"
+        chosen = player.ai.choose_action_to_gain_from_trash(
+            game_state, player, gainable_actions
+        )
+        if chosen is None or chosen not in game_state.trash:
+            return
+        game_state.trash.remove(chosen)
+        player.discard.append(chosen)
+        chosen.on_gain(game_state, player)

--- a/dominion/cards/intrigue/lurker.py
+++ b/dominion/cards/intrigue/lurker.py
@@ -68,5 +68,9 @@ class Lurker(Card):
         if chosen is None or chosen not in game_state.trash:
             return
         game_state.trash.remove(chosen)
-        player.discard.append(chosen)
-        chosen.on_gain(game_state, player)
+        # Route through gain_card so the gain participates in shared
+        # bookkeeping (cards_gained_this_turn, actions_gained_this_turn,
+        # Cauldron's third-Action-gain trigger, project on_gain hooks,
+        # Watchtower / Royal Seal / Insignia reactions, …). Supply isn't
+        # decremented because the card came out of the trash, not supply.
+        game_state.gain_card(player, chosen)

--- a/dominion/cards/plunder/__init__.py
+++ b/dominion/cards/plunder/__init__.py
@@ -18,6 +18,7 @@ from .loot_cards import (
 )
 from .first_mate import FirstMate
 from .barbarian import Barbarian
+from .crew import Crew
 from .flagship import Flagship
 from .trickster import Trickster
 from .highwayman import Highwayman
@@ -43,6 +44,7 @@ __all__ = [
     'Sword',
     'FirstMate',
     'Barbarian',
+    'Crew',
     'Flagship',
     'Trickster',
     'Highwayman',

--- a/dominion/cards/plunder/crew.py
+++ b/dominion/cards/plunder/crew.py
@@ -21,9 +21,14 @@ class Crew(Card):
 
     def on_duration(self, game_state):
         player = game_state.current_player
-        # Move Crew from duration to top of deck. Mark as persistent so the
-        # engine's post-on_duration cleanup does not also try to discard it.
+        # Move Crew from duration *and* in_play onto the top of the deck.
+        # Without removing from in_play, cleanup later this turn would also
+        # discard the same card object, leaving Crew duplicated across deck
+        # and discard. Marking duration_persistent suppresses the engine's
+        # default move-to-discard since we've handled it ourselves.
         if self in player.duration:
             player.duration.remove(self)
+        if self in player.in_play:
+            player.in_play.remove(self)
         player.deck.append(self)
         self.duration_persistent = True

--- a/dominion/cards/plunder/crew.py
+++ b/dominion/cards/plunder/crew.py
@@ -17,7 +17,12 @@ class Crew(Card):
         game_state.draw_cards(player, 3)
         # Stay in play until the start-of-next-turn duration trigger fires.
         self.duration_persistent = True
-        player.duration.append(self)
+        # Guard against duplicate listings when Crew is replayed in the same
+        # turn (Flagship, Throne Room, etc. operate on the same instance).
+        # Each replay still draws +3 above, but the duration list may only
+        # carry the card once or on_duration would top-deck it multiple times.
+        if self not in player.duration:
+            player.duration.append(self)
 
     def on_duration(self, game_state):
         player = game_state.current_player

--- a/dominion/cards/plunder/crew.py
+++ b/dominion/cards/plunder/crew.py
@@ -1,0 +1,29 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Crew(Card):
+    """Plunder $5 Action-Duration: +3 Cards. At start of next turn, top-deck this."""
+
+    def __init__(self):
+        super().__init__(
+            name="Crew",
+            cost=CardCost(coins=5),
+            stats=CardStats(),
+            types=[CardType.ACTION, CardType.DURATION],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+        game_state.draw_cards(player, 3)
+        # Stay in play until the start-of-next-turn duration trigger fires.
+        self.duration_persistent = True
+        player.duration.append(self)
+
+    def on_duration(self, game_state):
+        player = game_state.current_player
+        # Move Crew from duration to top of deck. Mark as persistent so the
+        # engine's post-on_duration cleanup does not also try to discard it.
+        if self in player.duration:
+            player.duration.remove(self)
+        player.deck.append(self)
+        self.duration_persistent = True

--- a/dominion/cards/registry.py
+++ b/dominion/cards/registry.py
@@ -196,11 +196,20 @@ from dominion.cards.hinterlands import (
     WitchsHut,
 )
 from dominion.cards.renaissance import ActingTroupe, Inventor
-from dominion.cards.allies import Taskmaster, WealthyVillage
+from dominion.cards.allies import (
+    Conjurer,
+    Lich,
+    Pilgrim,
+    Sorcerer,
+    Student,
+    Taskmaster,
+    WealthyVillage,
+)
 from dominion.cards.intrigue import (
     Torturer,
     Patrol,
     Bridge,
+    Lurker,
     Nobles,
     WishingWell,
     Conspirator,
@@ -209,7 +218,7 @@ from dominion.cards.intrigue import (
     Steward,
     Swindler,
 )
-from dominion.cards.plunder import Barbarian, FirstMate, Flagship, Highwayman, Trickster, Astrolabe, Pickaxe, HarborVillage
+from dominion.cards.plunder import Barbarian, Crew, FirstMate, Flagship, Highwayman, Trickster, Astrolabe, Pickaxe, HarborVillage
 from dominion.cards.dark_ages import Armory, Count, Ironmonger, Marauder, PoorHouse, Spoils, Ruins, Graverobber, Procession, Sage
 from dominion.cards.seaside import Bazaar, Lookout, NativeVillage, TradingPost, Wharf, Treasury, Pirate
 from dominion.cards.adventures import Artificer, Giant, Messenger
@@ -467,6 +476,17 @@ CARD_TYPES: dict[str, Type[Card]] = {
     "Gatekeeper": Gatekeeper,
     "Aristocrat": Aristocrat,
     "Harbor Village": HarborVillage,
+    # Wizards split pile (Allies)
+    "Student": Student,
+    "Conjurer": Conjurer,
+    "Sorcerer": Sorcerer,
+    "Lich": Lich,
+    # Other Allies
+    "Pilgrim": Pilgrim,
+    # Intrigue
+    "Lurker": Lurker,
+    # Plunder
+    "Crew": Crew,
 }
 
 CARD_ALIASES: dict[str, str] = {

--- a/dominion/events/continue_event.py
+++ b/dominion/events/continue_event.py
@@ -1,0 +1,57 @@
+"""The Continue event from Plunder."""
+
+from dominion.cards.base_card import CardCost
+from dominion.cards.registry import get_card
+
+from .base_event import Event
+
+
+class Continue(Event):
+    """$8: gain a non-Victory non-Command card costing up to $4, then play it."""
+
+    def __init__(self):
+        super().__init__("Continue", CardCost(coins=8))
+
+    def on_buy(self, game_state, player) -> None:
+        candidates = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            if card.is_victory or card.is_command:
+                continue
+            if card.cost.potions > 0:
+                continue
+            if card.cost.coins > 4:
+                continue
+            if not card.may_be_bought(game_state):
+                continue
+            candidates.append(card)
+
+        if not candidates:
+            return
+
+        chosen = player.ai.choose_continue_target(game_state, player, candidates)
+        if chosen is None:
+            return
+        if game_state.supply.get(chosen.name, 0) <= 0:
+            return
+
+        game_state.supply[chosen.name] -= 1
+        game_state.log_callback(
+            ("supply_change", chosen.name, -1, game_state.supply[chosen.name])
+        )
+        gained = game_state.gain_card(player, chosen)
+
+        if not gained.is_action:
+            return
+
+        # Play the gained Action — pull it out of discard and resolve it.
+        if gained in player.discard:
+            player.discard.remove(gained)
+        player.in_play.append(gained)
+        # Continue grants a free play; we deliberately don't deduct an action.
+        gained.on_play(game_state)

--- a/dominion/events/continue_event.py
+++ b/dominion/events/continue_event.py
@@ -46,12 +46,22 @@ class Continue(Event):
         )
         gained = game_state.gain_card(player, chosen)
 
-        if not gained.is_action:
+        # Locate the gained card in whichever post-gain zone it landed in
+        # (Insignia/Royal Seal can top-deck; the default destination is the
+        # discard pile). Only play it if we can find it in a normal zone —
+        # if a reaction trashed or exiled it, the play step is skipped, the
+        # same way a Watchtower-trashed gain wouldn't be playable.
+        zone = None
+        for candidate in (player.discard, player.deck):
+            if gained in candidate:
+                zone = candidate
+                break
+
+        if zone is None:
             return
 
-        # Play the gained Action — pull it out of discard and resolve it.
-        if gained in player.discard:
-            player.discard.remove(gained)
+        zone.remove(gained)
         player.in_play.append(gained)
-        # Continue grants a free play; we deliberately don't deduct an action.
+        # Continue grants a free play of the gain (Action *or* Treasure);
+        # we deliberately don't deduct an action.
         gained.on_play(game_state)

--- a/dominion/events/continue_event.py
+++ b/dominion/events/continue_event.py
@@ -46,13 +46,14 @@ class Continue(Event):
         )
         gained = game_state.gain_card(player, chosen)
 
-        # Locate the gained card in whichever post-gain zone it landed in
-        # (Insignia/Royal Seal can top-deck; the default destination is the
-        # discard pile). Only play it if we can find it in a normal zone —
-        # if a reaction trashed or exiled it, the play step is skipped, the
-        # same way a Watchtower-trashed gain wouldn't be playable.
+        # Locate the gained card in whichever post-gain zone it landed in.
+        # Default destination is the discard pile, but Insignia/Royal Seal
+        # can top-deck and Villa's on_gain moves itself into hand. Only play
+        # it if we can find it in a normal zone — if a reaction trashed or
+        # exiled it, the play step is skipped (Watchtower-trashed gains
+        # aren't playable).
         zone = None
-        for candidate in (player.discard, player.deck):
+        for candidate in (player.hand, player.discard, player.deck):
             if gained in candidate:
                 zone = candidate
                 break

--- a/dominion/events/registry.py
+++ b/dominion/events/registry.py
@@ -3,6 +3,7 @@
 from typing import Type
 
 from .base_event import Event
+from .continue_event import Continue
 from .gain_silver import GainSilver
 from .looting import Looting
 from .menagerie_events import (
@@ -27,6 +28,7 @@ from .training import Training
 EVENT_TYPES: dict[str, Type[Event]] = {
     "Gain Silver": GainSilver,
     "Looting": Looting,
+    "Continue": Continue,
     "Desperation": Desperation,
     "Gamble": Gamble,
     "March": March,

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -107,6 +107,13 @@ class GameState:
             for player in self.players:
                 player.coin_tokens += 1
 
+        # Allies rules: when an Ally is in the game, each player starts with
+        # 1 Favor. Without this, Ally abilities can't be activated until a
+        # Liaison resolves, which skews early-turn behavior on Ally boards.
+        if self.allies:
+            for player in self.players:
+                player.favors += 1
+
         # Create a more readable player list for logging
         player_descriptions = []
         for idx, player in enumerate(self.players, start=1):

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -155,6 +155,20 @@ class GameState:
                 if partner.name not in self.supply:
                     self.supply[partner.name] = partner.starting_supply(self)
 
+            # Wizards split pile: add the other three partners with
+            # player-count-aware supply via each partner's starting_supply.
+            from dominion.cards.allies.wizards import (
+                WIZARDS_PILE_ORDER,
+                WizardsSplitCard,
+            )
+            if isinstance(card, WizardsSplitCard):
+                for partner_name in WIZARDS_PILE_ORDER:
+                    if partner_name == card.name:
+                        continue
+                    if partner_name not in self.supply:
+                        partner = get_card(partner_name)
+                        self.supply[partner_name] = partner.starting_supply(self)
+
             extras = card.get_additional_piles()
             for name, count in extras.items():
                 if name not in self.supply:

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -17,6 +17,7 @@ class GameState:
     events: list = field(default_factory=list)
     projects: list = field(default_factory=list)
     ways: list = field(default_factory=list)
+    allies: list = field(default_factory=list)
     current_player_index: int = 0
     phase: str = "start"
     turn_number: int = 1
@@ -87,6 +88,7 @@ class GameState:
         events: list = None,
         projects: list = None,
         ways: list = None,
+        allies: list = None,
     ):
         """Set up the game with given AIs and kingdom cards."""
         # Create PlayerState objects for each AI
@@ -95,6 +97,7 @@ class GameState:
         self.events = events or []
         self.projects = projects or []
         self.ways = ways or []
+        self.allies = allies or []
 
         # Initialize players
         for player in self.players:
@@ -202,14 +205,21 @@ class GameState:
 
     @property
     def empty_piles(self) -> int:
-        """Return number of empty supply piles, counting split piles once."""
+        """Return number of empty supply piles, counting split/Wizards piles once."""
+        from dominion.cards.allies.wizards import WIZARDS_PILE_ORDER, WizardsSplitCard
+
         counted: set[str] = set()
         empties = 0
         for name in list(self.supply.keys()):
             if name in counted:
                 continue
             card = get_card(name)
-            if isinstance(card, SplitPileMixin):
+            if isinstance(card, WizardsSplitCard):
+                wizard_names = set(WIZARDS_PILE_ORDER)
+                counted.update(wizard_names)
+                if all(self.supply.get(n, 0) == 0 for n in wizard_names if n in self.supply):
+                    empties += 1
+            elif isinstance(card, SplitPileMixin):
                 partner = card.partner_card_name
                 counted.add(name)
                 counted.add(partner)
@@ -267,6 +277,10 @@ class GameState:
         # Resolve project effects that occur at the start of the turn
         for project in self.current_player.projects:
             project.on_turn_start(self, self.current_player)
+
+        # Resolve Ally effects (e.g. Cave Dwellers' Favor-spending hook)
+        for ally in self.allies:
+            ally.on_turn_start(self, self.current_player)
 
         # Log turn header with complete state
         resources = {

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1058,8 +1058,21 @@ class GameState:
         self.discard_hex(hex_name)
         return hex_name
 
-    def gain_card(self, player: PlayerState, card: Card, to_deck: bool = False) -> Card:
+    def gain_card(
+        self,
+        player: PlayerState,
+        card: Card,
+        to_deck: bool = False,
+        from_supply: bool = True,
+    ) -> Card:
         """Add a card to a player's discard or deck, honoring topdeck effects.
+
+        ``from_supply`` controls supply-restoration semantics. The default
+        (``True``) matches the historical contract: the caller has already
+        decremented the supply for ``card.name``, so Trader's reaction and
+        the Exile-reclamation path may add 1 back when they replace the
+        gain. For trash-origin gains (Lurker, Lich), pass ``False`` so the
+        supply pile isn't inflated by the restoration logic.
 
         If the player has a matching card on their Exile mat, that card is
         reclaimed instead of the newly gained copy.
@@ -1078,7 +1091,7 @@ class GameState:
 
         if not reclaimed:
             actual_card = self._handle_trader_exchange(
-                player, card, actual_card, destination_is_deck
+                player, card, actual_card, destination_is_deck, from_supply=from_supply
             )
 
         if not destination_is_deck and getattr(player, "topdeck_gains", False):
@@ -1091,9 +1104,10 @@ class GameState:
         ):
             destination_is_deck = True
 
-        if reclaimed and card.name in self.supply:
+        if reclaimed and from_supply and card.name in self.supply:
             # Caller already decremented the supply; restore it since the
-            # Exiled card is being used instead.
+            # Exiled card is being used instead. Only valid for from-supply
+            # gains — trash-origin gains never decremented in the first place.
             self.supply[card.name] = self.supply.get(card.name, 0) + 1
 
         if destination_is_deck:
@@ -1164,8 +1178,15 @@ class GameState:
         original_card: Card,
         actual_card: Card,
         to_deck: bool,
+        from_supply: bool = True,
     ) -> Card:
-        """Allow Trader reactions to replace a gain with a Silver."""
+        """Allow Trader reactions to replace a gain with a Silver.
+
+        ``from_supply`` mirrors ``gain_card``: when the caller decremented
+        supply for ``original_card`` (the normal case), Trader restores it.
+        For trash-origin gains the caller never touched supply so we must
+        not "restore" a count that was never decremented.
+        """
 
         if self.supply.get("Silver", 0) <= 0:
             return actual_card
@@ -1176,7 +1197,7 @@ class GameState:
         if not player.ai.should_reveal_trader(self, player, original_card, to_deck=to_deck):
             return actual_card
 
-        if original_card.name in self.supply:
+        if from_supply and original_card.name in self.supply:
             self.supply[original_card.name] = self.supply.get(original_card.name, 0) + 1
 
         self.supply["Silver"] -= 1

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -39,6 +39,7 @@ class PlayerState:
     # Misc counters
     vp_tokens: int = 0
     villagers: int = 0
+    favors: int = 0
     miser_coppers: int = 0
     native_village_mat: list[Card] = field(default_factory=list)
     ignore_action_bonuses: bool = False

--- a/dominion/simulation/strategy_battle.py
+++ b/dominion/simulation/strategy_battle.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from dominion.ai.genetic_ai import GeneticAI
+from dominion.allies.registry import get_ally
 from dominion.boards.loader import BoardConfig, load_board
 from dominion.cards.registry import get_card
 from dominion.events.registry import get_event
@@ -110,13 +111,15 @@ class StrategyBattle:
         events = []
         projects = []
         ways = []
+        allies = []
 
         if self.board_config:
             events = [get_event(name) for name in self.board_config.events]
             projects = [get_project(name) for name in self.board_config.projects]
             ways = [get_way(name) for name in self.board_config.ways]
+            allies = [get_ally(name) for name in self.board_config.allies]
 
-        return kingdom_cards, events, projects, ways
+        return kingdom_cards, events, projects, ways, allies
 
     def run_battle(self, strategy1_name: str, strategy2_name: str, num_games: int = 100) -> dict[str, Any]:
         """Run multiple games between two strategies"""
@@ -230,7 +233,7 @@ class StrategyBattle:
         game_state.set_logger(self.logger)
 
         # Initialize game
-        kingdom_cards, events, projects, ways = self._prepare_board_components(kingdom_card_names)
+        kingdom_cards, events, projects, ways, allies = self._prepare_board_components(kingdom_card_names)
         game_state.initialize_game(
             [ai1, ai2],
             kingdom_cards,
@@ -238,6 +241,7 @@ class StrategyBattle:
             events=events,
             projects=projects,
             ways=ways,
+            allies=allies,
         )
 
         # Apply traits from board config

--- a/dominion/strategy/strategies/wizards_lich_engine.py
+++ b/dominion/strategy/strategies/wizards_lich_engine.py
@@ -1,0 +1,150 @@
+"""Hand-written strategy for the Wizards/Lich kingdom.
+
+Board: Beggar, Lurker, Settlers/Bustling Village, Wishing Well,
+       Student/Conjurer/Sorcerer/Lich, Mill, Baker, Cauldron, Crew, Pilgrim
+Event: Continue        Ally: Cave Dwellers
+
+Plan: open Student + Cauldron; trash through Estates/Coppers; race up the
+Wizards pile; pick up Cauldron and Pilgrim for payload/draw; grab Bustling
+Village once Settlers run out (Lurker accelerates this); end with multiple
+Liches. Mill greens during engine turns.
+"""
+
+from .base_strategy import BaseStrategy, PriorityRule
+from dominion.strategy.enhanced_strategy import EnhancedStrategy
+
+
+class WizardsLichEngine(BaseStrategy):
+    """Lich-payload engine fed by Student/Conjurer trashing and Cave Dwellers."""
+
+    def __init__(self):
+        super().__init__()
+        self.name = "WizardsLichEngine"
+        self.description = (
+            "Wizards split-pile engine: Student trashing, Sorcerer/Cauldron "
+            "cursing, Pilgrim draw, Lich payload. Cave Dwellers smooths shuffles."
+        )
+        self.version = "1.0"
+
+        self.gain_priority = [
+            # Greening
+            PriorityRule("Province", PriorityRule.resources("coins", ">=", 8)),
+            PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
+            PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),
+
+            # --- Engine spine: race up the Wizards pile ---
+            # Lich is the payload card — buy every copy you can.
+            PriorityRule("Lich"),
+            # Sorcerer for cursing + cantrip-Liaison.
+            PriorityRule(
+                "Sorcerer",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Sorcerer", 2),
+                    PriorityRule.turn_number("<=", 16),
+                ),
+            ),
+            # Conjurer is a cantrip that gains a $4 — perfect for Mill/Conjurer chains.
+            PriorityRule(
+                "Conjurer",
+                PriorityRule.max_in_deck("Conjurer", 2),
+            ),
+            # Student opens trashing + Favors. Want exactly one early.
+            PriorityRule(
+                "Student",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Student", 1),
+                    PriorityRule.turn_number("<=", 8),
+                ),
+            ),
+
+            # --- Payload cards ---
+            # Pilgrim: terminal +4 draw with topdeck. Cave Dwellers cleans up junk.
+            PriorityRule(
+                "Pilgrim",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Pilgrim", 2),
+                    PriorityRule.turn_number("<=", 14),
+                ),
+            ),
+            # Cauldron: $2 + buy treasure that curses on third gain. Auto-include.
+            PriorityRule(
+                "Cauldron",
+                PriorityRule.max_in_deck("Cauldron", 2),
+            ),
+            # Bustling Village is the only village. Buy when exposed.
+            PriorityRule("Bustling Village"),
+            # Mid-engine money + cantrip-VP.
+            PriorityRule(
+                "Mill",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Mill", 3),
+                    PriorityRule.turn_number(">=", 5),
+                ),
+            ),
+            # Baker for Coffer smoothing.
+            PriorityRule(
+                "Baker",
+                PriorityRule.max_in_deck("Baker", 1),
+            ),
+            # Lurker accelerates Settlers and Wizards drains; cheap non-terminal.
+            PriorityRule(
+                "Lurker",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Lurker", 2),
+                    PriorityRule.turn_number("<=", 12),
+                ),
+            ),
+            # Gold as backup economy
+            PriorityRule("Gold", PriorityRule.resources("coins", ">=", 6)),
+            # One Wishing Well as a $3 cantrip (peeks the deck).
+            PriorityRule(
+                "Wishing Well",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Wishing Well", 1),
+                    PriorityRule.turn_number("<=", 8),
+                ),
+            ),
+            # Silver as fallback when nothing better is affordable.
+            PriorityRule("Silver", PriorityRule.provinces_left(">", 3)),
+        ]
+
+        self.action_priority = [
+            # Villages/cantrips first.
+            PriorityRule("Bustling Village"),
+            PriorityRule("Settlers"),
+            PriorityRule("Mill"),
+            PriorityRule("Wishing Well"),
+            # Liaisons / Wizards. Lich needs +2 actions; play it before Pilgrim
+            # so we keep terminal slots open.
+            PriorityRule("Lich"),
+            PriorityRule("Conjurer"),
+            PriorityRule("Sorcerer"),
+            PriorityRule("Student"),
+            PriorityRule("Baker"),
+            # Lurker is non-terminal — play whenever, but after villages.
+            PriorityRule("Lurker"),
+            # Terminal draw last.
+            PriorityRule("Pilgrim"),
+            PriorityRule("Crew"),
+            # Beggar gives 3 Coppers — only play if no trasher available.
+            PriorityRule("Beggar"),
+        ]
+
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Cauldron"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+        self.trash_priority = [
+            PriorityRule("Curse"),
+            PriorityRule("Estate", PriorityRule.provinces_left(">", 4)),
+            PriorityRule("Hovel"),
+            PriorityRule("Overgrown Estate"),
+            PriorityRule("Copper", PriorityRule.has_cards(["Silver"], 2)),
+        ]
+
+
+def create_wizards_lich_engine() -> EnhancedStrategy:
+    return WizardsLichEngine()

--- a/generated_strategies/wizards_lich_evolved_20260429_163005.py
+++ b/generated_strategies/wizards_lich_evolved_20260429_163005.py
@@ -1,0 +1,49 @@
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class WizardsLichEvolved(EnhancedStrategy):
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = 'gen15-4978269648'
+        self.description = "Auto-generated strategy from genetic training"
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule('Province', PriorityRule.resources('coins', '>=', 8)),
+            PriorityRule('Cauldron', PriorityRule.turn_number('<=', 11)),
+            PriorityRule('Province', PriorityRule.resources('coins', '>=', 8)),
+            PriorityRule('Province'),
+            PriorityRule('Duchy', PriorityRule.has_cards(['Duchy', 'Province', 'Silver'], 2)),
+            PriorityRule('Baker', PriorityRule.turn_number('<=', 8)),
+            PriorityRule('Bustling Village'),
+            PriorityRule('Mill'),
+            PriorityRule('Silver'),
+        ]
+
+        self.action_priority = [
+            PriorityRule('Settlers', PriorityRule.has_cards(['Province', 'Duchy', 'Gold'], 0)),
+            PriorityRule('Settlers', PriorityRule.max_in_deck('Gold', 6)),
+            PriorityRule('Mill', PriorityRule.score_diff('>=', -6)),
+            PriorityRule('Pilgrim'),
+            PriorityRule('Conjurer'),
+            PriorityRule('Settlers', PriorityRule.deck_size('>', 18)),
+            PriorityRule('Lurker'),
+        ]
+
+        self.treasure_priority = [
+            PriorityRule('Cauldron'),
+            PriorityRule('Copper'),
+            PriorityRule('Gold'),
+            PriorityRule('Silver'),
+        ]
+
+        self.trash_priority = [
+            PriorityRule('Curse'),
+            PriorityRule('Estate', PriorityRule.provinces_left('>', 6)),
+            PriorityRule('Hovel'),
+            PriorityRule('Overgrown Estate'),
+            PriorityRule('Copper', PriorityRule.has_cards(['Silver', 'Gold'], 2)),
+        ]
+
+def create_wizardslichevolved() -> EnhancedStrategy:
+    return WizardsLichEvolved()

--- a/scripts/evolve_wizards_lich.py
+++ b/scripts/evolve_wizards_lich.py
@@ -1,0 +1,99 @@
+"""Evolve a strategy for the Wizards/Lich kingdom and battle it against the
+hand-written WizardsLichEngine and Big Money."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import datetime
+from pathlib import Path
+
+import coloredlogs
+
+from dominion.ai.genetic_ai import GeneticAI
+from dominion.boards.loader import load_board
+from dominion.simulation.genetic_trainer import GeneticTrainer
+from dominion.simulation.strategy_battle import StrategyBattle
+from dominion.strategy.strategy_loader import StrategyLoader
+from dominion.strategy.strategies.wizards_lich_engine import (
+    create_wizards_lich_engine,
+)
+from runner import save_strategy_as_python
+
+
+logger = logging.getLogger(__name__)
+coloredlogs.install(level="INFO", logger=logger)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--board", default="boards/wizards_lich.txt")
+    parser.add_argument("--population", type=int, default=24)
+    parser.add_argument("--generations", type=int, default=40)
+    parser.add_argument("--games-per-eval", type=int, default=40)
+    parser.add_argument("--mutation-rate", type=float, default=0.18)
+    parser.add_argument("--validation-games", type=int, default=120)
+    parser.add_argument("--output-dir", type=Path, default=Path("generated_strategies"))
+    args = parser.parse_args()
+
+    cfg = load_board(args.board)
+    board_name = Path(args.board).stem
+
+    loader = StrategyLoader()
+    big_money = loader.get_strategy("Big Money")
+    big_money_smithy = loader.get_strategy("Big Money Smithy")
+
+    seed = create_wizards_lich_engine()
+
+    panel = [seed, big_money, big_money_smithy]
+    logger.info("Fitness panel: %s", ", ".join(p.name for p in panel))
+
+    trainer = GeneticTrainer(
+        kingdom_cards=cfg.kingdom_cards,
+        population_size=args.population,
+        generations=args.generations,
+        mutation_rate=args.mutation_rate,
+        games_per_eval=args.games_per_eval,
+        board_config=cfg,
+    )
+    trainer.inject_strategy(seed)
+    trainer.set_baseline_panel(panel)
+
+    best, metrics = trainer.train()
+    if best is None:
+        logger.error("No best strategy evolved")
+        return
+
+    logger.info("Best evolved fitness: %.1f%%", metrics.get("win_rate", 0.0))
+    logger.info("Panel breakdown: %s", trainer.last_eval_breakdown)
+
+    args.output_dir.mkdir(exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_file = args.output_dir / f"{board_name}_evolved_{timestamp}.py"
+    save_strategy_as_python(best, out_file, "WizardsLichEvolved")
+    logger.info("Saved evolved strategy to %s", out_file)
+
+    # Validation: head-to-head vs hand-written and BM
+    battle = StrategyBattle(kingdom_cards=cfg.kingdom_cards, board_config=cfg, log_frequency=0)
+
+    def head_to_head(opp_factory, name: str) -> None:
+        wins = 0
+        for i in range(args.validation_games):
+            ai1 = GeneticAI(best)
+            ai2 = GeneticAI(opp_factory())
+            if i % 2 == 0:
+                winner, _, _, _ = battle.run_game(ai1, ai2, cfg.kingdom_cards)
+            else:
+                winner, _, _, _ = battle.run_game(ai2, ai1, cfg.kingdom_cards)
+            if winner == ai1:
+                wins += 1
+        rate = wins / args.validation_games * 100
+        logger.info("Evolved vs %s: %d/%d (%.1f%%)", name, wins, args.validation_games, rate)
+
+    head_to_head(create_wizards_lich_engine, "WizardsLichEngine (hand-written)")
+    head_to_head(lambda: loader.get_strategy("Big Money"), "Big Money")
+    head_to_head(lambda: loader.get_strategy("Big Money Smithy"), "Big Money Smithy")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_board_loader.py
+++ b/tests/test_board_loader.py
@@ -48,12 +48,13 @@ def test_strategy_battle_prepares_landscapes(tmp_path):
     board = load_board(path)
     battle = StrategyBattle(board_config=board)
 
-    kingdom, events, projects, ways = battle._prepare_board_components(board.kingdom_cards)
+    kingdom, events, projects, ways, allies = battle._prepare_board_components(board.kingdom_cards)
 
     assert [card.name for card in kingdom] == board.kingdom_cards
     assert events == []
     assert [project.name for project in projects] == board.projects
     assert [way.name for way in ways] == board.ways
+    assert allies == []
 
 
 def test_load_board_requires_cards(tmp_path):

--- a/tests/test_board_loader.py
+++ b/tests/test_board_loader.py
@@ -57,6 +57,23 @@ def test_strategy_battle_prepares_landscapes(tmp_path):
     assert allies == []
 
 
+def test_way_of_the_prefix_with_target(tmp_path):
+    """``Way of the Mouse: Native Village`` should parse as the parametric
+    Way ``Way of the Mouse (Native Village)`` — what the registry expects."""
+    path = write_board(
+        tmp_path,
+        """
+        Bridge
+        Way of the Mouse: Native Village
+        """,
+    )
+
+    board = load_board(path)
+
+    assert board.kingdom_cards == ["Bridge"]
+    assert board.ways == ["Way of the Mouse (Native Village)"]
+
+
 def test_load_board_requires_cards(tmp_path):
     path = write_board(tmp_path, "# Only comments")
 

--- a/tests/test_continue_event.py
+++ b/tests/test_continue_event.py
@@ -49,7 +49,8 @@ class _FixedTargetAI:
 def _new_state(target_name: str) -> tuple[GameState, PlayerState]:
     state = GameState(players=[])
     state.players = [PlayerState(_FixedTargetAI(target_name))]
-    state.setup_supply([get_card("Village")])
+    # Include Villa in the kingdom so Continue can target it when asked.
+    state.setup_supply([get_card("Village"), get_card("Villa")])
     state.players[0].coins = 8
     return state, state.players[0]
 
@@ -81,6 +82,17 @@ def test_continue_does_not_duplicate_topdecked_gains():
     assert len(villages_in_play) == 1, f"Village should be in_play once; in_play has {len(villages_in_play)}"
     assert villages_in_deck == [], f"Village should not be left on deck; got {len(villages_in_deck)}"
     assert villages_in_discard == [], f"Village should not be in discard pre-cleanup; got {len(villages_in_discard)}"
+
+
+def test_continue_finds_gain_in_hand_for_villa():
+    """Villa's on_gain moves itself into hand. Continue must still play it."""
+    state, player = _new_state("Villa")
+    Continue().on_buy(state, player)
+
+    villas_in_play = [c for c in player.in_play if c.name == "Villa"]
+    villas_in_hand = [c for c in player.hand if c.name == "Villa"]
+    assert len(villas_in_play) == 1, "Villa should be in_play after Continue plays it"
+    assert villas_in_hand == [], "Villa should not be left in hand"
 
 
 def test_continue_skips_play_if_gain_was_intercepted():

--- a/tests/test_continue_event.py
+++ b/tests/test_continue_event.py
@@ -1,0 +1,106 @@
+"""Tests for the Continue event from Plunder.
+
+Continue's text: "$8: gain a non-Victory non-Command card costing up to $4,
+then play it." Two invariants under test:
+
+1. The "play it" clause applies to *any* gained card type (Action or
+   Treasure), not just Actions. A gained Silver should be played and add
+   its $2 to the player's coin pool.
+2. The play step must locate the gained card across all post-gain zones,
+   not just ``discard``. If a top-deck reaction (Royal Seal, Insignia, …)
+   places the gain on top of the deck, Continue must still find it there
+   and move it cleanly into ``in_play`` — leaving the same object in two
+   zones would corrupt later cleanup and draw.
+"""
+
+from dominion.cards.registry import get_card
+from dominion.events.continue_event import Continue
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+
+class _FixedTargetAI:
+    """AI that always picks the named card from Continue's choices."""
+
+    def __init__(self, target_name: str):
+        self.name = "fixed"
+        self.target_name = target_name
+        self.strategy = None
+
+    def choose_action(self, *args, **kwargs):
+        return None
+
+    def choose_treasure(self, *args, **kwargs):
+        return None
+
+    def choose_buy(self, *args, **kwargs):
+        return None
+
+    def choose_card_to_trash(self, *args, **kwargs):
+        return None
+
+    def choose_continue_target(self, state, player, choices):
+        for c in choices:
+            if c.name == self.target_name:
+                return c
+        return choices[0] if choices else None
+
+
+def _new_state(target_name: str) -> tuple[GameState, PlayerState]:
+    state = GameState(players=[])
+    state.players = [PlayerState(_FixedTargetAI(target_name))]
+    state.setup_supply([get_card("Village")])
+    state.players[0].coins = 8
+    return state, state.players[0]
+
+
+def test_continue_plays_a_gained_treasure():
+    """Gaining Silver via Continue should add $2 to the coin pool."""
+    state, player = _new_state("Silver")
+    coins_before = player.coins
+    Continue().on_buy(state, player)
+    # Silver is in_play and contributed +$2.
+    assert any(c.name == "Silver" for c in player.in_play), "Silver should be in_play after Continue"
+    assert player.coins == coins_before + 2, f"Silver should add $2; got {player.coins - coins_before}"
+
+
+def test_continue_does_not_duplicate_topdecked_gains():
+    """If Insignia tops-decks the gain, Continue must still find and play it
+    cleanly without leaving the same object in both deck and in_play."""
+    state, player = _new_state("Village")
+    player.insignia_active = True
+    # Make the AI accept top-decking.
+    player.ai.should_topdeck_with_insignia = lambda *a, **k: True
+
+    Continue().on_buy(state, player)
+
+    # Locate the Village. It should be in_play exactly once and not in deck.
+    villages_in_play = [c for c in player.in_play if c.name == "Village"]
+    villages_in_deck = [c for c in player.deck if c.name == "Village"]
+    villages_in_discard = [c for c in player.discard if c.name == "Village"]
+    assert len(villages_in_play) == 1, f"Village should be in_play once; in_play has {len(villages_in_play)}"
+    assert villages_in_deck == [], f"Village should not be left on deck; got {len(villages_in_deck)}"
+    assert villages_in_discard == [], f"Village should not be in discard pre-cleanup; got {len(villages_in_discard)}"
+
+
+def test_continue_skips_play_if_gain_was_intercepted():
+    """If the gain landed somewhere unusual (trashed, exiled), Continue should
+    not blindly append the card to in_play."""
+    state, player = _new_state("Village")
+
+    # Patch gain_card to drop the card on the floor (simulating a Watchtower
+    # trash reaction) so the returned object lives in no normal zone.
+    real_gain = state.gain_card
+    intercepted: list = []
+
+    def fake_gain(p, card, to_deck=False):
+        intercepted.append(card)
+        # Don't add to any zone — caller must handle this gracefully.
+        return card
+
+    state.gain_card = fake_gain  # type: ignore[assignment]
+
+    # Should not raise, and Village should not appear in in_play (we skipped play).
+    Continue().on_buy(state, player)
+    assert not any(c.name == "Village" for c in player.in_play)
+    state.gain_card = real_gain  # restore (not strictly needed, fresh state)

--- a/tests/test_crew_duration.py
+++ b/tests/test_crew_duration.py
@@ -1,0 +1,124 @@
+"""Regression tests for Crew's duration cleanup.
+
+Crew is an Action-Duration: +3 Cards on play, then top-decks itself at the
+start of the next turn. Without explicit cleanup the same Crew object would
+end up referenced from both ``deck`` (via the top-deck) and ``in_play``
+(left over from the previous turn), and the cleanup phase would then move
+the in_play copy to ``discard`` while the deck reference persists, giving
+the player two Crews where there should be one.
+"""
+
+from collections import Counter
+
+from dominion.cards.plunder.crew import Crew
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+
+class _NullAI:
+    name = "null"
+
+    def __init__(self):
+        self.strategy = None
+
+    def choose_action(self, *args, **kwargs):
+        return None
+
+    def choose_treasure(self, *args, **kwargs):
+        return None
+
+    def choose_buy(self, *args, **kwargs):
+        return None
+
+    def choose_card_to_trash(self, *args, **kwargs):
+        return None
+
+
+def _all_cards(player: PlayerState):
+    return (
+        list(player.hand)
+        + list(player.deck)
+        + list(player.discard)
+        + list(player.in_play)
+        + list(player.duration)
+    )
+
+
+def test_crew_does_not_duplicate_after_duration_topdeck():
+    state = GameState(players=[])
+    state.players = [PlayerState(_NullAI())]
+    state.players[0].deck = [get_card("Copper") for _ in range(5)]
+    state.players[0].draw_cards(0)  # initialize hand state
+
+    crew = Crew()
+    player = state.players[0]
+    player.hand = [crew] + [get_card("Copper") for _ in range(4)]
+    player.in_play = []
+    player.duration = []
+
+    # Simulate the action phase placing Crew into in_play, then on_play.
+    player.hand.remove(crew)
+    player.in_play.append(crew)
+    crew.on_play(state)
+
+    assert crew in player.in_play, "Crew should remain in play after on_play (duration)"
+    assert crew in player.duration, "Crew should be tracked as a duration"
+
+    # End-of-turn cleanup analog: durations stay in_play. Skip the full
+    # cleanup logic and just verify the on_duration step's cleanup.
+    crew.on_duration(state)
+
+    # Exactly one reference, on top of the deck.
+    occurrences = sum(1 for card in _all_cards(player) if card is crew)
+    assert occurrences == 1, f"Crew duplicated across zones: {occurrences}"
+    assert player.deck and player.deck[-1] is crew, "Crew should be on top of deck"
+    assert crew not in player.in_play
+    assert crew not in player.duration
+
+
+def test_crew_in_play_count_is_one_after_full_duration_cycle():
+    """End-to-end: play Crew, run start-of-next-turn, ensure no zone duplicates."""
+    from dominion.ai.base_ai import AI
+
+    class _PassAI(AI):
+        @property
+        def name(self):
+            return "pass"
+
+        def choose_action(self, state, choices):
+            return None
+
+        def choose_treasure(self, state, choices):
+            return None
+
+        def choose_buy(self, state, choices):
+            return None
+
+        def choose_card_to_trash(self, state, choices):
+            return None
+
+    state = GameState(players=[])
+    state.players = [PlayerState(_PassAI()), PlayerState(_PassAI())]
+    for p in state.players:
+        p.initialize()
+
+    crew = Crew()
+    player = state.players[0]
+    player.hand.append(crew)
+
+    # Play Crew via the engine action loop's mechanics.
+    player.hand.remove(crew)
+    player.in_play.append(crew)
+    crew.on_play(state)
+
+    # Run the cleanup-phase preserve logic (durations stay in play).
+    state.handle_cleanup_phase()
+
+    # Now the next turn's duration phase fires.
+    state.current_player_index = 0
+    state.handle_start_phase()
+
+    cards = _all_cards(player)
+    counts = Counter(id(c) for c in cards)
+    assert counts[id(crew)] == 1, "Crew exists in exactly one zone after duration trigger"

--- a/tests/test_crew_replay.py
+++ b/tests/test_crew_replay.py
@@ -1,0 +1,79 @@
+"""Crew must not duplicate itself when replayed during the same turn.
+
+Effects like Flagship and Throne Room can play the same Crew instance more
+than once on the same turn. Each play of Crew draws cards, but the duration
+listing must not be added multiple times — otherwise the start-of-next-turn
+duration phase iterates the same instance several times and ``on_duration``
+appends the same card object to the deck more than once.
+"""
+
+from collections import Counter
+
+from dominion.cards.plunder.crew import Crew
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+
+class _NullAI:
+    name = "null"
+
+    def __init__(self):
+        self.strategy = None
+
+    def choose_action(self, *a, **k):
+        return None
+
+    def choose_treasure(self, *a, **k):
+        return None
+
+    def choose_buy(self, *a, **k):
+        return None
+
+    def choose_card_to_trash(self, *a, **k):
+        return None
+
+
+def test_crew_replay_does_not_duplicate_in_duration():
+    """Two play_effect calls (simulating Flagship's extra play) must not add
+    Crew to player.duration twice."""
+    state = GameState(players=[])
+    state.players = [PlayerState(_NullAI())]
+    state.players[0].deck = [get_card("Copper") for _ in range(8)]
+    crew = Crew()
+    player = state.players[0]
+    player.in_play.append(crew)
+
+    crew.on_play(state)  # first play
+    crew.on_play(state)  # Flagship replay
+
+    counts = Counter(id(c) for c in player.duration)
+    assert counts[id(crew)] == 1, (
+        "Crew must appear in duration exactly once even after a replay; "
+        f"got {counts[id(crew)]} entries"
+    )
+
+
+def test_crew_replay_does_not_duplicate_in_deck_after_duration():
+    """If Flagship replayed Crew, the start-of-next-turn duration phase must
+    still leave exactly one Crew on the deck, not two."""
+    state = GameState(players=[])
+    state.players = [PlayerState(_NullAI())]
+    state.players[0].deck = [get_card("Copper") for _ in range(8)]
+    crew = Crew()
+    player = state.players[0]
+    player.in_play.append(crew)
+
+    crew.on_play(state)
+    crew.on_play(state)
+
+    # Pretend the engine just kicked the duration phase: iterate a snapshot.
+    for entry in list(player.duration):
+        entry.on_duration(state)
+
+    crew_count_in_deck = sum(1 for c in player.deck if c is crew)
+    assert crew_count_in_deck == 1, (
+        f"Crew should appear on the deck exactly once after duration; got {crew_count_in_deck}"
+    )
+    assert crew not in player.duration
+    assert crew not in player.in_play

--- a/tests/test_starting_favor.py
+++ b/tests/test_starting_favor.py
@@ -1,0 +1,58 @@
+"""Each player starts with 1 Favor token when an Ally is in the game.
+
+Per the official Dominion: Allies rules, "Each player starts the game with 1
+Favor" whenever an Ally is included. Without this setup step, Ally abilities
+can't be activated until a Liaison resolves, which silently changes early-turn
+behavior on Ally boards.
+"""
+
+from dominion.allies.registry import get_ally
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+
+class _NullAI:
+    name = "null"
+
+    def __init__(self):
+        self.strategy = None
+
+    def choose_action(self, *args, **kwargs):
+        return None
+
+    def choose_treasure(self, *args, **kwargs):
+        return None
+
+    def choose_buy(self, *args, **kwargs):
+        return None
+
+    def choose_card_to_trash(self, *args, **kwargs):
+        return None
+
+
+def _initialize(player_count: int, allies: list) -> GameState:
+    state = GameState(players=[])
+    ais = [_NullAI() for _ in range(player_count)]
+    # initialize_game uses ais to construct PlayerState; pass a minimal kingdom.
+    state.initialize_game(ais, [get_card("Village")], allies=allies)
+    return state
+
+
+def test_each_player_gets_one_favor_when_ally_is_in_game():
+    cave_dwellers = get_ally("Cave Dwellers")
+    state = _initialize(2, allies=[cave_dwellers])
+    for player in state.players:
+        assert player.favors == 1
+
+
+def test_no_starting_favor_when_no_ally_present():
+    state = _initialize(2, allies=[])
+    for player in state.players:
+        assert player.favors == 0
+
+
+def test_starting_favor_scales_with_player_count():
+    cave_dwellers = get_ally("Cave Dwellers")
+    state = _initialize(4, allies=[cave_dwellers])
+    assert sum(p.favors for p in state.players) == 4

--- a/tests/test_student_trash_topdeck.py
+++ b/tests/test_student_trash_topdeck.py
@@ -1,0 +1,86 @@
+"""Student top-decks itself when its trashed card is a Treasure.
+
+Per Allies rules, Student says: "+1 Action. +1 Favor. Trash a card from your
+hand. If it's a Treasure, put this onto your deck." The previous implementation
+only granted the +1 Favor and left Student in the normal play→discard flow,
+which silently dropped the recycle effect on Treasure-trash turns.
+"""
+
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+
+class _TrashCopperAI:
+    """AI that always picks Copper from a trash prompt and is a no-op otherwise."""
+
+    name = "trash-copper"
+
+    def __init__(self):
+        self.strategy = None
+
+    def choose_action(self, *args, **kwargs):
+        return None
+
+    def choose_treasure(self, *args, **kwargs):
+        return None
+
+    def choose_buy(self, *args, **kwargs):
+        return None
+
+    def choose_card_to_trash(self, _state, choices):
+        for c in choices:
+            if c.name == "Copper":
+                return c
+        return None
+
+
+class _TrashEstateAI(_TrashCopperAI):
+    name = "trash-estate"
+
+    def choose_card_to_trash(self, _state, choices):
+        for c in choices:
+            if c.name == "Estate":
+                return c
+        return None
+
+
+def _new_state(ai_cls) -> tuple[GameState, PlayerState]:
+    state = GameState(players=[])
+    state.players = [PlayerState(ai_cls())]
+    state.setup_supply([get_card("Student")])
+    return state, state.players[0]
+
+
+def test_student_top_decks_itself_after_trashing_a_treasure():
+    state, player = _new_state(_TrashCopperAI)
+    student = get_card("Student")
+    player.hand = [get_card("Copper")]
+    player.in_play = [student]
+
+    student.play_effect(state)
+
+    assert get_card("Copper") not in player.hand
+    # Student should now be on top of the deck (end of list = top).
+    assert player.deck and player.deck[-1] is student, (
+        "Student should be moved to the top of the deck after trashing a Treasure"
+    )
+    assert student not in player.in_play
+    # And +1 Favor was awarded for the Treasure trash (on top of the Liaison +1).
+    assert player.favors == 2
+
+
+def test_student_stays_in_play_when_trashing_a_non_treasure():
+    state, player = _new_state(_TrashEstateAI)
+    student = get_card("Student")
+    player.hand = [get_card("Estate")]
+    player.in_play = [student]
+
+    student.play_effect(state)
+
+    assert student in player.in_play, (
+        "Student should stay in play when the trashed card was not a Treasure"
+    )
+    assert student not in player.deck
+    # Only the Liaison favor was awarded.
+    assert player.favors == 1

--- a/tests/test_trash_gain_hooks.py
+++ b/tests/test_trash_gain_hooks.py
@@ -1,0 +1,115 @@
+"""Regression tests for Lurker and Lich trash-gain paths.
+
+Both cards can pull a card out of the trash and put it into the player's
+deck/discard. These paths must route through ``GameState.gain_card`` so the
+gain participates in shared bookkeeping (``cards_gained_this_turn``,
+``actions_gained_this_turn``, project on-gain hooks, Watchtower/Insignia/
+Royal Seal reactions, and the Cauldron third-Action-gain curse trigger).
+"""
+
+from dominion.cards.allies.wizards import Lich
+from dominion.cards.intrigue.lurker import Lurker
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+
+class _GainFromTrashAI:
+    """AI that picks Lurker mode='gain' and trashes/gains a fixed card."""
+
+    def __init__(self, target_name: str | None = None):
+        self.name = "trash-gain"
+        self.target_name = target_name
+        self.strategy = None
+
+    def choose_action(self, *args, **kwargs):
+        return None
+
+    def choose_treasure(self, *args, **kwargs):
+        return None
+
+    def choose_buy(self, *args, **kwargs):
+        return None
+
+    def choose_card_to_trash(self, state, choices):
+        return choices[0] if choices else None
+
+    def choose_lurker_mode(self, state, player, can_trash, can_gain):
+        return "gain" if can_gain else "trash"
+
+    def choose_action_to_gain_from_trash(self, state, player, choices):
+        if self.target_name:
+            for c in choices:
+                if c.name == self.target_name:
+                    return c
+        return choices[0] if choices else None
+
+    def choose_card_to_gain_from_trash(self, state, player, choices, max_cost):
+        if self.target_name:
+            for c in choices:
+                if c.name == self.target_name:
+                    return c
+        return choices[0] if choices else None
+
+    def choose_cards_to_discard(self, state, player, choices, count, *, reason=None):
+        # Drop the cheapest cards.
+        ordered = sorted(choices, key=lambda c: (c.cost.coins, c.name))
+        return ordered[:count]
+
+
+def _setup(kingdom_extras: list[str] = ()) -> tuple[GameState, PlayerState]:
+    state = GameState(players=[])
+    state.players = [PlayerState(_GainFromTrashAI())]
+    cards = [get_card("Village")] + [get_card(n) for n in kingdom_extras]
+    state.setup_supply(cards)
+    return state, state.players[0]
+
+
+def test_lurker_trash_gain_increments_cards_gained_this_turn():
+    state, player = _setup()
+    village = get_card("Village")
+    state.trash.append(village)
+
+    before = player.cards_gained_this_turn
+    Lurker().play_effect(state)
+
+    assert player.cards_gained_this_turn == before + 1, (
+        "Lurker's trash gain should bump cards_gained_this_turn so it "
+        "participates in the same bookkeeping as buy-phase gains"
+    )
+    assert village in player.discard, "Gained card should land in discard"
+    assert village not in state.trash, "Gained card should leave the trash"
+
+
+def test_lurker_trash_gain_increments_actions_gained_this_turn():
+    """Cauldron-style trigger: action gains from trash must count."""
+    state, player = _setup()
+    village = get_card("Village")
+    state.trash.append(village)
+
+    before = player.actions_gained_this_turn
+    Lurker().play_effect(state)
+
+    assert player.actions_gained_this_turn == before + 1, (
+        "Lurker's trash gain should advance actions_gained_this_turn so "
+        "Cauldron's third-Action-gain trigger fires consistently"
+    )
+
+
+def test_lich_trash_gain_increments_cards_gained_this_turn():
+    """Lich's '+ gain a cheaper Action from trash' clause must also route through gain_card."""
+    state, player = _setup()
+    # Put a cheaper Action in trash (Village costs $3, less than Lich's $6).
+    village = get_card("Village")
+    state.trash.append(village)
+    # Lich draws +6 / +2A then asks the AI to discard 2 — give the player a hand.
+    player.hand = [get_card("Copper") for _ in range(3)]
+
+    before_cards = player.cards_gained_this_turn
+    before_actions = player.actions_gained_this_turn
+    Lich().play_effect(state)
+
+    assert player.cards_gained_this_turn == before_cards + 1
+    assert player.actions_gained_this_turn == before_actions + 1
+    assert village in player.discard
+    assert village not in state.trash

--- a/tests/test_trash_gain_supply.py
+++ b/tests/test_trash_gain_supply.py
@@ -1,0 +1,101 @@
+"""Regression: Lurker/Lich trash gains must not inflate supply via Trader.
+
+When ``GameState.gain_card`` runs, it assumes the caller has already
+decremented the supply for the original card (true for normal buys and
+Workshop-style gainers). For Lurker and Lich, the gain comes from the
+trash and the caller did *not* decrement supply. Trader's reaction logic
+then runs `self.supply[original.name] += 1` to "restore" the supply,
+inflating it. The fix is to pass an explicit `from_supply=False` flag
+through to suppress the restoration and the analogous Exile-reclamation
+restoration when the gain didn't come from the supply pile.
+"""
+
+from dominion.cards.allies.wizards import Lich
+from dominion.cards.intrigue.lurker import Lurker
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+
+class _RevealsTraderAI:
+    name = "trader-reveal"
+
+    def __init__(self):
+        self.strategy = None
+
+    def choose_action(self, *a, **k):
+        return None
+
+    def choose_treasure(self, *a, **k):
+        return None
+
+    def choose_buy(self, *a, **k):
+        return None
+
+    def choose_card_to_trash(self, state, choices):
+        return choices[0] if choices else None
+
+    def choose_lurker_mode(self, state, player, can_trash, can_gain):
+        return "gain" if can_gain else "trash"
+
+    def choose_action_to_gain_from_trash(self, state, player, choices):
+        return choices[0] if choices else None
+
+    def choose_card_to_gain_from_trash(self, state, player, choices, max_cost):
+        return choices[0] if choices else None
+
+    def choose_cards_to_discard(self, state, player, choices, count, *, reason=None):
+        # Preserve Trader so it can react to the gain.
+        ranked = sorted(choices, key=lambda c: 0 if c.name != "Trader" else 1)
+        return ranked[:count]
+
+    def should_reveal_trader(self, state, player, gained_card, *, to_deck):
+        # Always reveal Trader so the exchange flow runs.
+        return True
+
+
+def _setup() -> tuple[GameState, PlayerState]:
+    state = GameState(players=[])
+    state.players = [PlayerState(_RevealsTraderAI())]
+    state.setup_supply([get_card("Village")])
+    return state, state.players[0]
+
+
+def test_lurker_trash_gain_with_trader_does_not_inflate_supply():
+    state, player = _setup()
+    village_supply_before = state.supply["Village"]
+    silver_supply_before = state.supply["Silver"]
+
+    # Set up: Village in trash for Lurker to gain; Trader in hand.
+    state.trash.append(get_card("Village"))
+    player.hand = [get_card("Trader")]
+
+    Lurker().play_effect(state)
+
+    # Trader replaced the gain with Silver. Pile-count invariants:
+    #   - Village supply is unchanged (we took it from trash, not supply).
+    #   - Silver supply went down by exactly 1.
+    assert state.supply["Village"] == village_supply_before, (
+        f"Village supply should be unchanged; before={village_supply_before}, after={state.supply['Village']}"
+    )
+    assert state.supply["Silver"] == silver_supply_before - 1, (
+        f"Silver supply should decrement by 1; before={silver_supply_before}, after={state.supply['Silver']}"
+    )
+    assert any(c.name == "Silver" for c in player.discard), "Player should end up with Silver"
+
+
+def test_lich_trash_gain_with_trader_does_not_inflate_supply():
+    state, player = _setup()
+    village_supply_before = state.supply["Village"]
+    silver_supply_before = state.supply["Silver"]
+
+    state.trash.append(get_card("Village"))
+    player.hand = [get_card("Trader"), get_card("Copper"), get_card("Copper")]
+
+    Lich().play_effect(state)
+
+    assert state.supply["Village"] == village_supply_before, (
+        f"Village supply should be unchanged; before={village_supply_before}, after={state.supply['Village']}"
+    )
+    assert state.supply["Silver"] == silver_supply_before - 1
+    assert any(c.name == "Silver" for c in player.discard)

--- a/tests/test_wizards_supply.py
+++ b/tests/test_wizards_supply.py
@@ -1,0 +1,49 @@
+"""Wizards split pile supply sizing across player counts.
+
+The four-card Wizards pile (Student → Conjurer → Sorcerer → Lich) must use
+the same player-count-aware supply size for every partner pile, mirroring
+how ``SplitPileMixin`` already handles two-card splits.
+"""
+
+from dominion.cards.allies.wizards import WIZARDS_PILE_ORDER
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+
+class _NullAI:
+    name = "null"
+
+    def __init__(self):
+        self.strategy = None
+
+    def choose_action(self, *args, **kwargs):
+        return None
+
+    def choose_treasure(self, *args, **kwargs):
+        return None
+
+    def choose_buy(self, *args, **kwargs):
+        return None
+
+    def choose_card_to_trash(self, *args, **kwargs):
+        return None
+
+
+def _setup(player_count: int) -> GameState:
+    state = GameState(players=[])
+    state.players = [PlayerState(_NullAI()) for _ in range(player_count)]
+    state.setup_supply([get_card("Student")])
+    return state
+
+
+def test_wizards_pile_uses_two_player_supply():
+    state = _setup(2)
+    for name in WIZARDS_PILE_ORDER:
+        assert state.supply[name] == 4, f"{name} should have 4 copies in 2-player"
+
+
+def test_wizards_pile_uses_higher_player_supply():
+    state = _setup(3)
+    for name in WIZARDS_PILE_ORDER:
+        assert state.supply[name] == 5, f"{name} should have 5 copies in 3-player"


### PR DESCRIPTION
## Summary
- Implements the cards needed for a Wizards/Lich kingdom: **Lurker**, **Wizards split pile (Student/Conjurer/Sorcerer/Lich)**, **Crew**, **Pilgrim**, the **Continue** event, and the **Cave Dwellers** Ally.
- Adds the supporting infrastructure: Favor tokens on `PlayerState`, an `Ally` base + registry, `BoardConfig.allies` threaded through `StrategyBattle` → `GameState`, and a custom multi-card split pile mechanism (extends the existing `SplitPileMixin` pattern).
- Adds AI decision hooks: `should_spend_favor_on_cave_dwellers`, `choose_card_to_topdeck_from_hand`, `choose_action_to_trash_from_supply`, `choose_action_to_gain_from_trash`, `choose_lurker_mode`, `choose_continue_target`, `choose_card_to_gain_from_trash`.
- Ships `boards/wizards_lich.txt` (the kingdom file), a hand-written `WizardsLichEngine` strategy, a `scripts/evolve_wizards_lich.py` driver that runs the genetic trainer with a 3-strategy fitness panel, and the resulting evolved strategy.

## Validation (200-game head-to-heads on the kingdom)
| Matchup | Wins | Avg score |
|---|---|---|
| Evolved vs WizardsLichEngine (hand-written) | **194 / 200 (97.0%)** | 47.5 vs 33.2 |
| Evolved vs Big Money | **160 / 200 (80.0%)** | 37.7 vs 31.9 |
| Evolved vs Big Money Smithy | **200 / 200 (100.0%)** | 49.7 vs 14.8 |
| Hand-written vs Big Money | 44 / 200 (22.0%) | 30.6 vs 37.3 |
| Hand-written vs Big Money Smithy | 200 / 200 (100.0%) | 60.9 vs 21.4 |

Notable finding: the evolved strategy ignores the Wizards engine entirely and plays Cauldron-fuelled Big Money + Mill greening — beats both Big Money and the engine attempt on this simulator. Full deck profile and trade-offs in the commit message / strategy file.

## Test plan
- [x] All cards load via `get_card`, the event via `get_event`, the ally via `get_ally`.
- [x] BM-mirror smoke test runs to completion on the new kingdom.
- [x] Hand-written and evolved strategies battle to completion across 200+ games each, no exceptions.
- [x] `empty_piles` correctly counts the four-card Wizards split as one pile.
- [x] Crew duration cleanup (top-deck self) works without double-removal from `player.duration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)