### PR TITLE
Add hand-aware predicates and smarter unexpected-action fallback

### DIFF
--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -131,12 +131,15 @@ class GeneticTrainer:
             "empty_piles", "deck_size", "action_density", "score_diff",
             "actions_in_play", "max_in_deck",
             "actions_gained_this_turn", "cards_gained_this_turn",
+            "actions_in_hand", "terminals_in_hand", "treasures_in_hand",
+            "excess_actions",
             "none",
         ]
-        # card_in_play only makes sense if we have at least one kingdom
-        # action card to reference.
+        # card_in_play / card_in_hand only make sense if we have at least
+        # one kingdom action card name to reference.
         if self._kingdom_action_cards:
             choices.append("card_in_play")
+            choices.append("card_in_hand")
         kind = random.choice(choices)
         if kind == "provinces_left":
             op = random.choice(["<=", ">", ">=", "<"])
@@ -193,6 +196,25 @@ class GeneticTrainer:
         if kind == "card_in_play":
             card = random.choice(self._kingdom_action_cards)
             return PriorityRule.card_in_play(card)
+        if kind == "card_in_hand":
+            card = random.choice(self._kingdom_action_cards)
+            return PriorityRule.card_in_hand(card)
+        if kind == "actions_in_hand":
+            op = random.choice([">=", "<=", ">", "<"])
+            amount = random.randint(1, 4)
+            return PriorityRule.actions_in_hand(op, amount)
+        if kind == "terminals_in_hand":
+            op = random.choice([">=", "<=", ">", "<"])
+            amount = random.randint(1, 3)
+            return PriorityRule.terminals_in_hand(op, amount)
+        if kind == "treasures_in_hand":
+            op = random.choice([">=", "<=", ">", "<"])
+            amount = random.randint(1, 4)
+            return PriorityRule.treasures_in_hand(op, amount)
+        if kind == "excess_actions":
+            op = random.choice([">=", "<=", ">", "<"])
+            amount = random.choice([-1, 0, 1])
+            return PriorityRule.excess_actions(op, amount)
         return None
 
     def create_random_strategy(self) -> BaseStrategy:

--- a/dominion/strategy/enhanced_strategy.py
+++ b/dominion/strategy/enhanced_strategy.py
@@ -124,6 +124,60 @@ class PriorityRule:
         return PriorityRule._tag_source(fn, f"PriorityRule.card_in_play({card_name!r})")
 
     @staticmethod
+    def card_in_hand(card_name: str) -> Callable[["GameState", "PlayerState"], bool]:
+        """True when the named card is currently in hand.
+
+        Useful for synergy rules such as "play Village only if a terminal is in
+        hand", e.g. ``and_(card_in_hand("Smithy"), resources("actions", "<", 2))``.
+        """
+        fn = lambda _s, me, _card=card_name: any(c.name == _card for c in me.hand)
+        return PriorityRule._tag_source(fn, f"PriorityRule.card_in_hand({card_name!r})")
+
+    @staticmethod
+    def actions_in_hand(op: str, amount: int) -> Callable[["GameState", "PlayerState"], bool]:
+        """True when the number of action cards currently in hand satisfies the comparison."""
+        cmp = PriorityRule._OP_MAP[op]
+        fn = lambda _s, me, _amount=amount, _cmp=cmp: _cmp(
+            sum(1 for c in me.hand if c.is_action), _amount
+        )
+        return PriorityRule._tag_source(fn, f"PriorityRule.actions_in_hand({op!r}, {amount!r})")
+
+    @staticmethod
+    def terminals_in_hand(op: str, amount: int) -> Callable[["GameState", "PlayerState"], bool]:
+        """True when the number of terminal action cards in hand satisfies the comparison.
+
+        A terminal is an action that grants no ``+Action`` (``stats.actions == 0``)."""
+        cmp = PriorityRule._OP_MAP[op]
+        fn = lambda _s, me, _amount=amount, _cmp=cmp: _cmp(
+            sum(1 for c in me.hand if c.is_action and c.stats.actions == 0), _amount
+        )
+        return PriorityRule._tag_source(fn, f"PriorityRule.terminals_in_hand({op!r}, {amount!r})")
+
+    @staticmethod
+    def treasures_in_hand(op: str, amount: int) -> Callable[["GameState", "PlayerState"], bool]:
+        """True when the number of treasure cards currently in hand satisfies the comparison."""
+        cmp = PriorityRule._OP_MAP[op]
+        fn = lambda _s, me, _amount=amount, _cmp=cmp: _cmp(
+            sum(1 for c in me.hand if c.is_treasure), _amount
+        )
+        return PriorityRule._tag_source(fn, f"PriorityRule.treasures_in_hand({op!r}, {amount!r})")
+
+    @staticmethod
+    def excess_actions(op: str, amount: int) -> Callable[["GameState", "PlayerState"], bool]:
+        """True when remaining actions minus terminals waiting in hand satisfies the comparison.
+
+        ``excess_actions(">=", 1)`` answers "do I have headroom to play another terminal?"
+        ``excess_actions("<", 1)`` answers "would playing another terminal strand me?"
+        """
+        cmp = PriorityRule._OP_MAP[op]
+
+        def _eval(_s, me, _amount=amount, _cmp=cmp):
+            terminals = sum(1 for c in me.hand if c.is_action and c.stats.actions == 0)
+            return _cmp(me.actions - terminals, _amount)
+
+        return PriorityRule._tag_source(_eval, f"PriorityRule.excess_actions({op!r}, {amount!r})")
+
+    @staticmethod
     def deck_count_diff(card_a: str, card_b: str, op: str, amount: int) -> Callable[["GameState", "PlayerState"], bool]:
         """True when (count of card_a in deck) minus (count of card_b in deck) satisfies the comparison."""
         cmp = PriorityRule._OP_MAP[op]
@@ -279,9 +333,27 @@ class EnhancedStrategy:
         unexpected = [c for c in choices if c is not None and c.name not in priority_names]
         if not unexpected:
             return None
-        # Prefer non-terminal actions (+actions) to avoid wasting remaining actions
-        non_terminal = [c for c in unexpected if c.stats.actions >= 1]
-        return non_terminal[0] if non_terminal else unexpected[0]
+        return self._score_unexpected_action(unexpected, player)
+
+    @staticmethod
+    def _score_unexpected_action(unexpected: list[Card], player: PlayerState) -> Optional[Card]:
+        """Pick the safest unexpected action to play.
+
+        Prefers cantrips (+Action and +Card), then non-terminals, then terminals
+        scored by net resources delivered (cards, coins, buys). A cantrip
+        replaces itself in hand, so it's strictly safer than a terminal.
+        """
+        non_terminals = [c for c in unexpected if c.stats.actions >= 1]
+        if non_terminals:
+            def _nt_score(c: Card) -> tuple:
+                cantrip = 1 if c.stats.cards >= 1 else 0
+                return (cantrip, c.stats.actions, c.stats.cards, c.stats.coins, c.stats.buys)
+            return max(non_terminals, key=_nt_score)
+
+        # Only terminals remain. Score by net resources delivered.
+        def _t_score(c: Card) -> tuple:
+            return (c.stats.cards, c.stats.coins, c.stats.buys)
+        return max(unexpected, key=_t_score)
 
     def choose_treasure(self, state, player, choices):
         result = self._choose_from_priority(self.treasure_priority, choices, state, player)

--- a/tests/test_play_algorithm_improvements.py
+++ b/tests/test_play_algorithm_improvements.py
@@ -1,0 +1,177 @@
+"""Tests for play-algorithm improvements: hand-aware predicates and the smarter
+unexpected-action fallback in :class:`EnhancedStrategy`.
+
+The new predicates let strategies express synergy and over-commit checks that
+the existing condition vocabulary couldn't capture (e.g. "play Village only if
+a terminal is queued in hand", "don't play another Smithy if it would strand
+my actions"). The fallback improvements pick the safest available unexpected
+action — preferring cantrips over terminals — instead of the previous
+"first non-terminal wins" rule.
+"""
+
+import types
+
+from dominion.cards.registry import get_card
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+def _make_state():
+    state = types.SimpleNamespace()
+    state.turn_number = 1
+    state.supply = {}
+    state.empty_piles = 0
+    state.players = []
+    state.ways = []
+    return state
+
+
+def _make_player(hand=None, actions=1):
+    player = types.SimpleNamespace()
+    player.hand = list(hand or [])
+    player.in_play = []
+    player.actions = actions
+    player.actions_gained_this_turn = 0
+    player.cards_gained_this_turn = 0
+    return player
+
+
+# ----------------------------------------------------------------------
+# Hand-aware predicates
+# ----------------------------------------------------------------------
+
+class TestCardInHand:
+    def test_true_when_card_in_hand(self):
+        cond = PriorityRule.card_in_hand("Smithy")
+        player = _make_player(hand=[get_card("Smithy")])
+        assert cond(_make_state(), player) is True
+
+    def test_false_when_card_absent(self):
+        cond = PriorityRule.card_in_hand("Smithy")
+        player = _make_player(hand=[get_card("Village")])
+        assert cond(_make_state(), player) is False
+
+    def test_source_tagged(self):
+        cond = PriorityRule.card_in_hand("Smithy")
+        assert cond._source == "PriorityRule.card_in_hand('Smithy')"
+
+
+class TestActionsInHand:
+    def test_counts_action_cards(self):
+        cond = PriorityRule.actions_in_hand(">=", 2)
+        player = _make_player(hand=[get_card("Village"), get_card("Smithy"), get_card("Copper")])
+        assert cond(_make_state(), player) is True
+
+    def test_excludes_treasures_and_victories(self):
+        cond = PriorityRule.actions_in_hand(">=", 1)
+        player = _make_player(hand=[get_card("Copper"), get_card("Estate"), get_card("Silver")])
+        assert cond(_make_state(), player) is False
+
+
+class TestTerminalsInHand:
+    def test_counts_terminal_actions_only(self):
+        # Smithy is a terminal (+3 cards, 0 actions). Village is non-terminal.
+        cond = PriorityRule.terminals_in_hand(">=", 1)
+        player = _make_player(hand=[get_card("Smithy"), get_card("Village")])
+        assert cond(_make_state(), player) is True
+
+    def test_zero_when_only_non_terminals(self):
+        cond = PriorityRule.terminals_in_hand(">=", 1)
+        player = _make_player(hand=[get_card("Village"), get_card("Village")])
+        assert cond(_make_state(), player) is False
+
+    def test_threshold_arithmetic(self):
+        cond_eq2 = PriorityRule.terminals_in_hand("==", 2)
+        player = _make_player(hand=[get_card("Smithy"), get_card("Witch")])
+        assert cond_eq2(_make_state(), player) is True
+
+
+class TestTreasuresInHand:
+    def test_counts_treasures(self):
+        cond = PriorityRule.treasures_in_hand(">=", 2)
+        player = _make_player(hand=[get_card("Copper"), get_card("Silver"), get_card("Estate")])
+        assert cond(_make_state(), player) is True
+
+    def test_excludes_actions(self):
+        cond = PriorityRule.treasures_in_hand(">=", 1)
+        player = _make_player(hand=[get_card("Smithy"), get_card("Village")])
+        assert cond(_make_state(), player) is False
+
+
+class TestExcessActions:
+    def test_positive_when_actions_exceed_terminals(self):
+        # 2 actions remaining, 1 terminal in hand → 1 action of headroom.
+        cond = PriorityRule.excess_actions(">=", 1)
+        player = _make_player(hand=[get_card("Smithy")], actions=2)
+        assert cond(_make_state(), player) is True
+
+    def test_zero_when_actions_equal_terminals(self):
+        cond = PriorityRule.excess_actions(">=", 1)
+        player = _make_player(hand=[get_card("Smithy")], actions=1)
+        assert cond(_make_state(), player) is False
+
+    def test_negative_when_terminals_exceed_actions(self):
+        # 1 action, 2 terminals → -1 excess (over-committed).
+        cond = PriorityRule.excess_actions("<", 0)
+        player = _make_player(hand=[get_card("Smithy"), get_card("Witch")], actions=1)
+        assert cond(_make_state(), player) is True
+
+    def test_non_terminals_dont_count(self):
+        # Village is non-terminal — playing it gives back the action. Excess should still match.
+        cond = PriorityRule.excess_actions(">=", 1)
+        player = _make_player(hand=[get_card("Village")], actions=1)
+        assert cond(_make_state(), player) is True
+
+    def test_source_tagged(self):
+        cond = PriorityRule.excess_actions("<", 0)
+        assert cond._source == "PriorityRule.excess_actions('<', 0)"
+
+
+# ----------------------------------------------------------------------
+# Smarter unexpected-action fallback
+# ----------------------------------------------------------------------
+
+class TestUnexpectedActionFallback:
+    """`EnhancedStrategy.choose_action` falls back to a scored selection when the
+    priority list returns no match. Cantrips beat plain non-terminals, and
+    non-terminals beat terminals."""
+
+    def test_prefers_cantrip_over_plain_non_terminal(self):
+        # Laboratory (+2 cards +1 action) vs Necropolis-style? Use Lab vs Village.
+        # Lab is a cantrip-and-then-some; Village is +1 card +2 actions. Both are
+        # non-terminals. The fallback should still pick something reasonable —
+        # specifically, a card that draws is preferred for tie-breaking.
+        strategy = EnhancedStrategy()  # empty action_priority — everything is unexpected
+        lab = get_card("Laboratory")
+        village = get_card("Village")
+        choice = strategy.choose_action(_make_state(), _make_player(), [lab, village])
+        # Both are cantrips; tie-break by (cantrip, +actions, +cards). Village
+        # wins on +actions (2 vs 1).
+        assert choice is village
+
+    def test_prefers_non_terminal_over_terminal(self):
+        strategy = EnhancedStrategy()
+        smithy = get_card("Smithy")          # terminal +3 cards
+        village = get_card("Village")         # non-terminal +1 card +2 actions
+        choice = strategy.choose_action(_make_state(), _make_player(), [smithy, village])
+        assert choice is village
+
+    def test_falls_back_to_best_terminal(self):
+        # Only terminals — pick the one with most net cards.
+        strategy = EnhancedStrategy()
+        smithy = get_card("Smithy")           # +3 cards
+        moat = get_card("Moat")               # +2 cards
+        choice = strategy.choose_action(_make_state(), _make_player(), [moat, smithy])
+        assert choice is smithy
+
+    def test_returns_none_for_empty_choices(self):
+        strategy = EnhancedStrategy()
+        assert strategy.choose_action(_make_state(), _make_player(), []) is None
+
+    def test_priority_list_still_takes_precedence(self):
+        # When a priority rule matches, the fallback is not consulted.
+        strategy = EnhancedStrategy()
+        strategy.action_priority = [PriorityRule("Smithy")]
+        smithy = get_card("Smithy")
+        village = get_card("Village")
+        choice = strategy.choose_action(_make_state(), _make_player(), [smithy, village])
+        assert choice is smithy


### PR DESCRIPTION
The play-decision algorithm in EnhancedStrategy.choose_action could only
inspect supply, deck composition, and turn state — it couldn't reason about
hand contents, so strategies couldn't express "play Village only if a
terminal is queued" or "don't play another Smithy if it would strand my
actions." The unexpected-action fallback also picked the first non-terminal
in choices order, which can play opponents' Swindled-in junk over a strict
cantrip already in hand.

This adds five hand-aware condition predicates (card_in_hand,
actions_in_hand, terminals_in_hand, treasures_in_hand, excess_actions),
wires them into the genetic trainer's mutation vocabulary so evolution can
discover them, and replaces the fallback's first-match logic with a scored
selection that prefers cantrips over plain non-terminals over terminals.