### PR TITLE
Let mutator produce compound and_(card_in_play(X), inner) conditions

### DIFF
--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -86,6 +86,34 @@ class GeneticTrainer:
             except ValueError:
                 pass
 
+    # Probability that ``_random_condition_with_compound`` wraps a normally
+    # sampled inner condition in ``and_(card_in_play(X), inner)``. Tunable.
+    _COMPOUND_CONDITION_PROB = 0.15
+
+    def _random_condition_with_compound(self) -> "Callable | None":
+        """Return a random callable condition, with ~15% probability returning
+        a compound ``and_(card_in_play(X), inner)`` where ``X`` is drawn from
+        the kingdom's action cards and ``inner`` is a normally-sampled
+        condition.
+
+        If the kingdom has no action cards, falls back to a non-compound
+        condition (since ``card_in_play`` with no kingdom action is not
+        meaningful).
+        """
+        if (
+            self._kingdom_action_cards
+            and random.random() < self._COMPOUND_CONDITION_PROB
+        ):
+            inner = self._random_condition()
+            card = random.choice(self._kingdom_action_cards)
+            if inner is None:
+                # A degenerate ``and_(card_in_play(X))`` collapses to just the
+                # card_in_play check; emit it directly so the _source string
+                # stays clean.
+                return PriorityRule.card_in_play(card)
+            return PriorityRule.and_(PriorityRule.card_in_play(card), inner)
+        return self._random_condition()
+
     @staticmethod
     def _random_condition() -> "Callable | None":
         """Return a random callable condition from a diverse vocabulary."""
@@ -165,7 +193,7 @@ class GeneticTrainer:
                 elif card in self.kingdom_cards:
                     condition = PriorityRule.turn_number("<=", random.randint(5, 15))
                 else:
-                    condition = self._random_condition()
+                    condition = self._random_condition_with_compound()
             strategy.gain_priority.append(PriorityRule(card, condition))
 
         # Generate action priorities (only actual action cards)
@@ -181,7 +209,7 @@ class GeneticTrainer:
                     elif card in ["Smithy", "Laboratory"]:
                         condition = PriorityRule.resources("actions", ">=", 1)
                     else:
-                        condition = self._random_condition()
+                        condition = self._random_condition_with_compound()
                 strategy.action_priority.append(PriorityRule(card, condition))
 
         # Generate treasure priorities — include kingdom treasures
@@ -292,13 +320,13 @@ class GeneticTrainer:
                         elif priority.card_name in self.kingdom_cards:
                             priority.condition = PriorityRule.turn_number("<=", random.randint(5, 15))
                         else:
-                            priority.condition = self._random_condition()
+                            priority.condition = self._random_condition_with_compound()
                     else:
                         # Existing condition — half the time drop it, half the time replace
                         if random.random() < 0.5:
                             priority.condition = None
                         else:
-                            priority.condition = self._random_condition()
+                            priority.condition = self._random_condition_with_compound()
 
         # Reorder: swap two adjacent gain rules
         if random.random() < self.mutation_rate and len(strategy.gain_priority) >= 2:
@@ -322,7 +350,7 @@ class GeneticTrainer:
             if missing:
                 card = random.choice(missing)
                 pos = random.randint(0, len(strategy.gain_priority))
-                strategy.gain_priority.insert(pos, PriorityRule(card, self._random_condition()))
+                strategy.gain_priority.insert(pos, PriorityRule(card, self._random_condition_with_compound()))
 
         # Remove a low-value gain entry (but keep at least 3 rules)
         if random.random() < self.mutation_rate * 0.2 and len(strategy.gain_priority) > 3:
@@ -349,7 +377,7 @@ class GeneticTrainer:
                             elif priority.card_name in ["Smithy", "Laboratory"]:
                                 priority.condition = PriorityRule.resources("actions", ">=", 1)
                             else:
-                                priority.condition = self._random_condition()
+                                priority.condition = self._random_condition_with_compound()
 
         # Add/remove action cards (only actual action cards)
         if random.random() < self.mutation_rate * 0.3:
@@ -358,7 +386,7 @@ class GeneticTrainer:
             if missing:
                 card = random.choice(missing)
                 pos = random.randint(0, len(strategy.action_priority))
-                strategy.action_priority.insert(pos, PriorityRule(card, self._random_condition()))
+                strategy.action_priority.insert(pos, PriorityRule(card, self._random_condition_with_compound()))
 
         if random.random() < self.mutation_rate * 0.2 and len(strategy.action_priority) > 1:
             i = random.randint(0, len(strategy.action_priority) - 1)

--- a/tests/test_compound_mutation.py
+++ b/tests/test_compound_mutation.py
@@ -1,0 +1,194 @@
+"""Tests for compound (and_) condition generation in the genetic mutator."""
+
+import importlib
+import random
+import sys
+import types
+
+from dominion.simulation.genetic_trainer import GeneticTrainer
+from dominion.strategy.enhanced_strategy import PriorityRule
+from dominion.strategy.strategies.base_strategy import BaseStrategy
+
+
+def _make_mock_state(turn_number=5, provinces_left=8, empty_piles=0, players=None):
+    state = types.SimpleNamespace()
+    state.turn_number = turn_number
+    state.supply = {"Province": provinces_left}
+    state.empty_piles = empty_piles
+    state.players = players if players is not None else []
+    return state
+
+
+def _make_mock_player(coins=3, actions=1, buys=1, vp=3, all_cards=None, in_play=None):
+    player = types.SimpleNamespace()
+    player.coins = coins
+    player.actions = actions
+    player.buys = buys
+    player.hand = []
+    player.in_play = in_play if in_play is not None else []
+    player.count_in_deck = lambda card_name: 0
+    cards = all_cards if all_cards is not None else []
+    player.all_cards = lambda _cards=cards: list(_cards)
+    player.get_victory_points = lambda _g=None, _vp=vp: _vp
+    return player
+
+
+class TestCompoundConditionGeneration:
+    def test_compound_generator_returns_callable(self):
+        trainer = GeneticTrainer(
+            ["Village", "Smithy", "Market", "Laboratory"],
+            population_size=1, generations=1,
+        )
+        random.seed(42)
+        for _ in range(50):
+            cond = trainer._random_condition_with_compound()
+            assert cond is None or callable(cond), f"Got {type(cond)}"
+
+    def test_compound_generator_eventually_produces_compound(self):
+        trainer = GeneticTrainer(
+            ["Village", "Smithy", "Market", "Laboratory", "Witch"],
+            population_size=1, generations=1,
+        )
+        random.seed(0)
+        compound_count = 0
+        for _ in range(400):
+            cond = trainer._random_condition_with_compound()
+            if cond is None:
+                continue
+            src = getattr(cond, "_source", "")
+            if "PriorityRule.and_(" in src and "PriorityRule.card_in_play(" in src:
+                compound_count += 1
+        assert compound_count > 0
+
+    def test_compound_generator_falls_back_when_no_actions(self):
+        trainer = GeneticTrainer(
+            ["Village"],
+            population_size=1, generations=1,
+        )
+        trainer._kingdom_action_cards = []
+        random.seed(1)
+        for _ in range(100):
+            cond = trainer._random_condition_with_compound()
+            if cond is None:
+                continue
+            src = getattr(cond, "_source", "")
+            assert "card_in_play" not in src, src
+
+    def test_compound_conditions_evaluate_safely(self):
+        trainer = GeneticTrainer(
+            ["Village", "Smithy", "Market", "Laboratory"],
+            population_size=1, generations=1,
+        )
+        random.seed(7)
+        action_card = types.SimpleNamespace(name="Village", is_action=True)
+        deck = [action_card, action_card, action_card]
+        state = _make_mock_state()
+        player = _make_mock_player(all_cards=deck, in_play=[action_card])
+        for _ in range(200):
+            cond = trainer._random_condition_with_compound()
+            if cond is None:
+                continue
+            result = cond(state, player)
+            assert isinstance(result, bool)
+
+    def test_card_in_play_uses_kingdom_actions(self):
+        kingdom = ["Village", "Smithy", "Market", "Laboratory"]
+        trainer = GeneticTrainer(kingdom, population_size=1, generations=1)
+        random.seed(123)
+        compounds_seen = 0
+        for _ in range(500):
+            cond = trainer._random_condition_with_compound()
+            if cond is None:
+                continue
+            src = getattr(cond, "_source", "")
+            if "PriorityRule.card_in_play(" not in src:
+                continue
+            compounds_seen += 1
+            start = src.index("PriorityRule.card_in_play(") + len("PriorityRule.card_in_play(")
+            end = src.index(")", start)
+            card_arg = src[start:end].strip().strip("'\"")
+            assert card_arg in trainer._kingdom_action_cards
+        assert compounds_seen > 0
+
+
+class TestCompoundSerializationRoundTrip:
+    def test_compound_round_trips(self, tmp_path):
+        from runner import save_strategy_as_python
+        strategy = BaseStrategy()
+        strategy.name = "CompoundRoundTrip"
+        compound_cond = PriorityRule.and_(
+            PriorityRule.card_in_play("Village"),
+            PriorityRule.resources("actions", "<", 2),
+        )
+        strategy.gain_priority = [
+            PriorityRule("Smithy", compound_cond),
+            PriorityRule("Province"),
+        ]
+        strategy.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+        strategy.trash_priority = []
+        out_file = tmp_path / "compound_strategy.py"
+        save_strategy_as_python(strategy, out_file, "CompoundStrategy")
+        source = out_file.read_text()
+        assert "<lambda" not in source, source
+        assert "<function" not in source, source
+        assert "PriorityRule.and_(" in source, source
+        assert "PriorityRule.card_in_play(" in source, source
+        sys.path.insert(0, str(tmp_path))
+        try:
+            mod = importlib.import_module("compound_strategy")
+            generated = mod.CompoundStrategy()
+            assert generated.name == "CompoundRoundTrip"
+            smithy_rule = generated.gain_priority[0]
+            assert smithy_rule.condition is not None
+            assert callable(smithy_rule.condition)
+            village = types.SimpleNamespace(name="Village", is_action=True)
+            state = _make_mock_state()
+            player = _make_mock_player(actions=1, in_play=[village])
+            assert smithy_rule.condition(state, player) is True
+            player_empty = _make_mock_player(actions=1, in_play=[])
+            assert smithy_rule.condition(state, player_empty) is False
+        finally:
+            sys.path.pop(0)
+            sys.modules.pop("compound_strategy", None)
+
+
+class TestMutateCanProduceCompound:
+    def test_mutation_eventually_produces_compound_condition(self):
+        from copy import deepcopy
+        trainer = GeneticTrainer(
+            ["Village", "Smithy", "Market", "Laboratory", "Witch"],
+            population_size=1, generations=1, mutation_rate=1.0,
+        )
+        seed = BaseStrategy()
+        seed.name = "seed"
+        seed.gain_priority = [
+            PriorityRule("Province"),
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+        ]
+        seed.action_priority = [PriorityRule("Village"), PriorityRule("Smithy")]
+        seed.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+        seed.trash_priority = []
+        random.seed(99)
+        saw_compound = False
+        for _ in range(200):
+            mutated = trainer._mutate(deepcopy(seed))
+            for lst in (mutated.gain_priority, mutated.action_priority):
+                for rule in lst:
+                    src = getattr(rule.condition, "_source", "") if rule.condition else ""
+                    if "PriorityRule.and_(" in src and "card_in_play" in src:
+                        saw_compound = True
+                        break
+                if saw_compound:
+                    break
+            if saw_compound:
+                break
+        assert saw_compound


### PR DESCRIPTION
## Summary
- `_mutate` / `create_random_strategy` in `GeneticTrainer` now route their condition generation through a new instance method `_random_condition_with_compound`, which with ~15% probability wraps a normally-sampled condition in `and_(card_in_play(X), inner)`. `X` is drawn from the kingdom's action cards (`self._kingdom_action_cards`); if the kingdom has no actions, the method falls back to the basic vocabulary.
- The static `_random_condition` is kept untouched so existing call-sites (e.g. `GeneticTrainer._random_condition()` in `tests/test_genetic_trainer.py`) keep working.
- The DSL already supports compound conditions via `PriorityRule.and_` and `_source` tagging, so `save_strategy_as_python` round-trips them with no changes — confirmed by a new round-trip test.

This is what lets the trainer evolve coordinated multi-predicate rules like "buy Lurker when Cauldron is in play AND we haven't reached our action quota".

## Test plan
- [x] `PYTHONPATH=. python -m pytest tests/test_compound_mutation.py` — 7 new tests pass
- [x] `PYTHONPATH=. python -m pytest tests/test_genetic_trainer.py` — 47 existing tests still pass
- [x] `PYTHONPATH=. python -m pytest` — full suite (233 tests) green

New tests cover:
- compound generator returns callable
- across many samples some conditions are `and_(card_in_play(...), inner)` compounds
- with no kingdom actions, the generator never produces `card_in_play` compounds
- generated compounds evaluate to a `bool` without raising
- `card_in_play` arg is always one of the kingdom's action cards
- mutating a strategy eventually produces a compound condition
- a strategy with a compound condition serializes via `save_strategy_as_python` and re-imports cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)