### PR TITLE
Implement Wandering Minstrel, Market Square, Feodum, Hunting Grounds, Samurai

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -361,6 +361,22 @@ class AI(ABC):
 
         return list(cards)
 
+    def should_react_with_market_square(
+        self, state: GameState, player: PlayerState, trashed_card: Card
+    ) -> bool:
+        """Decide whether to discard Market Square to gain a Gold."""
+
+        return True
+
+    def choose_hunting_grounds_reward(
+        self, state: GameState, player: PlayerState
+    ) -> str:
+        """Choose between gaining a Duchy or three Estates when Hunting Grounds is trashed."""
+
+        if state.supply.get("Duchy", 0) > 0:
+            return "duchy"
+        return "estates"
+
     def choose_way(self, state: GameState, card: Card, ways: list) -> Optional[object]:
         """Choose a Way to use when playing a card. Default is none."""
         return None

--- a/dominion/cards/allies/__init__.py
+++ b/dominion/cards/allies/__init__.py
@@ -1,6 +1,7 @@
 from .collection import Collection
 from .modify import Modify
+from .samurai import Samurai
 from .taskmaster import Taskmaster
 from .wealthy_village import WealthyVillage
 
-__all__ = ['Collection', 'Modify', 'Taskmaster', 'WealthyVillage']
+__all__ = ['Collection', 'Modify', 'Samurai', 'Taskmaster', 'WealthyVillage']

--- a/dominion/cards/allies/samurai.py
+++ b/dominion/cards/allies/samurai.py
@@ -1,0 +1,56 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Samurai(Card):
+    """Action - Attack that stays in play.
+
+    When you play this, each other player with 5 or more cards in hand
+    discards down to 3. While this is in play, +1 Coin at the start of
+    each of your turns.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Samurai",
+            cost=CardCost(coins=5),
+            stats=CardStats(),
+            types=[CardType.ACTION, CardType.ATTACK, CardType.DURATION],
+        )
+        self.duration_persistent = True
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        def attack_target(target):
+            if len(target.hand) <= 3:
+                return
+
+            discard_needed = len(target.hand) - 3
+            selected = target.ai.choose_cards_to_discard(
+                game_state, target, list(target.hand), discard_needed, reason="samurai"
+            )
+
+            for card in selected[:discard_needed]:
+                if card in target.hand:
+                    target.hand.remove(card)
+                    game_state.discard_card(target, card)
+
+            while len(target.hand) > 3:
+                card = target.hand[-1]
+                target.hand.remove(card)
+                game_state.discard_card(target, card)
+
+        for other in game_state.players:
+            if other is player:
+                continue
+            game_state.attack_player(other, attack_target)
+
+        # Stays in play to provide +1 Coin at the start of each future turn
+        player.duration.append(self)
+        self.duration_persistent = True
+
+    def on_duration(self, game_state):
+        player = game_state.current_player
+        player.coins += 1
+        # Samurai never leaves play on its own
+        self.duration_persistent = True

--- a/dominion/cards/allies/samurai.py
+++ b/dominion/cards/allies/samurai.py
@@ -22,7 +22,7 @@ class Samurai(Card):
         player = game_state.current_player
 
         def attack_target(target):
-            if len(target.hand) <= 3:
+            if len(target.hand) < 5:
                 return
 
             discard_needed = len(target.hand) - 3

--- a/dominion/cards/dark_ages/__init__.py
+++ b/dominion/cards/dark_ages/__init__.py
@@ -1,5 +1,8 @@
 from .beggar import Beggar
+from .feodum import Feodum
 from .forager import Forager
+from .hunting_grounds import HuntingGrounds
+from .market_square import MarketSquare
 from .rats import Rats
 from .rebuild import Rebuild
 from .shelters import Hovel, Necropolis, OvergrownEstate
@@ -16,7 +19,10 @@ from .sage import Sage
 
 __all__ = [
     'Beggar',
+    'Feodum',
     'Forager',
+    'HuntingGrounds',
+    'MarketSquare',
     'Rats',
     'Rebuild',
     'Hovel',

--- a/dominion/cards/dark_ages/feodum.py
+++ b/dominion/cards/dark_ages/feodum.py
@@ -1,0 +1,32 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Feodum(Card):
+    """Victory card worth 1 VP per 3 Silvers you have (rounded down).
+
+    When trashed, gain 3 Silvers.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Feodum",
+            cost=CardCost(coins=4),
+            stats=CardStats(),
+            types=[CardType.VICTORY],
+        )
+
+    def starting_supply(self, game_state) -> int:
+        return 8 if len(game_state.players) <= 2 else 12
+
+    def get_victory_points(self, player) -> int:
+        silvers = sum(1 for card in player.all_cards() if card.name == "Silver")
+        return silvers // 3
+
+    def on_trash(self, game_state, player):
+        from ..registry import get_card
+
+        for _ in range(3):
+            if game_state.supply.get("Silver", 0) <= 0:
+                break
+            game_state.supply["Silver"] -= 1
+            game_state.gain_card(player, get_card("Silver"))

--- a/dominion/cards/dark_ages/hunting_grounds.py
+++ b/dominion/cards/dark_ages/hunting_grounds.py
@@ -1,0 +1,38 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class HuntingGrounds(Card):
+    """+4 Cards. When trashed, gain a Duchy or 3 Estates."""
+
+    def __init__(self):
+        super().__init__(
+            name="Hunting Grounds",
+            cost=CardCost(coins=6),
+            stats=CardStats(cards=4),
+            types=[CardType.ACTION],
+        )
+
+    def on_trash(self, game_state, player):
+        from ..registry import get_card
+
+        choice = player.ai.choose_hunting_grounds_reward(game_state, player)
+
+        duchy_available = game_state.supply.get("Duchy", 0) > 0
+        estates_available = game_state.supply.get("Estate", 0) > 0
+
+        if choice == "duchy" and not duchy_available and estates_available:
+            choice = "estates"
+        if choice == "estates" and not estates_available and duchy_available:
+            choice = "duchy"
+
+        if choice == "duchy":
+            if duchy_available:
+                game_state.supply["Duchy"] -= 1
+                game_state.gain_card(player, get_card("Duchy"))
+            return
+
+        for _ in range(3):
+            if game_state.supply.get("Estate", 0) <= 0:
+                break
+            game_state.supply["Estate"] -= 1
+            game_state.gain_card(player, get_card("Estate"))

--- a/dominion/cards/dark_ages/market_square.py
+++ b/dominion/cards/dark_ages/market_square.py
@@ -1,0 +1,17 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class MarketSquare(Card):
+    """+1 Card, +1 Action, +1 Buy.
+
+    When you trash a card, you may discard this from your hand. If you do,
+    gain a Gold.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Market Square",
+            cost=CardCost(coins=3),
+            stats=CardStats(cards=1, actions=1, buys=1),
+            types=[CardType.ACTION, CardType.REACTION],
+        )

--- a/dominion/cards/expansions/__init__.py
+++ b/dominion/cards/expansions/__init__.py
@@ -53,12 +53,16 @@ from ..empires import (
 from ..nocturne.crypt import Crypt
 from ..nocturne.skulk import Skulk
 from ..dark_ages.beggar import Beggar
+from ..dark_ages.feodum import Feodum
 from ..dark_ages.forager import Forager
+from ..dark_ages.hunting_grounds import HuntingGrounds
+from ..dark_ages.market_square import MarketSquare
 from ..dark_ages.rats import Rats
 from ..dark_ages.rebuild import Rebuild
 from ..dark_ages.shelters import Hovel, Necropolis, OvergrownEstate
 from ..allies.collection import Collection
 from ..allies.modify import Modify
+from ..allies.samurai import Samurai
 from ..promo import (
     Avanto,
     BlackMarket,
@@ -153,6 +157,7 @@ from ..hinterlands import (
     Trader,
     Trail,
     Tunnel,
+    WanderingMinstrel,
     Weaver,
     Wheelwright,
     WitchsHut,
@@ -312,9 +317,14 @@ __all__ = [
     'Trader',
     'Trail',
     'Tunnel',
+    'WanderingMinstrel',
     'Weaver',
     'Wheelwright',
     'WitchsHut',
+    'Feodum',
+    'HuntingGrounds',
+    'MarketSquare',
+    'Samurai',
     'ActingTroupe',
     'Taskmaster',
     'Torturer',

--- a/dominion/cards/hinterlands/__init__.py
+++ b/dominion/cards/hinterlands/__init__.py
@@ -31,6 +31,7 @@ from .stables import Stables
 from .trader import Trader
 from .trail import Trail
 from .tunnel import Tunnel
+from .wandering_minstrel import WanderingMinstrel
 from .weaver import Weaver
 from .wheelwright import Wheelwright
 from .witchs_hut import WitchsHut
@@ -69,6 +70,7 @@ __all__ = [
     'Trader',
     'Trail',
     'Tunnel',
+    'WanderingMinstrel',
     'Weaver',
     'Wheelwright',
     'WitchsHut',

--- a/dominion/cards/hinterlands/wandering_minstrel.py
+++ b/dominion/cards/hinterlands/wandering_minstrel.py
@@ -1,0 +1,39 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class WanderingMinstrel(Card):
+    """+1 Card, +2 Actions. Reveal the top 3 cards of your deck.
+
+    Put the revealed Actions back on top in any order; discard the rest.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Wandering Minstrel",
+            cost=CardCost(coins=4),
+            stats=CardStats(cards=1, actions=2),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        revealed: list[Card] = []
+        for _ in range(3):
+            if not player.deck and player.discard:
+                player.shuffle_discard_into_deck()
+            if not player.deck:
+                break
+            revealed.append(player.deck.pop())
+
+        actions = [c for c in revealed if c.is_action]
+        non_actions = [c for c in revealed if not c.is_action]
+
+        ordered = player.ai.order_cards_for_topdeck(game_state, player, actions)
+        # `order_cards_for_topdeck` returns the topdeck order from top to bottom;
+        # push them onto the deck in reverse so the first item ends up on top.
+        for card in reversed(ordered):
+            player.deck.append(card)
+
+        for card in non_actions:
+            game_state.discard_card(player, card)

--- a/dominion/cards/hinterlands/wandering_minstrel.py
+++ b/dominion/cards/hinterlands/wandering_minstrel.py
@@ -29,7 +29,14 @@ class WanderingMinstrel(Card):
         actions = [c for c in revealed if c.is_action]
         non_actions = [c for c in revealed if not c.is_action]
 
-        ordered = player.ai.order_cards_for_topdeck(game_state, player, actions)
+        ordered = player.ai.order_cards_for_topdeck(game_state, player, list(actions))
+        # Defensive: a malformed AI response (duplicates, omissions, or
+        # unrelated cards) must not be allowed to duplicate or destroy cards.
+        # Mirror the guard used by Sentry/Rabble: fall back to the revealed
+        # order if the returned multiset doesn't match.
+        if set(ordered) != set(actions) or len(ordered) != len(actions):
+            ordered = actions
+
         # `order_cards_for_topdeck` returns the topdeck order from top to bottom;
         # push them onto the deck in reverse so the first item ends up on top.
         for card in reversed(ordered):

--- a/dominion/cards/registry.py
+++ b/dominion/cards/registry.py
@@ -210,7 +210,23 @@ from dominion.cards.intrigue import (
     Swindler,
 )
 from dominion.cards.plunder import Barbarian, FirstMate, Flagship, Highwayman, Trickster, Astrolabe, Pickaxe, HarborVillage
-from dominion.cards.dark_ages import Armory, Count, Ironmonger, Marauder, PoorHouse, Spoils, Ruins, Graverobber, Procession, Sage
+from dominion.cards.dark_ages import (
+    Armory,
+    Count,
+    Feodum,
+    HuntingGrounds,
+    Ironmonger,
+    Marauder,
+    MarketSquare,
+    PoorHouse,
+    Spoils,
+    Ruins,
+    Graverobber,
+    Procession,
+    Sage,
+)
+from dominion.cards.allies import Samurai
+from dominion.cards.hinterlands.wandering_minstrel import WanderingMinstrel
 from dominion.cards.seaside import Bazaar, Lookout, NativeVillage, TradingPost, Wharf, Treasury, Pirate
 from dominion.cards.adventures import Artificer, Giant, Messenger
 from dominion.cards.nocturne import TragicHero
@@ -467,6 +483,11 @@ CARD_TYPES: dict[str, Type[Card]] = {
     "Gatekeeper": Gatekeeper,
     "Aristocrat": Aristocrat,
     "Harbor Village": HarborVillage,
+    "Wandering Minstrel": WanderingMinstrel,
+    "Feodum": Feodum,
+    "Hunting Grounds": HuntingGrounds,
+    "Market Square": MarketSquare,
+    "Samurai": Samurai,
 }
 
 CARD_ALIASES: dict[str, str] = {
@@ -480,6 +501,11 @@ CARD_ALIASES: dict[str, str] = {
     "Trading post": "Trading Post",
     "Native village": "Native Village",
     "Harbor village": "Harbor Village",
+    "Wandering minstrel": "Wandering Minstrel",
+    "Wandering Minstrels": "Wandering Minstrel",
+    "Wandering minstrels": "Wandering Minstrel",
+    "Hunting grounds": "Hunting Grounds",
+    "Market square": "Market Square",
 }
 
 

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1389,6 +1389,28 @@ class GameState:
             if hasattr(project, "on_trash"):
                 project.on_trash(self, player, card)
 
+        self._handle_market_square_reaction(player, card)
+
+    def _handle_market_square_reaction(self, player: PlayerState, trashed_card: Card) -> None:
+        """Offer Market Square reactions for any card the player just trashed."""
+
+        from ..cards.registry import get_card
+
+        while True:
+            squares = [card for card in player.hand if card.name == "Market Square"]
+            if not squares:
+                return
+            if self.supply.get("Gold", 0) <= 0:
+                return
+            if not player.ai.should_react_with_market_square(self, player, trashed_card):
+                return
+
+            square = squares[0]
+            player.hand.remove(square)
+            self.discard_card(player, square)
+            self.supply["Gold"] -= 1
+            self.gain_card(player, get_card("Gold"))
+
     def _handle_cargo_ship_gain(self, player: PlayerState, gained_card: Card) -> None:
         """Check if a Cargo Ship in play wants to set aside the gained card."""
         for card in list(player.in_play):

--- a/tests/test_dark_ages_extra_cards.py
+++ b/tests/test_dark_ages_extra_cards.py
@@ -313,6 +313,28 @@ def test_samurai_skips_attack_for_small_hand():
     assert len(victim.hand) == 3  # unchanged
 
 
+def test_samurai_does_not_attack_four_card_hand():
+    ai1 = GainFirstBuyAI()
+    ai2 = DummyAI()
+    state = GameState(players=[])
+    state.initialize_game([ai1, ai2], [get_card("Village")])
+    attacker, victim = state.players
+
+    samurai = get_card("Samurai")
+    attacker.hand = [samurai]
+    attacker.in_play = []
+    attacker.duration = []
+
+    victim.hand = [get_card("Copper") for _ in range(4)]
+
+    attacker.hand.remove(samurai)
+    attacker.in_play.append(samurai)
+    samurai.on_play(state)
+
+    # Samurai only attacks opponents with 5+ cards; a 4-card hand is immune.
+    assert len(victim.hand) == 4
+
+
 def test_samurai_on_duration_grants_one_coin_and_persists():
     state, player = _setup(GainFirstBuyAI())
     samurai = get_card("Samurai")

--- a/tests/test_dark_ages_extra_cards.py
+++ b/tests/test_dark_ages_extra_cards.py
@@ -70,6 +70,40 @@ def test_wandering_minstrel_cards_actions_and_topdeck():
     assert any(c.name == "Copper" for c in player.discard)
 
 
+class BadOrderAI(GainFirstBuyAI):
+    """AI that returns a malformed topdeck order (duplicates an entry)."""
+
+    def order_cards_for_topdeck(self, state, player, cards):
+        if cards:
+            return cards + [cards[0]]
+        return list(cards)
+
+
+def test_wandering_minstrel_rejects_malformed_topdeck_order():
+    state, player = _setup(BadOrderAI())
+    minstrel = get_card("Wandering Minstrel")
+    village_a = get_card("Village")
+    village_b = get_card("Village")
+    estate = get_card("Estate")
+    copper = get_card("Copper")
+    player.hand = [minstrel]
+    # Drawn first (top of deck), then 3 revealed (in pop order):
+    # village_b (action), village_a (action), estate (victory).
+    player.deck = [estate, village_a, village_b, copper]
+
+    player.hand.remove(minstrel)
+    player.in_play.append(minstrel)
+    minstrel.on_play(state)
+
+    # Two action cards were revealed; both should be on the deck exactly once
+    # despite the AI trying to inject a duplicate.
+    deck_villages = [c for c in player.deck if c.name == "Village"]
+    assert len(deck_villages) == 2
+    assert village_a in deck_villages and village_b in deck_villages
+    # Estate (non-action) was discarded.
+    assert estate in player.discard
+
+
 def test_wandering_minstrel_with_short_deck():
     state, player = _setup(GainFirstBuyAI())
     minstrel = get_card("Wandering Minstrel")

--- a/tests/test_dark_ages_extra_cards.py
+++ b/tests/test_dark_ages_extra_cards.py
@@ -1,0 +1,326 @@
+"""Tests for Wandering Minstrel, Market Square, Feodum, Hunting Grounds, Samurai."""
+
+from typing import Optional
+
+from dominion.cards.base_card import Card
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+from tests.utils import ChooseFirstActionAI, DummyAI
+
+
+class GainFirstBuyAI(ChooseFirstActionAI):
+    def choose_buy(self, state, choices):
+        for c in choices:
+            if c is not None:
+                return c
+        return None
+
+    def choose_card_to_trash(self, state, choices):
+        for c in choices:
+            if c is not None:
+                return c
+        return None
+
+    def choose_treasure(self, state, choices):
+        for c in choices:
+            if c is not None:
+                return c
+        return None
+
+
+def _setup(ai, kingdom_cards=None):
+    if kingdom_cards is None:
+        kingdom_cards = [get_card("Village")]
+    state = GameState(players=[])
+    state.initialize_game([ai], kingdom_cards)
+    player = state.players[0]
+    player.hand = []
+    player.deck = []
+    player.discard = []
+    player.in_play = []
+    player.duration = []
+    player.actions = 1
+    player.buys = 1
+    player.coins = 0
+    return state, player
+
+
+# --- Wandering Minstrel ---
+
+def test_wandering_minstrel_cards_actions_and_topdeck():
+    state, player = _setup(GainFirstBuyAI())
+    minstrel = get_card("Wandering Minstrel")
+    player.hand = [minstrel]
+    player.deck = [get_card("Copper"), get_card("Estate"), get_card("Village"), get_card("Silver")]
+
+    player.hand.remove(minstrel)
+    player.in_play.append(minstrel)
+    minstrel.on_play(state)
+
+    # +1 Card, +2 Actions
+    assert player.actions == 3
+    # Drew Silver (top of deck pre-reveal)
+    assert any(c.name == "Silver" for c in player.hand)
+    # Revealed three: Village (action), Estate (victory), Copper (treasure).
+    # Action goes back on top; the others are discarded.
+    assert player.deck[-1].name == "Village"
+    assert any(c.name == "Estate" for c in player.discard)
+    assert any(c.name == "Copper" for c in player.discard)
+
+
+def test_wandering_minstrel_with_short_deck():
+    state, player = _setup(GainFirstBuyAI())
+    minstrel = get_card("Wandering Minstrel")
+    player.hand = [minstrel]
+    # 1 card to draw, then nothing left to reveal
+    player.deck = [get_card("Copper")]
+    player.discard = []
+
+    player.hand.remove(minstrel)
+    player.in_play.append(minstrel)
+    minstrel.on_play(state)
+
+    # +1 Card brings Copper into hand. Deck/discard now empty for reveals.
+    assert any(c.name == "Copper" for c in player.hand)
+    assert player.actions == 3
+
+
+# --- Market Square ---
+
+def test_market_square_basic_play_stats():
+    state, player = _setup(GainFirstBuyAI())
+    square = get_card("Market Square")
+    player.hand = [square]
+    player.deck = [get_card("Copper")]
+
+    player.hand.remove(square)
+    player.in_play.append(square)
+    square.on_play(state)
+
+    # on_play applies card stats directly without deducting the action cost
+    assert player.actions == 2  # 1 + 1
+    assert player.buys == 2
+    assert len(player.hand) == 1
+
+
+def test_market_square_reaction_grants_gold_when_trashing():
+    state, player = _setup(GainFirstBuyAI())
+    square = get_card("Market Square")
+    estate = get_card("Estate")
+    player.hand = [square, estate]
+    state.supply["Gold"] = 10
+
+    # Player trashes Estate -> reaction triggers, discarding Market Square,
+    # gaining a Gold.
+    player.hand.remove(estate)
+    state.trash_card(player, estate)
+
+    assert estate in state.trash
+    assert square not in player.hand
+    assert square in player.discard
+    assert any(c.name == "Gold" for c in player.discard)
+    assert state.supply["Gold"] == 9
+
+
+def test_market_square_reaction_skips_when_not_in_hand():
+    state, player = _setup(GainFirstBuyAI())
+    square = get_card("Market Square")
+    estate = get_card("Estate")
+    player.in_play = [square]  # Market Square in play, not hand
+    player.hand = [estate]
+    state.supply["Gold"] = 10
+
+    player.hand.remove(estate)
+    state.trash_card(player, estate)
+
+    # No reaction since Market Square is not in hand.
+    assert square in player.in_play
+    assert state.supply["Gold"] == 10
+    assert all(c.name != "Gold" for c in player.discard)
+
+
+class DeclineSquareAI(GainFirstBuyAI):
+    def should_react_with_market_square(self, state, player, trashed_card):
+        return False
+
+
+def test_market_square_reaction_can_decline():
+    state, player = _setup(DeclineSquareAI())
+    square = get_card("Market Square")
+    estate = get_card("Estate")
+    player.hand = [square, estate]
+    state.supply["Gold"] = 10
+
+    player.hand.remove(estate)
+    state.trash_card(player, estate)
+
+    assert square in player.hand
+    assert state.supply["Gold"] == 10
+
+
+# --- Feodum ---
+
+def test_feodum_victory_points_scale_with_silvers():
+    state, player = _setup(GainFirstBuyAI())
+    feodum = get_card("Feodum")
+    player.discard = [feodum]
+    # 0 Silvers -> 0 VP
+    assert feodum.get_victory_points(player) == 0
+
+    player.discard.extend(get_card("Silver") for _ in range(2))
+    assert feodum.get_victory_points(player) == 0
+
+    player.discard.append(get_card("Silver"))  # 3 Silvers
+    assert feodum.get_victory_points(player) == 1
+
+    player.discard.extend(get_card("Silver") for _ in range(3))  # 6 Silvers
+    assert feodum.get_victory_points(player) == 2
+
+
+def test_feodum_on_trash_gains_three_silvers():
+    state, player = _setup(GainFirstBuyAI())
+    feodum = get_card("Feodum")
+    player.hand = [feodum]
+    state.supply["Silver"] = 10
+
+    player.hand.remove(feodum)
+    state.trash_card(player, feodum)
+
+    assert feodum in state.trash
+    silvers = sum(1 for c in player.discard if c.name == "Silver")
+    assert silvers == 3
+    assert state.supply["Silver"] == 7
+
+
+def test_feodum_on_trash_respects_empty_supply():
+    state, player = _setup(GainFirstBuyAI())
+    feodum = get_card("Feodum")
+    player.hand = [feodum]
+    state.supply["Silver"] = 1
+
+    player.hand.remove(feodum)
+    state.trash_card(player, feodum)
+
+    silvers = sum(1 for c in player.discard if c.name == "Silver")
+    assert silvers == 1
+    assert state.supply["Silver"] == 0
+
+
+# --- Hunting Grounds ---
+
+def test_hunting_grounds_draws_four():
+    state, player = _setup(GainFirstBuyAI())
+    grounds = get_card("Hunting Grounds")
+    player.hand = [grounds]
+    player.deck = [get_card("Copper") for _ in range(4)]
+
+    player.hand.remove(grounds)
+    player.in_play.append(grounds)
+    grounds.on_play(state)
+
+    assert len(player.hand) == 4
+
+
+def test_hunting_grounds_on_trash_gains_duchy_when_chosen():
+    state, player = _setup(GainFirstBuyAI())
+    grounds = get_card("Hunting Grounds")
+    state.supply["Duchy"] = 8
+    state.supply["Estate"] = 8
+
+    state.trash_card(player, grounds)
+
+    assert grounds in state.trash
+    assert any(c.name == "Duchy" for c in player.discard)
+    assert state.supply["Duchy"] == 7
+
+
+class EstatesGroundsAI(GainFirstBuyAI):
+    def choose_hunting_grounds_reward(self, state, player):
+        return "estates"
+
+
+def test_hunting_grounds_on_trash_gains_three_estates_when_chosen():
+    state, player = _setup(EstatesGroundsAI())
+    grounds = get_card("Hunting Grounds")
+    state.supply["Duchy"] = 8
+    state.supply["Estate"] = 8
+
+    state.trash_card(player, grounds)
+
+    estates = sum(1 for c in player.discard if c.name == "Estate")
+    assert estates == 3
+    assert state.supply["Estate"] == 5
+    assert state.supply["Duchy"] == 8
+
+
+def test_hunting_grounds_falls_back_when_duchy_pile_empty():
+    state, player = _setup(GainFirstBuyAI())
+    grounds = get_card("Hunting Grounds")
+    state.supply["Duchy"] = 0
+    state.supply["Estate"] = 8
+
+    state.trash_card(player, grounds)
+
+    estates = sum(1 for c in player.discard if c.name == "Estate")
+    assert estates == 3
+
+
+# --- Samurai ---
+
+def test_samurai_attacks_other_players_to_three_cards():
+    ai1 = GainFirstBuyAI()
+    ai2 = DummyAI()
+    state = GameState(players=[])
+    state.initialize_game([ai1, ai2], [get_card("Village")])
+    attacker, victim = state.players
+
+    samurai = get_card("Samurai")
+    attacker.hand = [samurai]
+    attacker.in_play = []
+    attacker.duration = []
+
+    victim.hand = [get_card("Copper") for _ in range(5)]
+
+    attacker.hand.remove(samurai)
+    attacker.in_play.append(samurai)
+    samurai.on_play(state)
+
+    assert len(victim.hand) == 3
+    assert samurai in attacker.duration
+    assert samurai.duration_persistent is True
+
+
+def test_samurai_skips_attack_for_small_hand():
+    ai1 = GainFirstBuyAI()
+    ai2 = DummyAI()
+    state = GameState(players=[])
+    state.initialize_game([ai1, ai2], [get_card("Village")])
+    attacker, victim = state.players
+
+    samurai = get_card("Samurai")
+    attacker.hand = [samurai]
+    attacker.in_play = []
+    attacker.duration = []
+
+    victim.hand = [get_card("Copper") for _ in range(3)]
+
+    attacker.hand.remove(samurai)
+    attacker.in_play.append(samurai)
+    samurai.on_play(state)
+
+    assert len(victim.hand) == 3  # unchanged
+
+
+def test_samurai_on_duration_grants_one_coin_and_persists():
+    state, player = _setup(GainFirstBuyAI())
+    samurai = get_card("Samurai")
+    player.duration = [samurai]
+    samurai.duration_persistent = True
+    player.coins = 0
+
+    samurai.on_duration(state)
+
+    assert player.coins == 1
+    assert samurai.duration_persistent is True


### PR DESCRIPTION
Adds the five cards needed to play the Poor House / Beggar / Wandering
Minstrel / Baker / Samurai / Soothsayer / Market Square / Feodum / Sage /
Hunting Grounds kingdom. Wires Market Square's on-trash reaction into
GameState.trash_card and adds AI hooks for the new player choices
(Market Square reveal, Hunting Grounds reward).