### PR TITLE
Implement full Rising Sun expansion

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -605,3 +605,120 @@ class AI(ABC):
     def should_topdeck_treasury(self, state: GameState, player: PlayerState) -> bool:
         """Decide whether to topdeck Treasury at end of buy phase."""
         return True
+
+    # ------------------------------------------------------------------
+    # Rising Sun decision hooks
+    # ------------------------------------------------------------------
+
+    def should_take_gold_mine_gold(
+        self, state: GameState, player: PlayerState
+    ) -> bool:
+        """Decide whether Gold Mine should gain a Gold (taking 4 Debt).
+
+        Default: take the Gold whenever the player can pay off the Debt
+        within a turn or two — i.e. the deck regularly produces $4+ — but
+        skip when already burdened by Debt.
+        """
+        if state.supply.get("Gold", 0) <= 0:
+            return False
+        if player.debt > 0:
+            return False
+        return True
+
+    def choose_kitsune_options(
+        self,
+        state: GameState,
+        player: PlayerState,
+        options: list[str],
+    ) -> list[str]:
+        """Pick two of Kitsune's four options.
+
+        Default heuristic: prefer cursing opponents, then +$2, then +1
+        Action, falling back to gaining a Silver.
+        """
+        priority = ["curse", "coins", "action", "silver"]
+        ordered = [opt for opt in priority if opt in options]
+        return ordered[:2]
+
+    def should_rustic_village_discard(
+        self, state: GameState, player: PlayerState
+    ) -> bool:
+        """Decide whether Rustic Village should discard 2 for +1 Card.
+
+        Default: discard when there are at least two clearly low-value cards
+        in hand (Curse, Copper, cheap Victory).
+        """
+        low_value = 0
+        for card in player.hand:
+            if card.name in {"Curse", "Copper", "Estate", "Hovel", "Overgrown Estate"}:
+                low_value += 1
+            elif card.is_victory and not card.is_action and card.cost.coins <= 2:
+                low_value += 1
+        return low_value >= 2
+
+    def should_reveal_snake_witch(
+        self, state: GameState, player: PlayerState
+    ) -> bool:
+        """Decide whether to reveal Snake Witch's hand to curse opponents.
+
+        Default: reveal whenever doing so would actually curse someone (the
+        Curse pile isn't empty) — handing back Snake Witch to its pile is a
+        small loss in exchange for distributing Curses.
+        """
+        if state.supply.get("Curse", 0) <= 0:
+            return False
+        return any(other is not player for other in state.players)
+
+    def choose_asceticism_overpay(
+        self, state: GameState, player: PlayerState, available: int
+    ) -> int:
+        """Choose how much extra coin to pay on top of Asceticism's $2.
+
+        Default: trash low-value cards (Curse, Copper, cheap Victory) only,
+        capped by available coins and hand size.
+        """
+        cheap = [
+            card
+            for card in player.hand
+            if card.name in {"Curse", "Copper", "Estate", "Hovel", "Overgrown Estate"}
+            or (card.is_victory and not card.is_action and card.cost.coins <= 2)
+        ]
+        return min(len(cheap), available)
+
+    def choose_sickness_mode(
+        self, state: GameState, player: PlayerState
+    ) -> str:
+        """Pick Sickness's mode at end of turn: 'curse' or 'discard'.
+
+        Default: discard 3 if the hand contains 3+ junk cards (Curses,
+        Coppers, cheap Victory cards), otherwise take the Curse onto your
+        deck.
+        """
+        junk = sum(
+            1
+            for card in player.hand
+            if card.name in {"Curse", "Copper", "Estate"}
+            or (card.is_victory and not card.is_action and card.cost.coins <= 2)
+        )
+        if junk >= 3:
+            return "discard"
+        return "curse"
+
+    def choose_riverboat_set_aside(
+        self, state: GameState, player: PlayerState, candidates: list[Card]
+    ) -> "Card | None":
+        """Pick which $5 non-Duration Action card Riverboat sets aside.
+
+        Default: prefer cards that produce extra cards/actions and survive
+        being played repeatedly across turns. Falls back to the first
+        candidate.
+        """
+        if not candidates:
+            return None
+        return max(
+            candidates,
+            key=lambda c: (
+                c.stats.cards * 2 + c.stats.actions + c.stats.coins,
+                c.name,
+            ),
+        )

--- a/dominion/cards/allies/__init__.py
+++ b/dominion/cards/allies/__init__.py
@@ -1,7 +1,6 @@
 from .collection import Collection
 from .modify import Modify
 from .pilgrim import Pilgrim
-from .samurai import Samurai
 from .taskmaster import Taskmaster
 from .wealthy_village import WealthyVillage
 from .wizards import Conjurer, Lich, Sorcerer, Student
@@ -10,7 +9,6 @@ __all__ = [
     'Collection',
     'Modify',
     'Pilgrim',
-    'Samurai',
     'Taskmaster',
     'WealthyVillage',
     'Student',

--- a/dominion/cards/base_card.py
+++ b/dominion/cards/base_card.py
@@ -32,6 +32,8 @@ class CardType(Enum):
     REACTION = "reaction"
     DURATION = "duration"
     COMMAND = "command"
+    SHADOW = "shadow"
+    OMEN = "omen"
 
 
 class Card:
@@ -77,6 +79,14 @@ class Card:
     def is_command(self) -> bool:
         return CardType.COMMAND in self.types
 
+    @property
+    def is_shadow(self) -> bool:
+        return CardType.SHADOW in self.types
+
+    @property
+    def is_omen(self) -> bool:
+        return CardType.OMEN in self.types
+
     def get_victory_points(self, player) -> int:
         """Get victory points this card provides for the given player."""
         return self.stats.vp
@@ -92,6 +102,14 @@ class Card:
     def on_play(self, game_state):
         """Execute this card's effects when played."""
         player = game_state.current_player
+
+        # Rising Sun: "+1 Sun" always appears first on Omens, before any
+        # other text. Removing the last Sun token activates the Prophecy in
+        # the middle of resolving the Omen (e.g. so Kitsune sees the new
+        # rule before its own choices apply).
+        if self.is_omen:
+            game_state.remove_sun_token(1)
+
         if player.ignore_action_bonuses:
             added_actions = 0
         else:

--- a/dominion/cards/expansions/__init__.py
+++ b/dominion/cards/expansions/__init__.py
@@ -62,7 +62,7 @@ from ..dark_ages.rebuild import Rebuild
 from ..dark_ages.shelters import Hovel, Necropolis, OvergrownEstate
 from ..allies.collection import Collection
 from ..allies.modify import Modify
-from ..allies.samurai import Samurai
+from ..rising_sun.samurai import Samurai
 from ..promo import (
     Avanto,
     BlackMarket,

--- a/dominion/cards/registry.py
+++ b/dominion/cards/registry.py
@@ -234,13 +234,38 @@ from dominion.cards.dark_ages import (
     Procession,
     Sage,
 )
-from dominion.cards.allies import Samurai
 from dominion.cards.hinterlands.wandering_minstrel import WanderingMinstrel
 from dominion.cards.seaside import Bazaar, Lookout, NativeVillage, TradingPost, Wharf, Treasury, Pirate
 from dominion.cards.adventures import Artificer, Giant, Messenger
 from dominion.cards.nocturne import TragicHero
 from dominion.cards.menagerie import Destrier, Horse, HuntingLodge, Mastermind, Paddock, Gatekeeper
-from dominion.cards.rising_sun import ImperialEnvoy, Aristocrat
+from dominion.cards.rising_sun import (
+    Alley,
+    Aristocrat,
+    Artist,
+    Change,
+    Craftsman,
+    Daimyo,
+    Fishmonger,
+    GoldMine,
+    ImperialEnvoy,
+    Kitsune,
+    Litter,
+    MountainShrine,
+    Ninja,
+    Poet,
+    Rice,
+    RiceBroker,
+    RiverShrine,
+    Riverboat,
+    Ronin,
+    RootCellar,
+    RusticVillage,
+    Samurai,
+    SnakeWitch,
+    Tanuki,
+    TeaHouse,
+)
 from dominion.cards.renaissance import CargoShip
 
 from dominion.cards.treasures import Copper, Gold, Silver
@@ -508,7 +533,30 @@ CARD_TYPES: dict[str, Type[Card]] = {
     "Feodum": Feodum,
     "Hunting Grounds": HuntingGrounds,
     "Market Square": MarketSquare,
+    # Rising Sun
+    "Alley": Alley,
+    "Artist": Artist,
+    "Change": Change,
+    "Craftsman": Craftsman,
+    "Daimyo": Daimyo,
+    "Fishmonger": Fishmonger,
+    "Gold Mine": GoldMine,
+    "Kitsune": Kitsune,
+    "Litter": Litter,
+    "Mountain Shrine": MountainShrine,
+    "Ninja": Ninja,
+    "Poet": Poet,
+    "Rice": Rice,
+    "Rice Broker": RiceBroker,
+    "River Shrine": RiverShrine,
+    "Riverboat": Riverboat,
+    "Ronin": Ronin,
+    "Root Cellar": RootCellar,
+    "Rustic Village": RusticVillage,
     "Samurai": Samurai,
+    "Snake Witch": SnakeWitch,
+    "Tanuki": Tanuki,
+    "Tea House": TeaHouse,
 }
 
 CARD_ALIASES: dict[str, str] = {

--- a/dominion/cards/rising_sun/__init__.py
+++ b/dominion/cards/rising_sun/__init__.py
@@ -1,4 +1,53 @@
-from .imperial_envoy import ImperialEnvoy
+from .alley import Alley
 from .aristocrat import Aristocrat
+from .artist import Artist
+from .change import Change
+from .craftsman import Craftsman
+from .daimyo import Daimyo
+from .fishmonger import Fishmonger
+from .gold_mine import GoldMine
+from .imperial_envoy import ImperialEnvoy
+from .kitsune import Kitsune
+from .litter import Litter
+from .mountain_shrine import MountainShrine
+from .ninja import Ninja
+from .poet import Poet
+from .rice import Rice
+from .rice_broker import RiceBroker
+from .river_shrine import RiverShrine
+from .riverboat import Riverboat
+from .ronin import Ronin
+from .root_cellar import RootCellar
+from .rustic_village import RusticVillage
+from .samurai import Samurai
+from .snake_witch import SnakeWitch
+from .tanuki import Tanuki
+from .tea_house import TeaHouse
 
-__all__ = ['ImperialEnvoy', 'Aristocrat']
+__all__ = [
+    'Alley',
+    'Aristocrat',
+    'Artist',
+    'Change',
+    'Craftsman',
+    'Daimyo',
+    'Fishmonger',
+    'GoldMine',
+    'ImperialEnvoy',
+    'Kitsune',
+    'Litter',
+    'MountainShrine',
+    'Ninja',
+    'Poet',
+    'Rice',
+    'RiceBroker',
+    'RiverShrine',
+    'Riverboat',
+    'Ronin',
+    'RootCellar',
+    'RusticVillage',
+    'Samurai',
+    'SnakeWitch',
+    'Tanuki',
+    'TeaHouse',
+]

--- a/dominion/cards/rising_sun/alley.py
+++ b/dominion/cards/rising_sun/alley.py
@@ -1,0 +1,27 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Alley(Card):
+    """Action-Shadow ($4): +1 Card, +1 Action, discard a card."""
+
+    def __init__(self):
+        super().__init__(
+            name="Alley",
+            cost=CardCost(coins=4),
+            stats=CardStats(cards=1, actions=1),
+            types=[CardType.ACTION, CardType.SHADOW],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+        if not player.hand:
+            return
+        chosen = player.ai.choose_cards_to_discard(
+            game_state, player, list(player.hand), 1, reason="alley"
+        )
+        if not chosen:
+            return
+        card = chosen[0]
+        if card in player.hand:
+            player.hand.remove(card)
+            game_state.discard_card(player, card)

--- a/dominion/cards/rising_sun/aristocrat.py
+++ b/dominion/cards/rising_sun/aristocrat.py
@@ -4,7 +4,7 @@ from ..base_card import Card, CardCost, CardStats, CardType
 
 
 class Aristocrat(Card):
-    """Aristocrat - Action ($5)
+    """Aristocrat - Action ($3)
 
     Look at how many Aristocrats you have in play (counting this).
     If it's:
@@ -17,7 +17,7 @@ class Aristocrat(Card):
     def __init__(self):
         super().__init__(
             name="Aristocrat",
-            cost=CardCost(coins=5),
+            cost=CardCost(coins=3),
             stats=CardStats(),
             types=[CardType.ACTION],
         )

--- a/dominion/cards/rising_sun/artist.py
+++ b/dominion/cards/rising_sun/artist.py
@@ -1,0 +1,31 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Artist(Card):
+    """Action ($8 Debt): +1 Action.
+    +1 Card per card you have exactly one copy of in play.
+
+    Counts cards still in play from previous turns (e.g. Samurai). The
+    cost is pure Debt — buying it takes 8 Debt.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Artist",
+            cost=CardCost(coins=0, debt=8),
+            stats=CardStats(actions=1),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        # Count cards in play (across in_play + duration). For each card
+        # name that appears exactly once, give +1 Card.
+        from collections import Counter
+
+        names = [c.name for c in player.in_play + player.duration]
+        counts = Counter(names)
+        unique_singletons = sum(1 for n, c in counts.items() if c == 1)
+        if unique_singletons > 0:
+            game_state.draw_cards(player, unique_singletons)

--- a/dominion/cards/rising_sun/change.py
+++ b/dominion/cards/rising_sun/change.py
@@ -1,0 +1,69 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Change(Card):
+    """Action ($4): If you have any Debt, +$3.
+    Otherwise, trash a card from your hand and gain a card costing more $;
+    take Debt equal to the difference in coin cost.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Change",
+            cost=CardCost(coins=4),
+            stats=CardStats(),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        from ..registry import get_card
+
+        player = game_state.current_player
+
+        if player.debt > 0:
+            player.coins += 3
+            return
+
+        if not player.hand:
+            return
+
+        trash_choice = player.ai.choose_card_to_trash(game_state, list(player.hand))
+        if trash_choice is None or trash_choice not in player.hand:
+            return
+
+        trashed_cost = game_state.get_card_cost(player, trash_choice)
+        player.hand.remove(trash_choice)
+        game_state.trash_card(player, trash_choice)
+
+        candidates = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            if card.cost.potions > 0:
+                continue
+            cost = game_state.get_card_cost(player, card)
+            if cost <= trashed_cost:
+                continue
+            if not card.may_be_bought(game_state):
+                continue
+            candidates.append(card)
+
+        if not candidates:
+            return
+
+        chosen = player.ai.choose_buy(game_state, candidates + [None])
+        if chosen is None:
+            return
+
+        if game_state.supply.get(chosen.name, 0) <= 0:
+            return
+
+        new_cost = game_state.get_card_cost(player, chosen)
+        game_state.supply[chosen.name] -= 1
+        game_state.gain_card(player, chosen)
+        debt_to_take = max(0, new_cost - trashed_cost)
+        player.debt += debt_to_take

--- a/dominion/cards/rising_sun/craftsman.py
+++ b/dominion/cards/rising_sun/craftsman.py
@@ -1,0 +1,53 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Craftsman(Card):
+    """Action ($3): +2 Debt. Gain a card costing up to $5.
+
+    "Up to $5" excludes any card with Debt in its cost.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Craftsman",
+            cost=CardCost(coins=3),
+            stats=CardStats(),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        from ..registry import get_card
+
+        player = game_state.current_player
+        player.debt += 2
+
+        candidates = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            # "Up to $5" excludes cards with Debt in their cost.
+            if card.cost.debt > 0:
+                continue
+            if card.cost.potions > 0:
+                continue
+            if game_state.get_card_cost(player, card) > 5:
+                continue
+            if not card.may_be_bought(game_state):
+                continue
+            candidates.append(card)
+
+        if not candidates:
+            return
+
+        chosen = player.ai.choose_buy(game_state, candidates + [None])
+        if chosen is None:
+            return
+        if game_state.supply.get(chosen.name, 0) <= 0:
+            return
+
+        game_state.supply[chosen.name] -= 1
+        game_state.gain_card(player, chosen)

--- a/dominion/cards/rising_sun/daimyo.py
+++ b/dominion/cards/rising_sun/daimyo.py
@@ -1,0 +1,25 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Daimyo(Card):
+    """Action-Command ($6 Debt): +1 Card, +1 Action.
+    The next time this turn you play a non-Command Action card, replay it.
+
+    Multiple Daimyos stack: each replays the next non-Command Action play.
+    Pure-debt cost: buying takes 6 Debt.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Daimyo",
+            cost=CardCost(coins=0, debt=6),
+            stats=CardStats(cards=1, actions=1),
+            types=[CardType.ACTION, CardType.COMMAND],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+        # Each Daimyo registers a pending replay; the action phase loop
+        # replays whatever non-Command Action card is played next.
+        pending = getattr(player, "daimyo_pending", 0)
+        player.daimyo_pending = pending + 1

--- a/dominion/cards/rising_sun/fishmonger.py
+++ b/dominion/cards/rising_sun/fishmonger.py
@@ -1,0 +1,13 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Fishmonger(Card):
+    """Action-Shadow ($2): +1 Buy, +$1."""
+
+    def __init__(self):
+        super().__init__(
+            name="Fishmonger",
+            cost=CardCost(coins=2),
+            stats=CardStats(coins=1, buys=1),
+            types=[CardType.ACTION, CardType.SHADOW],
+        )

--- a/dominion/cards/rising_sun/gold_mine.py
+++ b/dominion/cards/rising_sun/gold_mine.py
@@ -1,0 +1,29 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class GoldMine(Card):
+    """Action-Shadow ($5): +1 Card, +1 Action, +1 Buy.
+    You may gain a Gold; if you do, take 4 Debt.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Gold Mine",
+            cost=CardCost(coins=5),
+            stats=CardStats(cards=1, actions=1, buys=1),
+            types=[CardType.ACTION, CardType.SHADOW],
+        )
+
+    def play_effect(self, game_state):
+        from ..registry import get_card
+
+        player = game_state.current_player
+
+        if game_state.supply.get("Gold", 0) <= 0:
+            return
+        if not player.ai.should_take_gold_mine_gold(game_state, player):
+            return
+
+        game_state.supply["Gold"] -= 1
+        game_state.gain_card(player, get_card("Gold"))
+        player.debt += 4

--- a/dominion/cards/rising_sun/kitsune.py
+++ b/dominion/cards/rising_sun/kitsune.py
@@ -1,0 +1,65 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Kitsune(Card):
+    """Action-Attack-Omen ($5): +1 Sun.
+    Then choose two different options (in the listed order):
+    - Each other player gains a Curse
+    - +1 Action
+    - +$2
+    - Gain a Silver
+    """
+
+    OPTIONS = ["curse", "action", "coins", "silver"]
+
+    def __init__(self):
+        super().__init__(
+            name="Kitsune",
+            cost=CardCost(coins=5),
+            stats=CardStats(),
+            types=[CardType.ACTION, CardType.ATTACK, CardType.OMEN],
+        )
+
+    def play_effect(self, game_state):
+        from ..registry import get_card
+
+        player = game_state.current_player
+
+        chosen = player.ai.choose_kitsune_options(game_state, player, list(self.OPTIONS))
+        # Always pick at most two distinct options
+        seen = []
+        for option in chosen:
+            if option in self.OPTIONS and option not in seen:
+                seen.append(option)
+            if len(seen) == 2:
+                break
+
+        # Resolve in the listed order, regardless of pick order
+        for option in self.OPTIONS:
+            if option not in seen:
+                continue
+            if option == "curse":
+                self._curse_others(game_state, player)
+            elif option == "action":
+                player.actions += 1
+            elif option == "coins":
+                player.coins += 2
+            elif option == "silver":
+                if game_state.supply.get("Silver", 0) > 0:
+                    game_state.supply["Silver"] -= 1
+                    game_state.gain_card(player, get_card("Silver"))
+
+    def _curse_others(self, game_state, player):
+        from ..registry import get_card
+
+        for other in game_state.players:
+            if other is player:
+                continue
+
+            def attack_target(target):
+                if game_state.supply.get("Curse", 0) <= 0:
+                    return
+                game_state.supply["Curse"] -= 1
+                game_state.gain_card(target, get_card("Curse"))
+
+            game_state.attack_player(other, attack_target)

--- a/dominion/cards/rising_sun/litter.py
+++ b/dominion/cards/rising_sun/litter.py
@@ -1,0 +1,20 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Litter(Card):
+    """Action ($5): +2 Cards, +2 Actions, +1 Debt.
+
+    The "+1 Debt" is taken when you play Litter (Debt-producing card text,
+    similar to Imperial Envoy).
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Litter",
+            cost=CardCost(coins=5),
+            stats=CardStats(cards=2, actions=2),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        game_state.current_player.debt += 1

--- a/dominion/cards/rising_sun/mountain_shrine.py
+++ b/dominion/cards/rising_sun/mountain_shrine.py
@@ -1,0 +1,33 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class MountainShrine(Card):
+    """Action-Omen ($5 Debt): +1 Sun, +$2.
+    You may trash a card from your hand. Then if there are any Action cards
+    in the trash, +2 Cards.
+
+    Cost is pure Debt — buying it gives you 5 Debt. (Per the rulebook, "up
+    to $X" exclusions skip cards with any Debt in their cost.)
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Mountain Shrine",
+            cost=CardCost(coins=0, debt=5),
+            stats=CardStats(coins=2),
+            types=[CardType.ACTION, CardType.OMEN],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        if player.hand:
+            trash_choice = player.ai.choose_card_to_trash(
+                game_state, list(player.hand) + [None]
+            )
+            if trash_choice is not None and trash_choice in player.hand:
+                player.hand.remove(trash_choice)
+                game_state.trash_card(player, trash_choice)
+
+        if any(c.is_action for c in game_state.trash):
+            game_state.draw_cards(player, 2)

--- a/dominion/cards/rising_sun/ninja.py
+++ b/dominion/cards/rising_sun/ninja.py
@@ -1,0 +1,39 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Ninja(Card):
+    """Action-Shadow-Attack ($4): +1 Card.
+    Each other player discards down to 3 cards in hand.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Ninja",
+            cost=CardCost(coins=4),
+            stats=CardStats(cards=1),
+            types=[CardType.ACTION, CardType.ATTACK, CardType.SHADOW],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        def attack_target(target):
+            if len(target.hand) <= 3:
+                return
+            discard_needed = len(target.hand) - 3
+            chosen = target.ai.choose_cards_to_discard(
+                game_state, target, list(target.hand), discard_needed, reason="ninja"
+            )
+            for card in chosen[:discard_needed]:
+                if card in target.hand:
+                    target.hand.remove(card)
+                    game_state.discard_card(target, card)
+            while len(target.hand) > 3:
+                card = target.hand[-1]
+                target.hand.remove(card)
+                game_state.discard_card(target, card)
+
+        for other in game_state.players:
+            if other is player:
+                continue
+            game_state.attack_player(other, attack_target)

--- a/dominion/cards/rising_sun/poet.py
+++ b/dominion/cards/rising_sun/poet.py
@@ -1,0 +1,32 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Poet(Card):
+    """Action-Omen ($4): +1 Sun, +1 Card, +1 Action.
+    Reveal the top card of your deck. If it costs up to $3, put it into your
+    hand. Otherwise, put it back on top of your deck.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Poet",
+            cost=CardCost(coins=4),
+            stats=CardStats(cards=1, actions=1),
+            types=[CardType.ACTION, CardType.OMEN],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        if not player.deck and player.discard:
+            player.shuffle_discard_into_deck()
+        if not player.deck:
+            return
+
+        top_card = player.deck[-1]
+        cost = game_state.get_card_cost(player, top_card)
+        # "Up to $3" excludes cards with debt in the cost.
+        if top_card.cost.debt > 0 or cost > 3:
+            return  # leave on top
+        player.deck.pop()
+        player.hand.append(top_card)

--- a/dominion/cards/rising_sun/rice.py
+++ b/dominion/cards/rising_sun/rice.py
@@ -1,0 +1,24 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Rice(Card):
+    """Treasure ($7): +1 Buy.
+    +$1 per different type among cards you have in play.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Rice",
+            cost=CardCost(coins=7),
+            stats=CardStats(buys=1),
+            types=[CardType.TREASURE],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        type_set = set()
+        for card in player.in_play + player.duration:
+            for t in card.types:
+                type_set.add(t)
+        player.coins += len(type_set)

--- a/dominion/cards/rising_sun/rice_broker.py
+++ b/dominion/cards/rising_sun/rice_broker.py
@@ -1,0 +1,37 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class RiceBroker(Card):
+    """Action ($5): +1 Action. Trash a card from your hand.
+    If a Treasure, +2 Cards. If an Action, +5 Cards.
+    (A card that's both gives both, in that order: +2 then +5.)
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Rice Broker",
+            cost=CardCost(coins=5),
+            stats=CardStats(actions=1),
+            types=[CardType.ACTION],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        if not player.hand:
+            return
+
+        chosen = player.ai.choose_card_to_trash(game_state, list(player.hand))
+        if chosen is None or chosen not in player.hand:
+            return
+
+        is_treasure = chosen.is_treasure
+        is_action = chosen.is_action
+
+        player.hand.remove(chosen)
+        game_state.trash_card(player, chosen)
+
+        if is_treasure:
+            game_state.draw_cards(player, 2)
+        if is_action:
+            game_state.draw_cards(player, 5)

--- a/dominion/cards/rising_sun/river_shrine.py
+++ b/dominion/cards/rising_sun/river_shrine.py
@@ -1,0 +1,63 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class RiverShrine(Card):
+    """Action-Omen ($4): +1 Sun.
+    Trash up to 2 cards from your hand. At the start of Clean-up, if you
+    didn't gain any cards in your Buy phase this turn, gain a card costing
+    up to $4.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="River Shrine",
+            cost=CardCost(coins=4),
+            stats=CardStats(),
+            types=[CardType.ACTION, CardType.OMEN],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        for _ in range(2):
+            if not player.hand:
+                break
+            chosen = player.ai.choose_card_to_trash(
+                game_state, list(player.hand) + [None]
+            )
+            if chosen is None or chosen not in player.hand:
+                break
+            player.hand.remove(chosen)
+            game_state.trash_card(player, chosen)
+
+    def on_cleanup_start(self, game_state):
+        from ..registry import get_card
+
+        player = game_state.current_player
+        if getattr(player, "cards_gained_this_buy_phase", 0) > 0:
+            return
+
+        candidates = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            if card.cost.debt > 0 or card.cost.potions > 0:
+                continue
+            if game_state.get_card_cost(player, card) > 4:
+                continue
+            if not card.may_be_bought(game_state):
+                continue
+            candidates.append(card)
+        if not candidates:
+            return
+        chosen = player.ai.choose_buy(game_state, candidates + [None])
+        if chosen is None:
+            return
+        if game_state.supply.get(chosen.name, 0) <= 0:
+            return
+        game_state.supply[chosen.name] -= 1
+        game_state.gain_card(player, chosen)

--- a/dominion/cards/rising_sun/riverboat.py
+++ b/dominion/cards/rising_sun/riverboat.py
@@ -1,0 +1,35 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Riverboat(Card):
+    """Action-Duration ($3):
+    At the start of your next turn, play the Riverboat card (a non-Duration
+    Action card costing exactly $5, chosen at game setup and set aside).
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Riverboat",
+            cost=CardCost(coins=3),
+            stats=CardStats(),
+            types=[CardType.ACTION, CardType.DURATION],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+        # Stay in play until the set-aside card is played next turn.
+        player.duration.append(self)
+        self.duration_persistent = True
+
+    def on_duration(self, game_state):
+        player = game_state.current_player
+        target = game_state.riverboat_set_aside
+        if target is None:
+            self.duration_persistent = False
+            return
+        # Play the set-aside card without moving it from its set-aside
+        # location. It doesn't count as in-play but its effects still resolve
+        # (per rulebook: "This doesn't move the set aside card; it stays set
+        # aside, even if it has instructions on it that would move it.").
+        target.on_play(game_state)
+        self.duration_persistent = False

--- a/dominion/cards/rising_sun/riverboat.py
+++ b/dominion/cards/rising_sun/riverboat.py
@@ -32,4 +32,7 @@ class Riverboat(Card):
         # (per rulebook: "This doesn't move the set aside card; it stays set
         # aside, even if it has instructions on it that would move it.").
         target.on_play(game_state)
+        # Active prophecies (Great Leader, Approaching Army, etc.) react to
+        # this play just like an Action-phase play would.
+        game_state.fire_prophecy_action_hooks(player, target)
         self.duration_persistent = False

--- a/dominion/cards/rising_sun/ronin.py
+++ b/dominion/cards/rising_sun/ronin.py
@@ -1,0 +1,28 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Ronin(Card):
+    """Action-Shadow ($5):
+    Draw cards one at a time until you have 7 cards in hand (or can't draw
+    any more); if you already had 7 or more cards in hand, you don't draw
+    any.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Ronin",
+            cost=CardCost(coins=5),
+            stats=CardStats(),
+            types=[CardType.ACTION, CardType.SHADOW],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        if len(player.hand) >= 7:
+            return
+
+        while len(player.hand) < 7:
+            drawn = player.draw_cards(1)
+            if not drawn:
+                break

--- a/dominion/cards/rising_sun/root_cellar.py
+++ b/dominion/cards/rising_sun/root_cellar.py
@@ -1,0 +1,16 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class RootCellar(Card):
+    """Action-Shadow ($3): +3 Cards, +1 Action, +3 Debt."""
+
+    def __init__(self):
+        super().__init__(
+            name="Root Cellar",
+            cost=CardCost(coins=3),
+            stats=CardStats(cards=3, actions=1),
+            types=[CardType.ACTION, CardType.SHADOW],
+        )
+
+    def play_effect(self, game_state):
+        game_state.current_player.debt += 3

--- a/dominion/cards/rising_sun/rustic_village.py
+++ b/dominion/cards/rising_sun/rustic_village.py
@@ -1,0 +1,35 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class RusticVillage(Card):
+    """Action-Omen ($4): +1 Sun, +1 Card, +2 Actions.
+    You may discard 2 cards (including the one just drawn) for +1 Card.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Rustic Village",
+            cost=CardCost(coins=4),
+            stats=CardStats(cards=1, actions=2),
+            types=[CardType.ACTION, CardType.OMEN],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        if len(player.hand) < 2:
+            return
+        if not player.ai.should_rustic_village_discard(game_state, player):
+            return
+
+        chosen = player.ai.choose_cards_to_discard(
+            game_state, player, list(player.hand), 2, reason="rustic_village"
+        )
+        chosen = chosen[:2]
+        if len(chosen) < 2:
+            return
+        for card in chosen:
+            if card in player.hand:
+                player.hand.remove(card)
+                game_state.discard_card(player, card)
+        game_state.draw_cards(player, 1)

--- a/dominion/cards/rising_sun/samurai.py
+++ b/dominion/cards/rising_sun/samurai.py
@@ -2,17 +2,17 @@ from ..base_card import Card, CardCost, CardStats, CardType
 
 
 class Samurai(Card):
-    """Action - Attack that stays in play.
+    """Action-Duration-Attack ($6).
 
-    When you play this, each other player with 5 or more cards in hand
-    discards down to 3. While this is in play, +1 Coin at the start of
-    each of your turns.
+    When you play this, each other player discards down to 3 cards in hand.
+    The Samurai stays in play, and produces +$1 at the start of each of your
+    turns for the rest of the game.
     """
 
     def __init__(self):
         super().__init__(
             name="Samurai",
-            cost=CardCost(coins=5),
+            cost=CardCost(coins=6),
             stats=CardStats(),
             types=[CardType.ACTION, CardType.ATTACK, CardType.DURATION],
         )
@@ -22,7 +22,7 @@ class Samurai(Card):
         player = game_state.current_player
 
         def attack_target(target):
-            if len(target.hand) < 5:
+            if len(target.hand) <= 3:
                 return
 
             discard_needed = len(target.hand) - 3
@@ -45,12 +45,10 @@ class Samurai(Card):
                 continue
             game_state.attack_player(other, attack_target)
 
-        # Stays in play to provide +1 Coin at the start of each future turn
         player.duration.append(self)
         self.duration_persistent = True
 
     def on_duration(self, game_state):
         player = game_state.current_player
         player.coins += 1
-        # Samurai never leaves play on its own
         self.duration_persistent = True

--- a/dominion/cards/rising_sun/snake_witch.py
+++ b/dominion/cards/rising_sun/snake_witch.py
@@ -1,0 +1,48 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class SnakeWitch(Card):
+    """Action-Attack ($2): +1 Card, +1 Action.
+    You may reveal your hand. If all cards in it have different names, return
+    Snake Witch to its pile, and if you did, each other player gains a Curse.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Snake Witch",
+            cost=CardCost(coins=2),
+            stats=CardStats(cards=1, actions=1),
+            types=[CardType.ACTION, CardType.ATTACK],
+        )
+
+    def play_effect(self, game_state):
+        player = game_state.current_player
+
+        # Reveal hand: optional. Skip if hand has duplicates or AI declines.
+        names = [c.name for c in player.hand]
+        all_different = len(set(names)) == len(names)
+        if not all_different:
+            return
+        if not player.ai.should_reveal_snake_witch(game_state, player):
+            return
+
+        # Return Snake Witch from in_play to its pile, then curse opponents.
+        if self in player.in_play:
+            player.in_play.remove(self)
+            game_state.supply["Snake Witch"] = game_state.supply.get("Snake Witch", 0) + 1
+        else:
+            return
+
+        from ..registry import get_card
+
+        for other in game_state.players:
+            if other is player:
+                continue
+
+            def attack_target(target):
+                if game_state.supply.get("Curse", 0) <= 0:
+                    return
+                game_state.supply["Curse"] -= 1
+                game_state.gain_card(target, get_card("Curse"))
+
+            game_state.attack_player(other, attack_target)

--- a/dominion/cards/rising_sun/tanuki.py
+++ b/dominion/cards/rising_sun/tanuki.py
@@ -1,0 +1,58 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class Tanuki(Card):
+    """Action-Shadow ($5): Trash a card from your hand. Gain a card costing
+    up to $2 more than it (Remodel-style).
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="Tanuki",
+            cost=CardCost(coins=5),
+            stats=CardStats(),
+            types=[CardType.ACTION, CardType.SHADOW],
+        )
+
+    def play_effect(self, game_state):
+        from ..registry import get_card
+
+        player = game_state.current_player
+
+        if not player.hand:
+            return
+
+        trashed = player.ai.choose_card_to_trash(game_state, list(player.hand))
+        if trashed is None or trashed not in player.hand:
+            return
+
+        trashed_cost = game_state.get_card_cost(player, trashed)
+        player.hand.remove(trashed)
+        game_state.trash_card(player, trashed)
+
+        max_cost = trashed_cost + 2
+        candidates = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            if card.cost.potions > 0:
+                continue
+            cost = game_state.get_card_cost(player, card)
+            if cost > max_cost:
+                continue
+            if not card.may_be_bought(game_state):
+                continue
+            candidates.append(card)
+        if not candidates:
+            return
+        chosen = player.ai.choose_buy(game_state, candidates + [None])
+        if chosen is None:
+            return
+        if game_state.supply.get(chosen.name, 0) <= 0:
+            return
+        game_state.supply[chosen.name] -= 1
+        game_state.gain_card(player, chosen)

--- a/dominion/cards/rising_sun/tea_house.py
+++ b/dominion/cards/rising_sun/tea_house.py
@@ -1,0 +1,13 @@
+from ..base_card import Card, CardCost, CardStats, CardType
+
+
+class TeaHouse(Card):
+    """Action-Omen ($5): +1 Sun, +1 Card, +1 Action, +$2."""
+
+    def __init__(self):
+        super().__init__(
+            name="Tea House",
+            cost=CardCost(coins=5),
+            stats=CardStats(cards=1, actions=1, coins=2),
+            types=[CardType.ACTION, CardType.OMEN],
+        )

--- a/dominion/events/continue_event.py
+++ b/dominion/events/continue_event.py
@@ -76,6 +76,36 @@ class Continue(Event):
 
         zone.remove(gained)
         player.in_play.append(gained)
-        # Returning to the Action phase to play this gain doesn't consume an
-        # Action play.
-        gained.on_play(game_state)
+
+        # Per rulebook: "you return to your Action phase; and you play the
+        # Action card you gained." Switch the phase back so the gain plays
+        # under Action-phase semantics (Daimyo replays, Prophecy hooks).
+        game_state.phase = "action"
+
+        daimyo_replays = getattr(player, "daimyo_pending", 0)
+        player.daimyo_pending = 0
+        plays = 1 + daimyo_replays
+        for _ in range(plays):
+            gained.on_play(game_state)
+            if game_state.prophecy is not None and game_state.prophecy.is_active:
+                game_state.prophecy.on_play_action(game_state, player, gained)
+                # Continue can't gain Attack cards, so on_play_attack is dead
+
+        # Let the player use any remaining Action plays from hand. This loop
+        # also picks up any Shadow cards now exposed in the deck.
+        game_state.handle_action_phase()
+
+        # Skip the Treasure phase per the general rule "you cannot play further
+        # Treasures that turn after buying an Event," but return to Buy phase
+        # so the outer buy loop continues and 'start of Buy phase' abilities
+        # can repeat (Flourishing Trade in particular).
+        game_state.phase = "buy"
+        if (
+            game_state.prophecy is not None
+            and game_state.prophecy.is_active
+            and game_state.prophecy.name == "Flourishing Trade"
+            and player.actions > 0
+        ):
+            converted = player.actions
+            player.actions = 0
+            player.buys += converted

--- a/dominion/events/continue_event.py
+++ b/dominion/events/continue_event.py
@@ -87,9 +87,7 @@ class Continue(Event):
         plays = 1 + daimyo_replays
         for _ in range(plays):
             gained.on_play(game_state)
-            if game_state.prophecy is not None and game_state.prophecy.is_active:
-                game_state.prophecy.on_play_action(game_state, player, gained)
-                # Continue can't gain Attack cards, so on_play_attack is dead
+            game_state.fire_prophecy_action_hooks(player, gained)
 
         # Let the player use any remaining Action plays from hand. This loop
         # also picks up any Shadow cards now exposed in the deck.

--- a/dominion/events/continue_event.py
+++ b/dominion/events/continue_event.py
@@ -1,4 +1,4 @@
-"""The Continue event from Plunder."""
+"""The Continue event from Rising Sun."""
 
 from dominion.cards.base_card import CardCost
 from dominion.cards.registry import get_card
@@ -7,12 +7,24 @@ from .base_event import Event
 
 
 class Continue(Event):
-    """$8: gain a non-Victory non-Command card costing up to $4, then play it."""
+    """$8 Debt: Once per turn. Gain an Action card costing up to $4 that
+    isn't an Attack card; return to your Action phase; play the gained card.
+    +1 Action, +1 Buy.
+
+    Cost is pure Debt — buying it takes 8 Debt.
+    """
 
     def __init__(self):
-        super().__init__("Continue", CardCost(coins=8))
+        super().__init__("Continue", CardCost(coins=0, debt=8))
+
+    def may_be_bought(self, game_state, player) -> bool:
+        return not getattr(player, "continue_used_this_turn", False)
 
     def on_buy(self, game_state, player) -> None:
+        player.continue_used_this_turn = True
+        player.actions += 1
+        player.buys += 1
+
         candidates = []
         for name, count in game_state.supply.items():
             if count <= 0:
@@ -21,11 +33,17 @@ class Continue(Event):
                 card = get_card(name)
             except ValueError:
                 continue
-            if card.is_victory or card.is_command:
+            if not card.is_action:
+                continue
+            if card.is_attack:
+                continue
+            if card.is_command:
                 continue
             if card.cost.potions > 0:
                 continue
             if card.cost.coins > 4:
+                continue
+            if card.cost.debt > 0:
                 continue
             if not card.may_be_bought(game_state):
                 continue
@@ -47,11 +65,6 @@ class Continue(Event):
         gained = game_state.gain_card(player, chosen)
 
         # Locate the gained card in whichever post-gain zone it landed in.
-        # Default destination is the discard pile, but Insignia/Royal Seal
-        # can top-deck and Villa's on_gain moves itself into hand. Only play
-        # it if we can find it in a normal zone — if a reaction trashed or
-        # exiled it, the play step is skipped (Watchtower-trashed gains
-        # aren't playable).
         zone = None
         for candidate in (player.hand, player.discard, player.deck):
             if gained in candidate:
@@ -63,6 +76,6 @@ class Continue(Event):
 
         zone.remove(gained)
         player.in_play.append(gained)
-        # Continue grants a free play of the gain (Action *or* Treasure);
-        # we deliberately don't deduct an action.
+        # Returning to the Action phase to play this gain doesn't consume an
+        # Action play.
         gained.on_play(game_state)

--- a/dominion/events/registry.py
+++ b/dominion/events/registry.py
@@ -23,6 +23,17 @@ from .menagerie_events import (
     Transport,
 )
 from .prosperity_events import Investment
+from .rising_sun_events import (
+    Amass,
+    Asceticism,
+    Credit,
+    Foresight,
+    Gather,
+    Kintsugi,
+    Practice,
+    ReceiveTribute,
+    SeaTrade,
+)
 from .training import Training
 
 EVENT_TYPES: dict[str, Type[Event]] = {
@@ -45,6 +56,16 @@ EVENT_TYPES: dict[str, Type[Event]] = {
     "Transport": Transport,
     "Investment": Investment,
     "Training": Training,
+    # Rising Sun
+    "Amass": Amass,
+    "Asceticism": Asceticism,
+    "Credit": Credit,
+    "Foresight": Foresight,
+    "Gather": Gather,
+    "Kintsugi": Kintsugi,
+    "Practice": Practice,
+    "Receive Tribute": ReceiveTribute,
+    "Sea Trade": SeaTrade,
 }
 
 

--- a/dominion/events/rising_sun_events.py
+++ b/dominion/events/rising_sun_events.py
@@ -1,0 +1,325 @@
+"""Events from the Rising Sun expansion."""
+
+from dominion.cards.base_card import CardCost
+from dominion.cards.registry import get_card
+
+from .base_event import Event
+
+
+class Amass(Event):
+    """$2: If you have no Action cards in play, gain an Action card costing
+    up to $5.
+    """
+
+    def __init__(self):
+        super().__init__("Amass", CardCost(coins=2))
+
+    def on_buy(self, game_state, player) -> None:
+        # Per rulebook: Duration cards in play that were played on previous
+        # turns count too, blocking Amass.
+        all_in_play = list(player.in_play) + list(player.duration)
+        if any(card.is_action for card in all_in_play):
+            return
+
+        candidates = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            if not card.is_action:
+                continue
+            if card.cost.debt > 0 or card.cost.potions > 0:
+                continue
+            if game_state.get_card_cost(player, card) > 5:
+                continue
+            if not card.may_be_bought(game_state):
+                continue
+            candidates.append(card)
+
+        if not candidates:
+            return
+        chosen = player.ai.choose_buy(game_state, candidates + [None])
+        if chosen is None:
+            return
+        if game_state.supply.get(chosen.name, 0) <= 0:
+            return
+        game_state.supply[chosen.name] -= 1
+        game_state.gain_card(player, chosen)
+
+
+class Asceticism(Event):
+    """$2 (overpay supported): You may pay any extra amount $X. Trash X cards
+    from your hand.
+    """
+
+    def __init__(self):
+        super().__init__("Asceticism", CardCost(coins=2))
+
+    def on_buy(self, game_state, player) -> None:
+        extra = player.ai.choose_asceticism_overpay(
+            game_state, player, available=player.coins
+        )
+        extra = max(0, min(extra, player.coins, len(player.hand)))
+        if extra <= 0:
+            return
+        player.coins -= extra
+        player.coins_spent_this_turn += extra
+
+        chosen = player.ai.choose_cards_to_trash(
+            game_state, list(player.hand), extra
+        )
+        chosen = chosen[:extra]
+        for card in chosen:
+            if card in player.hand:
+                player.hand.remove(card)
+                game_state.trash_card(player, card)
+
+
+class Credit(Event):
+    """$2: Gain an Action or Treasure card costing up to $8. Take Debt equal
+    to its cost.
+
+    Excludes cards whose own cost contains Debt — "up to $X" by definition
+    skips them.
+    """
+
+    def __init__(self):
+        super().__init__("Credit", CardCost(coins=2))
+
+    def on_buy(self, game_state, player) -> None:
+        candidates = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            if not (card.is_action or card.is_treasure):
+                continue
+            if card.cost.debt > 0:
+                continue
+            if card.cost.potions > 0:
+                continue
+            if game_state.get_card_cost(player, card) > 8:
+                continue
+            if not card.may_be_bought(game_state):
+                continue
+            candidates.append(card)
+        if not candidates:
+            return
+        chosen = player.ai.choose_buy(game_state, candidates + [None])
+        if chosen is None:
+            return
+        if game_state.supply.get(chosen.name, 0) <= 0:
+            return
+        cost_to_pay = game_state.get_card_cost(player, chosen)
+        game_state.supply[chosen.name] -= 1
+        game_state.gain_card(player, chosen)
+        player.debt += cost_to_pay
+
+
+class Foresight(Event):
+    """$2: Reveal cards from the top of your deck until you reveal an Action.
+    Set it aside, discard the rest. The card is added to your hand after
+    drawing your next hand.
+    """
+
+    def __init__(self):
+        super().__init__("Foresight", CardCost(coins=2))
+
+    def on_buy(self, game_state, player) -> None:
+        revealed: list = []
+        found = None
+        while True:
+            if not player.deck and player.discard:
+                player.shuffle_discard_into_deck()
+            if not player.deck:
+                break
+            card = player.deck.pop()
+            revealed.append(card)
+            if card.is_action:
+                found = card
+                break
+
+        if found is not None:
+            revealed.remove(found)
+            player.foresight_set_aside.append(found)
+
+        for card in revealed:
+            game_state.discard_card(player, card)
+
+
+class Gather(Event):
+    """$7: Gain a card costing exactly $3, exactly $4, and exactly $5
+    (in that order; skip individually if no candidate exists).
+    """
+
+    def __init__(self):
+        super().__init__("Gather", CardCost(coins=7))
+
+    def on_buy(self, game_state, player) -> None:
+        for target_cost in (3, 4, 5):
+            candidates = []
+            for name, count in game_state.supply.items():
+                if count <= 0:
+                    continue
+                try:
+                    card = get_card(name)
+                except ValueError:
+                    continue
+                if card.cost.debt > 0 or card.cost.potions > 0:
+                    continue
+                if game_state.get_card_cost(player, card) != target_cost:
+                    continue
+                if not card.may_be_bought(game_state):
+                    continue
+                candidates.append(card)
+            if not candidates:
+                continue
+            chosen = player.ai.choose_buy(game_state, candidates + [None])
+            if chosen is None:
+                continue
+            if game_state.supply.get(chosen.name, 0) <= 0:
+                continue
+            game_state.supply[chosen.name] -= 1
+            game_state.gain_card(player, chosen)
+
+
+class Kintsugi(Event):
+    """$3: Trash a card from your hand. If you've gained a Gold this game,
+    gain a card costing up to $2 more than the trashed card.
+    """
+
+    def __init__(self):
+        super().__init__("Kintsugi", CardCost(coins=3))
+
+    def on_buy(self, game_state, player) -> None:
+        if not player.hand:
+            return
+        gained_gold = getattr(player, "kintsugi_has_gained_gold", False)
+        chosen = player.ai.choose_card_to_trash(game_state, list(player.hand))
+        if chosen is None or chosen not in player.hand:
+            return
+        trashed_cost = game_state.get_card_cost(player, chosen)
+        player.hand.remove(chosen)
+        game_state.trash_card(player, chosen)
+
+        if not gained_gold:
+            return
+
+        max_cost = trashed_cost + 2
+        candidates = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            if card.cost.debt > 0 or card.cost.potions > 0:
+                continue
+            if game_state.get_card_cost(player, card) > max_cost:
+                continue
+            if not card.may_be_bought(game_state):
+                continue
+            candidates.append(card)
+        if not candidates:
+            return
+        gain_choice = player.ai.choose_buy(game_state, candidates + [None])
+        if gain_choice is None:
+            return
+        if game_state.supply.get(gain_choice.name, 0) <= 0:
+            return
+        game_state.supply[gain_choice.name] -= 1
+        game_state.gain_card(player, gain_choice)
+
+
+class Practice(Event):
+    """$3: You may play an Action card from your hand twice."""
+
+    def __init__(self):
+        super().__init__("Practice", CardCost(coins=3))
+
+    def on_buy(self, game_state, player) -> None:
+        actions = [c for c in player.hand if c.is_action]
+        if not actions:
+            return
+        chosen = player.ai.choose_action(game_state, actions + [None])
+        if chosen is None or chosen not in player.hand:
+            return
+        player.hand.remove(chosen)
+        player.in_play.append(chosen)
+        chosen.on_play(game_state)
+        chosen.on_play(game_state)
+
+
+class ReceiveTribute(Event):
+    """$5: If you've gained at least 3 cards this turn, gain up to 3
+    differently named Action cards you don't have copies of in play.
+    """
+
+    def __init__(self):
+        super().__init__("Receive Tribute", CardCost(coins=5))
+
+    def on_buy(self, game_state, player) -> None:
+        if getattr(player, "cards_gained_this_turn", 0) < 3:
+            return
+        in_play_names = {c.name for c in player.in_play + player.duration}
+        gained_names: set = set()
+        for _ in range(3):
+            candidates = []
+            for name, count in game_state.supply.items():
+                if count <= 0:
+                    continue
+                try:
+                    card = get_card(name)
+                except ValueError:
+                    continue
+                if not card.is_action:
+                    continue
+                if name in in_play_names or name in gained_names:
+                    continue
+                if not card.may_be_bought(game_state):
+                    continue
+                candidates.append(card)
+            if not candidates:
+                return
+            chosen = player.ai.choose_buy(game_state, candidates + [None])
+            if chosen is None:
+                return
+            if game_state.supply.get(chosen.name, 0) <= 0:
+                return
+            game_state.supply[chosen.name] -= 1
+            game_state.gain_card(player, chosen)
+            gained_names.add(chosen.name)
+
+
+class SeaTrade(Event):
+    """$4: +1 Card per Action card you have in play. Trash up to that many
+    cards from your hand.
+    """
+
+    def __init__(self):
+        super().__init__("Sea Trade", CardCost(coins=4))
+
+    def on_buy(self, game_state, player) -> None:
+        action_count = sum(
+            1 for c in player.in_play + player.duration if c.is_action
+        )
+        if action_count <= 0:
+            return
+        game_state.draw_cards(player, action_count)
+        if not player.hand:
+            return
+        chosen = player.ai.choose_cards_to_trash(
+            game_state, list(player.hand), action_count
+        )
+        chosen = chosen[:action_count]
+        for card in chosen:
+            if card in player.hand:
+                player.hand.remove(card)
+                game_state.trash_card(player, card)

--- a/dominion/events/rising_sun_events.py
+++ b/dominion/events/rising_sun_events.py
@@ -253,8 +253,12 @@ class Practice(Event):
             return
         player.hand.remove(chosen)
         player.in_play.append(chosen)
+        # Each play fires the active Prophecy's after-Action hooks, matching
+        # what handle_action_phase would do.
         chosen.on_play(game_state)
+        game_state.fire_prophecy_action_hooks(player, chosen)
         chosen.on_play(game_state)
+        game_state.fire_prophecy_action_hooks(player, chosen)
 
 
 class ReceiveTribute(Event):

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -38,6 +38,11 @@ class GameState:
     sun_tokens: int = 0
     riverboat_set_aside: object = None  # Card set aside at game start for Riverboat
     harsh_winter_debt: dict = field(default_factory=dict)  # pile_name → debt tokens
+    # Names of the Kingdom card piles (and their split-pile partners) used at
+    # game setup. Tracked separately from the supply because Divine Wind
+    # needs to remove only those piles, not non-Kingdom support piles like
+    # Ruins, Spoils, or Horse.
+    original_kingdom_pile_names: set = field(default_factory=set)
 
     def __post_init__(self):
         """Initialize with default logger that prints to console."""
@@ -119,6 +124,20 @@ class GameState:
         """Set up the game with given AIs and kingdom cards."""
         # Create PlayerState objects for each AI
         self.players = [PlayerState(ai) for ai in ais]
+        # Snapshot the Kingdom selection before setup_supply expands the pile
+        # set with split-pile partners. We extend the snapshot with the
+        # partner names below since Divine Wind treats a split pile as one
+        # Kingdom pile to remove.
+        self.original_kingdom_pile_names = {c.name for c in kingdom_cards}
+        for c in kingdom_cards:
+            if isinstance(c, SplitPileMixin):
+                self.original_kingdom_pile_names.add(c.partner_card_name)
+            from dominion.cards.allies.wizards import (
+                WIZARDS_PILE_ORDER,
+                WizardsSplitCard,
+            )
+            if isinstance(c, WizardsSplitCard):
+                self.original_kingdom_pile_names.update(WIZARDS_PILE_ORDER)
         self.setup_supply(kingdom_cards)
         self.events = events or []
         self.projects = projects or []
@@ -366,6 +385,9 @@ class GameState:
         player.fortune_doubled_this_turn = False
         player.harbor_village_pending = 0
         player.continue_used_this_turn = False
+        # Daimyo's "next non-Command Action this turn" replay expires when the
+        # turn ends without a triggering Action being played.
+        player.daimyo_pending = 0
 
         # Return any cards delayed by the Delay event
         if self.current_player.delayed_cards:

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -32,7 +32,12 @@ class GameState:
     farmers_market_pile_tokens: int = 0
     temple_pile_tokens: int = 0
     tireless_piles: set = field(default_factory=set)  # card names with Tireless trait
-      
+
+    # Rising Sun: Prophecies and Sun tokens
+    prophecy: object = None
+    sun_tokens: int = 0
+    riverboat_set_aside: object = None  # Card set aside at game start for Riverboat
+    harsh_winter_debt: dict = field(default_factory=dict)  # pile_name → debt tokens
 
     def __post_init__(self):
         """Initialize with default logger that prints to console."""
@@ -80,6 +85,25 @@ class GameState:
     def current_player(self) -> PlayerState:
         return self.players[self.current_player_index]
 
+    def remove_sun_token(self, count: int = 1) -> None:
+        """Omen +1 Sun: remove ``count`` Sun tokens from the active Prophecy.
+
+        When the last token is removed, the Prophecy activates and its rule
+        text becomes effective for the rest of the game. No-ops when there is
+        no active Prophecy or when tokens have already been depleted.
+        """
+        if self.prophecy is None:
+            return
+        if self.sun_tokens <= 0:
+            return
+        for _ in range(count):
+            if self.sun_tokens <= 0:
+                break
+            self.sun_tokens -= 1
+            if self.sun_tokens == 0 and not self.prophecy.is_active:
+                self.prophecy.activate(self)
+                break
+
     def initialize_game(
         self,
         ais: list,
@@ -89,6 +113,8 @@ class GameState:
         projects: list = None,
         ways: list = None,
         allies: list = None,
+        prophecy: object = None,
+        riverboat_set_aside: Card = None,
     ):
         """Set up the game with given AIs and kingdom cards."""
         # Create PlayerState objects for each AI
@@ -98,6 +124,31 @@ class GameState:
         self.projects = projects or []
         self.ways = ways or []
         self.allies = allies or []
+
+        # Rising Sun: a Prophecy is dealt out whenever any Omen card is in the
+        # supply. Sun tokens are placed based on player count.
+        has_omen = any(card.is_omen for card in kingdom_cards)
+        if prophecy is None and has_omen:
+            from dominion.prophecies.registry import PROPHECY_TYPES
+            if PROPHECY_TYPES:
+                prophecy_class = random.choice(list(PROPHECY_TYPES.values()))
+                prophecy = prophecy_class()
+        if prophecy is not None:
+            self.prophecy = prophecy
+            tokens_per_count = {2: 5, 3: 8, 4: 10, 5: 12, 6: 13}
+            self.sun_tokens = tokens_per_count.get(len(self.players), 5)
+            prophecy.setup(self)
+            self.log_callback(
+                f"Prophecy: {prophecy.name} ({self.sun_tokens} Sun tokens)"
+            )
+
+        # Riverboat: a non-Duration Action card costing exactly $5 is set aside
+        # at the start of the game and played at the start of the turn after
+        # Riverboat is played.
+        if riverboat_set_aside is not None:
+            self.riverboat_set_aside = riverboat_set_aside
+        elif any(c.name == "Riverboat" for c in kingdom_cards):
+            self.riverboat_set_aside = self._pick_riverboat_set_aside(kingdom_cards)
 
         # Initialize players
         for player in self.players:
@@ -126,6 +177,31 @@ class GameState:
 
         self.log_callback("Game initialized with players: " + ", ".join(player_descriptions))
         self.log_callback("Kingdom cards: " + ", ".join(c.name for c in kingdom_cards))
+
+    def _pick_riverboat_set_aside(self, kingdom_cards: list[Card]) -> "Card | None":
+        """Choose a non-Duration Action card costing exactly $5 not in the supply.
+
+        Used at game setup when Riverboat is in the kingdom and the caller
+        didn't pass an explicit set-aside card.
+        """
+        in_kingdom = {c.name for c in kingdom_cards}
+        for name in get_all_card_names():
+            if name in in_kingdom:
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            if not card.is_action:
+                continue
+            if card.is_duration:
+                continue
+            if getattr(card, "is_event", False) or getattr(card, "is_project", False):
+                continue
+            if card.cost.coins != 5 or card.cost.debt != 0 or card.cost.potions != 0:
+                continue
+            return card
+        return None
 
     def setup_supply(self, kingdom_cards: list[Card]):
         """Set up the initial supply piles."""
@@ -289,6 +365,7 @@ class GameState:
         player.insignia_active = False
         player.fortune_doubled_this_turn = False
         player.harbor_village_pending = 0
+        player.continue_used_this_turn = False
 
         # Return any cards delayed by the Delay event
         if self.current_player.delayed_cards:
@@ -302,6 +379,10 @@ class GameState:
         # Resolve Ally effects (e.g. Cave Dwellers' Favor-spending hook)
         for ally in self.allies:
             ally.on_turn_start(self, self.current_player)
+
+        # Rising Sun: Prophecy start-of-turn hook (Kind Emperor)
+        if self.prophecy is not None and self.prophecy.is_active:
+            self.prophecy.on_turn_start(self, self.current_player)
 
         # Log turn header with complete state
         resources = {
@@ -373,11 +454,27 @@ class GameState:
     def handle_action_phase(self):
         """Handle the action phase of a turn."""
         player = self.current_player
+        enlightened = (
+            self.prophecy is not None
+            and self.prophecy.is_active
+            and self.prophecy.name == "Enlightenment"
+        )
 
         while True:
             action_cards = [card for card in player.hand if card.is_action]
+            # Rising Sun: Enlightenment turns Treasures into Actions for all
+            # purposes — they can be played from your hand in the Action phase.
+            if enlightened:
+                action_cards += [
+                    card for card in player.hand
+                    if card.is_treasure and not card.is_action
+                ]
+            # Rising Sun: Shadow cards may be played from the deck whenever
+            # you could normally play an Action.
+            shadow_in_deck = [card for card in player.deck if card.is_shadow]
+            playable = action_cards + shadow_in_deck
 
-            if not action_cards:
+            if not playable:
                 break
 
             if player.actions == 0:
@@ -395,7 +492,7 @@ class GameState:
                 else:
                     break
 
-            choice = player.ai.choose_action(self, action_cards + [None])
+            choice = player.ai.choose_action(self, playable + [None])
             if choice is None:
                 break
 
@@ -425,7 +522,11 @@ class GameState:
             player.actions -= 1
             player.actions_played += 1
             player.actions_this_turn += 1
-            player.hand.remove(choice)
+            # Shadow cards are played from the deck; everything else from hand.
+            if choice in player.hand:
+                player.hand.remove(choice)
+            elif choice in player.deck:
+                player.deck.remove(choice)
             player.in_play.append(choice)
             # Track coins before play for Harbor Village bonus
             coins_before_action = player.coins
@@ -448,11 +549,30 @@ class GameState:
                         if flagship in player.duration:
                             player.duration.remove(flagship)
 
-                plays = 1 + len(flagships_to_resolve)
+                # Rising Sun: Daimyo replays the next non-Command Action.
+                # Multiple Daimyos stack and all replay the same card.
+                daimyo_replays = 0
+                if not getattr(choice, "is_command", False):
+                    daimyo_replays = getattr(player, "daimyo_pending", 0)
+                    player.daimyo_pending = 0
+
+                plays = 1 + len(flagships_to_resolve) + daimyo_replays
                 for _ in range(plays):
-                    choice.on_play(self)
+                    if enlightened and choice.is_treasure and not choice.is_action:
+                        # Treasure played in Action phase under Enlightenment:
+                        # +1 Card, +1 Action (instead of its normal text).
+                        self.draw_cards(player, 1)
+                        player.actions += 1
+                    else:
+                        choice.on_play(self)
                     if training_pile and choice.name == training_pile:
                         player.coins += 1
+
+                    # Rising Sun: Prophecy hooks fire after each play
+                    if self.prophecy is not None and self.prophecy.is_active:
+                        self.prophecy.on_play_action(self, player, choice)
+                        if choice.is_attack:
+                            self.prophecy.on_play_attack(self, player, choice)
 
             # Harbor Village bonus: +$1 if the action gave +$
             if harbor_pending > 0 and choice.name != "Harbor Village":
@@ -479,6 +599,17 @@ class GameState:
         if player.envious:
             player.envious = False
             player.envious_effect_active = True
+
+        # Rising Sun Flourishing Trade: leftover Action plays become Buys.
+        if (
+            self.prophecy is not None
+            and self.prophecy.is_active
+            and self.prophecy.name == "Flourishing Trade"
+            and player.actions > 0
+        ):
+            converted = player.actions
+            player.actions = 0
+            player.buys += converted
 
     def handle_treasure_phase(self):
         """Handle the treasure phase of a turn."""
@@ -522,6 +653,10 @@ class GameState:
                 ):
                     player.coins = coins_before + 1
                     coins_after = player.coins
+
+                # Rising Sun: Prophecy hooks fire after each treasure plays
+                if self.prophecy is not None and self.prophecy.is_active:
+                    self.prophecy.on_play_treasure(self, player, choice)
 
             remaining = [c.name for c in player.hand if c.is_treasure]
             context = {
@@ -658,6 +793,10 @@ class GameState:
         if quarry_discount and card.is_action:
             cost -= 2 * quarry_discount
 
+        # Rising Sun: Flourishing Trade and other cost-modifying Prophecies.
+        if self.prophecy is not None and self.prophecy.is_active:
+            cost += self.prophecy.cost_modifier(self, player, card)
+
         return max(0, cost)
 
     def _get_affordable_cards(self, player):
@@ -744,6 +883,15 @@ class GameState:
         player.actions_this_turn = 0
         player.bought_this_turn = []
 
+        # Rising Sun: Prophecy cleanup-start hook (Biding Time, Sickness)
+        if self.prophecy is not None and self.prophecy.is_active:
+            self.prophecy.on_cleanup_start(self, player)
+
+        # Rising Sun: Cards in play with cleanup-start triggers (River Shrine)
+        for card in list(player.in_play):
+            if hasattr(card, "on_cleanup_start"):
+                card.on_cleanup_start(self)
+
         # Discard hand and in-play cards
         scheme_count = sum(1 for card in player.in_play if card.name == "Scheme")
         if scheme_count:
@@ -800,6 +948,14 @@ class GameState:
                 and getattr(player, "walled_villages_played", 0) <= 1
             ):
                 player.deck.insert(0, card)
+            elif (
+                card.is_treasure
+                and getattr(player, "panic_active", False)
+                and card.name in self.supply
+            ):
+                # Rising Sun Panic: discarded Treasures return to their pile
+                # (essentially a one-shot Treasure under Panic).
+                self.supply[card.name] = self.supply.get(card.name, 0) + 1
             else:
                 if card.name == "Capital":
                     player.debt += 6
@@ -823,6 +979,12 @@ class GameState:
 
         # Draw new hand
         player.draw_cards(5)
+
+        # Rising Sun Foresight: cards set aside earlier go into hand after
+        # drawing the next hand.
+        if getattr(player, "foresight_set_aside", None):
+            player.hand.extend(player.foresight_set_aside)
+            player.foresight_set_aside = []
 
         # Tireless: put set-aside cards on top of deck after drawing
         for card in tireless_set_aside:
@@ -1118,6 +1280,16 @@ class GameState:
         self._handle_gatekeeper_exile(player, actual_card, destination_is_deck, reclaimed)
 
         actual_card.on_gain(self, player)
+
+        # Rising Sun: Kintsugi event needs to know whether the player has
+        # ever gained a Gold.
+        if actual_card.name == "Gold":
+            player.kintsugi_has_gained_gold = True
+
+        # Rising Sun: Prophecy on-gain hook (Bureaucracy, Growth, Harsh Winter,
+        # Progress, Rapid Expansion all care about gains).
+        if self.prophecy is not None and self.prophecy.is_active:
+            self.prophecy.on_gain(self, player, actual_card)
 
         self._handle_trade_route_token(actual_card)
         self._handle_watchtower_reaction(player, actual_card)

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -90,6 +90,20 @@ class GameState:
     def current_player(self) -> PlayerState:
         return self.players[self.current_player_index]
 
+    def fire_prophecy_action_hooks(self, player: PlayerState, card: Card) -> None:
+        """Fire the active Prophecy's after-Action-play hooks for ``card``.
+
+        Used by Continue / Riverboat / Practice and any other code path that
+        plays an Action card outside ``handle_action_phase``. The hooks are
+        the same ones the action phase loop fires after each Action play
+        (Great Leader's +1 Action, Approaching Army's +$1 from Attacks).
+        """
+        if self.prophecy is None or not self.prophecy.is_active:
+            return
+        self.prophecy.on_play_action(self, player, card)
+        if card.is_attack:
+            self.prophecy.on_play_attack(self, player, card)
+
     def remove_sun_token(self, count: int = 1) -> None:
         """Omen +1 Sun: remove ``count`` Sun tokens from the active Prophecy.
 

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -59,6 +59,18 @@ class PlayerState:
     charm_next_buy_copies: int = 0
     walled_villages_played: int = 0
     fortune_doubled_this_turn: bool = False
+    # Rising Sun: Daimyo replays the next non-Command Action card played
+    daimyo_pending: int = 0
+    continue_used_this_turn: bool = False
+    foresight_set_aside: list = field(default_factory=list)
+    # Rising Sun: Kintsugi event cares whether Gold has ever been gained.
+    kintsugi_has_gained_gold: bool = False
+    # Rising Sun: Prophecy-driven per-player state
+    biding_time_set_aside: list = field(default_factory=list)
+    good_harvest_used_this_turn: bool = False
+    panic_active: bool = False
+    rapid_expansion_set_aside: list = field(default_factory=list)
+    flourishing_trade_active: bool = False
 
     # Turn tracking
     turns_taken: int = 0
@@ -139,6 +151,15 @@ class PlayerState:
         self.charm_next_buy_copies = 0
         self.walled_villages_played = 0
         self.fortune_doubled_this_turn = False
+        self.daimyo_pending = 0
+        self.continue_used_this_turn = False
+        self.foresight_set_aside = []
+        self.kintsugi_has_gained_gold = False
+        self.biding_time_set_aside = []
+        self.good_harvest_used_this_turn = False
+        self.panic_active = False
+        self.rapid_expansion_set_aside = []
+        self.flourishing_trade_active = False
         self.turns_taken = 0
         self.actions_played = 0
         self.actions_this_turn = 0
@@ -187,11 +208,27 @@ class PlayerState:
         return drawn
 
     def shuffle_discard_into_deck(self):
-        """Shuffle discard pile to create new deck, respecting Stash."""
+        """Shuffle discard pile to create new deck.
+
+        Respects Stash (top) and Rising Sun Shadow cards (bottom).
+        Cards at index 0 are the bottom of the deck (drawn last); cards at
+        the end are the top (drawn first via ``deck.pop()``).
+        """
         stash_cards = [card for card in self.discard if card.name == "Stash"]
-        others = [card for card in self.discard if card.name != "Stash"]
+        shadows = [
+            card
+            for card in self.discard
+            if card.name != "Stash" and getattr(card, "is_shadow", False)
+        ]
+        others = [
+            card
+            for card in self.discard
+            if card.name != "Stash" and not getattr(card, "is_shadow", False)
+        ]
         random.shuffle(others)
-        self.deck = others + stash_cards
+        # Shadows live at the bottom of the deck (index 0..) per Rising Sun
+        # rules; everything else is shuffled normally on top of them.
+        self.deck = shadows + others + stash_cards
         self.discard = []
 
     def count_in_deck(self, card_name: str) -> int:

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -67,7 +67,7 @@ class PlayerState:
     kintsugi_has_gained_gold: bool = False
     # Rising Sun: Prophecy-driven per-player state
     biding_time_set_aside: list = field(default_factory=list)
-    good_harvest_used_this_turn: bool = False
+    good_harvest_treasures_played: set = field(default_factory=set)
     panic_active: bool = False
     rapid_expansion_set_aside: list = field(default_factory=list)
     flourishing_trade_active: bool = False
@@ -156,7 +156,7 @@ class PlayerState:
         self.foresight_set_aside = []
         self.kintsugi_has_gained_gold = False
         self.biding_time_set_aside = []
-        self.good_harvest_used_this_turn = False
+        self.good_harvest_treasures_played = set()
         self.panic_active = False
         self.rapid_expansion_set_aside = []
         self.flourishing_trade_active = False

--- a/dominion/prophecies/__init__.py
+++ b/dominion/prophecies/__init__.py
@@ -1,0 +1,25 @@
+from .base_prophecy import Prophecy
+
+# Side-effect imports register each subclass with PROPHECY_TYPES via the
+# @register decorator.
+from . import (  # noqa: F401
+    approaching_army,
+    biding_time,
+    bureaucracy,
+    divine_wind,
+    enlightenment,
+    flourishing_trade,
+    good_harvest,
+    great_leader,
+    growth,
+    harsh_winter,
+    kind_emperor,
+    panic,
+    progress,
+    rapid_expansion,
+    sickness,
+)
+from .registry import PROPHECY_TYPES, get_prophecy
+
+__all__ = ['Prophecy', 'PROPHECY_TYPES', 'get_prophecy']
+

--- a/dominion/prophecies/approaching_army.py
+++ b/dominion/prophecies/approaching_army.py
@@ -1,0 +1,42 @@
+"""Approaching Army Prophecy."""
+
+from dataclasses import dataclass, field
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class ApproachingArmy(Prophecy):
+    name: str = "Approaching Army"
+    description: str = (
+        "Setup: add an Attack pile to the Supply. While active: +$1 from each "
+        "Attack card you play."
+    )
+
+    def setup(self, game_state) -> None:
+        from dominion.cards.registry import CARD_TYPES, get_card
+
+        existing = set(game_state.supply.keys())
+        for name in CARD_TYPES.keys():
+            if name in existing:
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            if not card.is_attack:
+                continue
+            if getattr(card, "is_event", False) or getattr(card, "is_project", False):
+                continue
+            if card.cost.potions > 0:
+                continue
+            game_state.supply[card.name] = card.starting_supply(game_state)
+            game_state.log_callback(
+                f"Approaching Army adds Attack pile: {card.name}"
+            )
+            return
+
+    def on_play_attack(self, game_state, player, card) -> None:
+        player.coins += 1

--- a/dominion/prophecies/approaching_army.py
+++ b/dominion/prophecies/approaching_army.py
@@ -33,6 +33,12 @@ class ApproachingArmy(Prophecy):
             if card.cost.potions > 0:
                 continue
             game_state.supply[card.name] = card.starting_supply(game_state)
+            # Marauder, Pillage, etc. require companion piles (Ruins, Spoils,
+            # Joust prizes). Add anything the Attack declares so the new pile
+            # functions in play.
+            for pile_name, count in card.get_additional_piles().items():
+                if pile_name not in game_state.supply:
+                    game_state.supply[pile_name] = count
             game_state.log_callback(
                 f"Approaching Army adds Attack pile: {card.name}"
             )

--- a/dominion/prophecies/base_prophecy.py
+++ b/dominion/prophecies/base_prophecy.py
@@ -1,0 +1,71 @@
+"""Base class for Rising Sun Prophecies.
+
+A Prophecy is a global rule change that activates once all Sun tokens are
+removed from it. Until then it sits on the table and doesn't do anything.
+Omens are how Sun tokens get removed (each Omen produces +1 Sun token,
+which removes one from the active Prophecy).
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Prophecy:
+    name: str = "Prophecy"
+    description: str = ""
+
+    def __post_init__(self):
+        self.is_active = False
+
+    def setup(self, game_state) -> None:
+        """Called once at game start. Override for prophecies that change
+        the supply or game setup (e.g. Approaching Army adds an Attack pile).
+        """
+        pass
+
+    def activate(self, game_state) -> None:
+        """Called when the last Sun token is removed."""
+        self.is_active = True
+        game_state.log_callback(("action", "Prophecy", f"{self.name} activates", {}))
+        self.on_activate(game_state)
+
+    def on_activate(self, game_state) -> None:
+        """Override for prophecies whose effect fires once on activation
+        (e.g. Divine Wind, Kind Emperor's first trigger).
+        """
+        pass
+
+    # ------------------------------------------------------------------
+    # Hooks called from game_state. Default no-ops; override as needed.
+    # ------------------------------------------------------------------
+
+    def on_play_action(self, game_state, player, card) -> None:
+        """Fired after each Action card finishes resolving while active."""
+        pass
+
+    def on_play_treasure(self, game_state, player, card) -> None:
+        """Fired after each Treasure card resolves while active."""
+        pass
+
+    def on_play_attack(self, game_state, player, card) -> None:
+        """Fired after each Attack card finishes resolving while active.
+
+        Used by Approaching Army (+$1 from each Attack played).
+        """
+        pass
+
+    def on_gain(self, game_state, player, card) -> None:
+        """Fired after a card is gained while active."""
+        pass
+
+    def on_turn_start(self, game_state, player) -> None:
+        """Fired at the start of each player's turn while active."""
+        pass
+
+    def on_cleanup_start(self, game_state, player) -> None:
+        """Fired at the start of cleanup, before discarding hand."""
+        pass
+
+    def cost_modifier(self, game_state, player, card) -> int:
+        """Return a modifier applied to the card's coin cost. Negative reduces."""
+        return 0

--- a/dominion/prophecies/biding_time.py
+++ b/dominion/prophecies/biding_time.py
@@ -1,0 +1,26 @@
+"""Biding Time Prophecy."""
+
+from dataclasses import dataclass
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class BidingTime(Prophecy):
+    name: str = "Biding Time"
+    description: str = (
+        "While active: instead of discarding unplayed cards in Clean-up, set "
+        "them aside; put them back into your hand at the start of your next turn."
+    )
+
+    def on_cleanup_start(self, game_state, player) -> None:
+        # Move all hand cards to a side stash to be returned next turn.
+        player.biding_time_set_aside.extend(player.hand)
+        player.hand = []
+
+    def on_turn_start(self, game_state, player) -> None:
+        if player.biding_time_set_aside:
+            player.hand.extend(player.biding_time_set_aside)
+            player.biding_time_set_aside = []

--- a/dominion/prophecies/bureaucracy.py
+++ b/dominion/prophecies/bureaucracy.py
@@ -1,0 +1,29 @@
+"""Bureaucracy Prophecy."""
+
+from dataclasses import dataclass
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class Bureaucracy(Prophecy):
+    name: str = "Bureaucracy"
+    description: str = (
+        "While active: when you gain a card with $ in its cost (cost.coins>0 "
+        "and not pure-Debt), gain a Copper."
+    )
+
+    def on_gain(self, game_state, player, card) -> None:
+        from dominion.cards.registry import get_card
+
+        if card.name == "Copper":
+            return
+        if card.cost.coins <= 0:
+            # Pure-Debt cost cards (or $0 cards) don't trigger Bureaucracy.
+            return
+        if game_state.supply.get("Copper", 0) <= 0:
+            return
+        game_state.supply["Copper"] -= 1
+        game_state.gain_card(player, get_card("Copper"))

--- a/dominion/prophecies/divine_wind.py
+++ b/dominion/prophecies/divine_wind.py
@@ -1,0 +1,60 @@
+"""Divine Wind Prophecy."""
+
+import random
+from dataclasses import dataclass
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class DivineWind(Prophecy):
+    name: str = "Divine Wind"
+    description: str = (
+        "On activation: the 10 Kingdom Supply piles are removed, and 10 new "
+        "Kingdom card piles are dealt out."
+    )
+
+    def on_activate(self, game_state) -> None:
+        from dominion.cards.registry import CARD_TYPES, get_card
+
+        protected = {
+            "Copper", "Silver", "Gold", "Platinum",
+            "Estate", "Duchy", "Province", "Colony",
+            "Curse", "Potion",
+        }
+        # Anything that isn't a basic / non-supply pile is treated as a
+        # Kingdom pile to remove.
+        old_kingdom = [
+            name for name in list(game_state.supply.keys())
+            if name not in protected
+        ]
+        for name in old_kingdom:
+            del game_state.supply[name]
+
+        # Pick 10 fresh Kingdom-eligible cards not previously in the supply.
+        candidates = []
+        for name, cls in CARD_TYPES.items():
+            if name in protected or name in old_kingdom:
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            if getattr(card, "is_event", False) or getattr(card, "is_project", False):
+                continue
+            if card.is_victory and not card.is_action:
+                continue
+            candidates.append(card)
+
+        random.shuffle(candidates)
+        added = 0
+        for card in candidates:
+            if added >= 10:
+                break
+            game_state.supply[card.name] = card.starting_supply(game_state)
+            added += 1
+        game_state.log_callback(
+            f"Divine Wind: replaced {len(old_kingdom)} Kingdom piles with {added} new ones"
+        )

--- a/dominion/prophecies/divine_wind.py
+++ b/dominion/prophecies/divine_wind.py
@@ -19,24 +19,24 @@ class DivineWind(Prophecy):
     def on_activate(self, game_state) -> None:
         from dominion.cards.registry import CARD_TYPES, get_card
 
-        protected = {
-            "Copper", "Silver", "Gold", "Platinum",
-            "Estate", "Duchy", "Province", "Colony",
-            "Curse", "Potion",
-        }
-        # Anything that isn't a basic / non-supply pile is treated as a
-        # Kingdom pile to remove.
-        old_kingdom = [
-            name for name in list(game_state.supply.keys())
-            if name not in protected
-        ]
-        for name in old_kingdom:
-            del game_state.supply[name]
+        # Per rulebook: only the Kingdom Supply piles used this game are
+        # removed. Basic piles (Copper/Silver/Gold/Platinum, Estate/Duchy/
+        # Province/Colony, Curse, Potion) and non-Kingdom support piles
+        # (Ruins, Spoils, Horse, Madman, Mercenary, Loot, Bystander/Joust
+        # rewards, etc.) stay — we identify the Kingdom piles by the snapshot
+        # taken at initialize_game time.
+        kingdom_pile_names = list(getattr(game_state, "original_kingdom_pile_names", set()))
+        removed = []
+        for name in kingdom_pile_names:
+            if name in game_state.supply:
+                del game_state.supply[name]
+                removed.append(name)
 
         # Pick 10 fresh Kingdom-eligible cards not previously in the supply.
+        previously_in_supply = set(removed) | set(game_state.supply.keys())
         candidates = []
         for name, cls in CARD_TYPES.items():
-            if name in protected or name in old_kingdom:
+            if name in previously_in_supply:
                 continue
             try:
                 card = get_card(name)
@@ -44,7 +44,10 @@ class DivineWind(Prophecy):
                 continue
             if getattr(card, "is_event", False) or getattr(card, "is_project", False):
                 continue
+            # Skip pure Victory cards and Curses as Kingdom replacements.
             if card.is_victory and not card.is_action:
+                continue
+            if card.name == "Curse":
                 continue
             candidates.append(card)
 
@@ -54,7 +57,10 @@ class DivineWind(Prophecy):
             if added >= 10:
                 break
             game_state.supply[card.name] = card.starting_supply(game_state)
+            # Track the new pile so a second Divine Wind (extremely unlikely)
+            # would also remove it.
+            game_state.original_kingdom_pile_names.add(card.name)
             added += 1
         game_state.log_callback(
-            f"Divine Wind: replaced {len(old_kingdom)} Kingdom piles with {added} new ones"
+            f"Divine Wind: replaced {len(removed)} Kingdom piles with {added} new ones"
         )

--- a/dominion/prophecies/enlightenment.py
+++ b/dominion/prophecies/enlightenment.py
@@ -1,0 +1,23 @@
+"""Enlightenment Prophecy."""
+
+from dataclasses import dataclass
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class Enlightenment(Prophecy):
+    name: str = "Enlightenment"
+    description: str = (
+        "While active: Treasures are Actions for all purposes. If played in "
+        "the Action phase, they produce +1 Card and +1 Action instead of "
+        "their normal effects."
+    )
+
+    def on_activate(self, game_state) -> None:
+        # The Action-phase substitution is handled at play time by the action
+        # phase loop checking the prophecy. The "treasures are actions" rule
+        # is exposed via Card.is_action which checks this prophecy.
+        pass

--- a/dominion/prophecies/flourishing_trade.py
+++ b/dominion/prophecies/flourishing_trade.py
@@ -1,0 +1,26 @@
+"""Flourishing Trade Prophecy."""
+
+from dataclasses import dataclass
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class FlourishingTrade(Prophecy):
+    name: str = "Flourishing Trade"
+    description: str = (
+        "While active: all cards cost $1 less (minimum $0). You can use "
+        "remaining Action plays as extra Buys in the Buy phase."
+    )
+
+    def cost_modifier(self, game_state, player, card) -> int:
+        # Per rulebook: cost lowering does not affect Event costs; this
+        # method is only invoked for cards (events handle costs separately).
+        return -1
+
+    def on_turn_start(self, game_state, player) -> None:
+        # Convert leftover Action plays into Buys at the buy phase. We do
+        # this lazily via a player flag picked up in handle_buy_phase.
+        player.flourishing_trade_active = True

--- a/dominion/prophecies/good_harvest.py
+++ b/dominion/prophecies/good_harvest.py
@@ -11,15 +11,20 @@ from .registry import register
 class GoodHarvest(Prophecy):
     name: str = "Good Harvest"
     description: str = (
-        "While active: the first time you play a Treasure each turn, "
-        "+1 Buy and +$1."
+        "While active: the first time you play each differently named "
+        "Treasure each turn, +1 Buy and +$1."
     )
 
     def on_turn_start(self, game_state, player) -> None:
-        player.good_harvest_used_this_turn = False
+        player.good_harvest_treasures_played = set()
 
     def on_play_treasure(self, game_state, player, card) -> None:
-        if not getattr(player, "good_harvest_used_this_turn", False):
-            player.good_harvest_used_this_turn = True
-            player.coins += 1
-            player.buys += 1
+        seen = getattr(player, "good_harvest_treasures_played", None)
+        if seen is None:
+            seen = set()
+            player.good_harvest_treasures_played = seen
+        if card.name in seen:
+            return
+        seen.add(card.name)
+        player.coins += 1
+        player.buys += 1

--- a/dominion/prophecies/good_harvest.py
+++ b/dominion/prophecies/good_harvest.py
@@ -1,0 +1,25 @@
+"""Good Harvest Prophecy."""
+
+from dataclasses import dataclass
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class GoodHarvest(Prophecy):
+    name: str = "Good Harvest"
+    description: str = (
+        "While active: the first time you play a Treasure each turn, "
+        "+1 Buy and +$1."
+    )
+
+    def on_turn_start(self, game_state, player) -> None:
+        player.good_harvest_used_this_turn = False
+
+    def on_play_treasure(self, game_state, player, card) -> None:
+        if not getattr(player, "good_harvest_used_this_turn", False):
+            player.good_harvest_used_this_turn = True
+            player.coins += 1
+            player.buys += 1

--- a/dominion/prophecies/great_leader.py
+++ b/dominion/prophecies/great_leader.py
@@ -1,0 +1,18 @@
+"""Great Leader Prophecy."""
+
+from dataclasses import dataclass
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class GreatLeader(Prophecy):
+    name: str = "Great Leader"
+    description: str = (
+        "While active: after each Action card you play, +1 Action."
+    )
+
+    def on_play_action(self, game_state, player, card) -> None:
+        player.actions += 1

--- a/dominion/prophecies/growth.py
+++ b/dominion/prophecies/growth.py
@@ -1,0 +1,51 @@
+"""Growth Prophecy."""
+
+from dataclasses import dataclass
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class Growth(Prophecy):
+    name: str = "Growth"
+    description: str = (
+        "While active: when you gain a Treasure, gain a cheaper card. "
+        "(Can chain: gaining the cheaper Treasure can trigger again.)"
+    )
+
+    def on_gain(self, game_state, player, card) -> None:
+        from dominion.cards.registry import get_card
+
+        if not card.is_treasure:
+            return
+        triggered_cost = game_state.get_card_cost(player, card)
+
+        candidates = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            try:
+                candidate = get_card(name)
+            except ValueError:
+                continue
+            if candidate.cost.debt > 0 or candidate.cost.potions > 0:
+                continue
+            if game_state.get_card_cost(player, candidate) >= triggered_cost:
+                continue
+            if not candidate.may_be_bought(game_state):
+                continue
+            candidates.append(candidate)
+
+        if not candidates:
+            return
+        chosen = player.ai.choose_buy(game_state, candidates + [None])
+        # Per rulebook: "This is not optional; if you gain a Treasure, you
+        # have to gain a cheaper card if you can."
+        if chosen is None:
+            chosen = max(candidates, key=lambda c: (c.cost.coins, c.name))
+        if game_state.supply.get(chosen.name, 0) <= 0:
+            return
+        game_state.supply[chosen.name] -= 1
+        game_state.gain_card(player, chosen)

--- a/dominion/prophecies/harsh_winter.py
+++ b/dominion/prophecies/harsh_winter.py
@@ -1,0 +1,31 @@
+"""Harsh Winter Prophecy."""
+
+from dataclasses import dataclass
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class HarshWinter(Prophecy):
+    name: str = "Harsh Winter"
+    description: str = (
+        "While active: when you gain a card on someone else's turn, put a "
+        "Debt token on its pile. When you gain a card with Debt in its cost, "
+        "remove all Debt tokens from its pile and take that much Debt."
+    )
+
+    def on_gain(self, game_state, player, card) -> None:
+        pile_name = card.name
+        # Off-turn gain → add a debt token to the pile
+        if player is not game_state.current_player:
+            game_state.harsh_winter_debt[pile_name] = (
+                game_state.harsh_winter_debt.get(pile_name, 0) + 1
+            )
+            return
+
+        # On-turn gain of a card whose cost has debt → take pile's debt
+        if card.cost.debt > 0 and game_state.harsh_winter_debt.get(pile_name, 0) > 0:
+            tokens = game_state.harsh_winter_debt.pop(pile_name)
+            player.debt += tokens

--- a/dominion/prophecies/harsh_winter.py
+++ b/dominion/prophecies/harsh_winter.py
@@ -11,21 +11,21 @@ from .registry import register
 class HarshWinter(Prophecy):
     name: str = "Harsh Winter"
     description: str = (
-        "While active: when you gain a card on someone else's turn, put a "
-        "Debt token on its pile. When you gain a card with Debt in its cost, "
-        "remove all Debt tokens from its pile and take that much Debt."
+        "While active: when you gain a card on your turn, if there's Debt on "
+        "its pile, take it; otherwise put 2 Debt on its pile. Off-turn gains "
+        "neither place nor take Debt."
     )
 
     def on_gain(self, game_state, player, card) -> None:
-        pile_name = card.name
-        # Off-turn gain → add a debt token to the pile
+        # Per rulebook clarification: "When it's not your turn, gaining a
+        # card neither puts on the pile nor removes from the pile."
         if player is not game_state.current_player:
-            game_state.harsh_winter_debt[pile_name] = (
-                game_state.harsh_winter_debt.get(pile_name, 0) + 1
-            )
             return
 
-        # On-turn gain of a card whose cost has debt → take pile's debt
-        if card.cost.debt > 0 and game_state.harsh_winter_debt.get(pile_name, 0) > 0:
-            tokens = game_state.harsh_winter_debt.pop(pile_name)
+        pile_name = card.name
+        tokens = game_state.harsh_winter_debt.get(pile_name, 0)
+        if tokens > 0:
+            del game_state.harsh_winter_debt[pile_name]
             player.debt += tokens
+        else:
+            game_state.harsh_winter_debt[pile_name] = 2

--- a/dominion/prophecies/kind_emperor.py
+++ b/dominion/prophecies/kind_emperor.py
@@ -1,0 +1,57 @@
+"""Kind Emperor Prophecy."""
+
+from dataclasses import dataclass
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class KindEmperor(Prophecy):
+    name: str = "Kind Emperor"
+    description: str = (
+        "While active: at the start of your turn, gain an Action card to "
+        "your hand. (The activating player gains one immediately.)"
+    )
+
+    def on_activate(self, game_state) -> None:
+        # Per rulebook: only the player who removed the last Sun token gains
+        # an Action immediately.
+        self._gain_action_to_hand(game_state, game_state.current_player)
+
+    def on_turn_start(self, game_state, player) -> None:
+        self._gain_action_to_hand(game_state, player)
+
+    def _gain_action_to_hand(self, game_state, player) -> None:
+        from dominion.cards.registry import get_card
+
+        candidates = []
+        for name, count in game_state.supply.items():
+            if count <= 0:
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            if not card.is_action:
+                continue
+            if not card.may_be_bought(game_state):
+                continue
+            candidates.append(card)
+        if not candidates:
+            return
+        chosen = player.ai.choose_buy(game_state, candidates + [None])
+        if chosen is None:
+            chosen = max(candidates, key=lambda c: (c.cost.coins, c.name))
+        if game_state.supply.get(chosen.name, 0) <= 0:
+            return
+        game_state.supply[chosen.name] -= 1
+        gained = game_state.gain_card(player, chosen)
+        # Move the gained card from wherever it landed (typically discard)
+        # into hand.
+        for zone in (player.discard, player.deck):
+            if gained in zone:
+                zone.remove(gained)
+                player.hand.append(gained)
+                return

--- a/dominion/prophecies/panic.py
+++ b/dominion/prophecies/panic.py
@@ -11,12 +11,12 @@ from .registry import register
 class Panic(Prophecy):
     name: str = "Panic"
     description: str = (
-        "While active: when you play a Treasure, +1 Buy. When you would "
+        "While active: when you play a Treasure, +2 Buys. When you would "
         "discard the Treasure from play, return it to its pile instead."
     )
 
     def on_play_treasure(self, game_state, player, card) -> None:
-        player.buys += 1
+        player.buys += 2
         # Cleanup-time return is handled by GameState.handle_cleanup_phase
         # via the panic_active flag below.
         player.panic_active = True

--- a/dominion/prophecies/panic.py
+++ b/dominion/prophecies/panic.py
@@ -1,0 +1,22 @@
+"""Panic Prophecy."""
+
+from dataclasses import dataclass
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class Panic(Prophecy):
+    name: str = "Panic"
+    description: str = (
+        "While active: when you play a Treasure, +1 Buy. When you would "
+        "discard the Treasure from play, return it to its pile instead."
+    )
+
+    def on_play_treasure(self, game_state, player, card) -> None:
+        player.buys += 1
+        # Cleanup-time return is handled by GameState.handle_cleanup_phase
+        # via the panic_active flag below.
+        player.panic_active = True

--- a/dominion/prophecies/progress.py
+++ b/dominion/prophecies/progress.py
@@ -1,0 +1,28 @@
+"""Progress Prophecy."""
+
+from dataclasses import dataclass
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class Progress(Prophecy):
+    name: str = "Progress"
+    description: str = (
+        "While active: when you gain a card, put it on top of your deck."
+    )
+
+    def on_gain(self, game_state, player, card) -> None:
+        # Move from wherever the gain landed to the top of the deck.
+        for zone in (player.discard, player.hand, player.deck):
+            if card in zone and zone is not player.deck:
+                zone.remove(card)
+                player.deck.append(card)
+                return
+        # Already on the deck (e.g. via insignia / royal seal)? Re-place it
+        # on top in case it was placed at the bottom.
+        if card in player.deck:
+            player.deck.remove(card)
+            player.deck.append(card)

--- a/dominion/prophecies/rapid_expansion.py
+++ b/dominion/prophecies/rapid_expansion.py
@@ -1,0 +1,35 @@
+"""Rapid Expansion Prophecy."""
+
+from dataclasses import dataclass
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class RapidExpansion(Prophecy):
+    name: str = "Rapid Expansion"
+    description: str = (
+        "While active: when you gain an Action or Treasure card, set it aside "
+        "and play it at the start of your next turn."
+    )
+
+    def on_gain(self, game_state, player, card) -> None:
+        if not (card.is_action or card.is_treasure):
+            return
+        # Move out of wherever the gain landed.
+        for zone in (player.discard, player.hand, player.deck):
+            if card in zone:
+                zone.remove(card)
+                break
+        player.rapid_expansion_set_aside.append(card)
+
+    def on_turn_start(self, game_state, player) -> None:
+        if not player.rapid_expansion_set_aside:
+            return
+        cards = list(player.rapid_expansion_set_aside)
+        player.rapid_expansion_set_aside = []
+        for card in cards:
+            player.in_play.append(card)
+            card.on_play(game_state)

--- a/dominion/prophecies/registry.py
+++ b/dominion/prophecies/registry.py
@@ -1,0 +1,22 @@
+"""Registry of Rising Sun Prophecies."""
+
+from typing import Type
+
+from .base_prophecy import Prophecy
+
+PROPHECY_TYPES: dict[str, Type[Prophecy]] = {}
+
+
+def register(cls: Type[Prophecy]) -> Type[Prophecy]:
+    """Decorator to register a Prophecy subclass by its instance ``name``."""
+    instance = cls()
+    PROPHECY_TYPES[instance.name] = cls
+    return cls
+
+
+def get_prophecy(name: str) -> Prophecy:
+    try:
+        prophecy_class = PROPHECY_TYPES[name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown prophecy: {name}") from exc
+    return prophecy_class()

--- a/dominion/prophecies/sickness.py
+++ b/dominion/prophecies/sickness.py
@@ -1,0 +1,45 @@
+"""Sickness Prophecy."""
+
+from dataclasses import dataclass
+
+from .base_prophecy import Prophecy
+from .registry import register
+
+
+@register
+@dataclass
+class Sickness(Prophecy):
+    name: str = "Sickness"
+    description: str = (
+        "While active: at the end of each player's turn (start of cleanup), "
+        "they gain a Curse onto their deck OR discard 3 cards."
+    )
+
+    def on_cleanup_start(self, game_state, player) -> None:
+        from dominion.cards.registry import get_card
+
+        choice = player.ai.choose_sickness_mode(game_state, player)
+        if choice == "curse":
+            if game_state.supply.get("Curse", 0) > 0:
+                game_state.supply["Curse"] -= 1
+                # Per rulebook: gain to deck. If pile is empty, the player
+                # may still choose to gain a Curse (gain nothing then).
+                gained = game_state.gain_card(player, get_card("Curse"), to_deck=True)
+                # Ensure on top of deck
+                if gained in player.discard:
+                    player.discard.remove(gained)
+                    player.deck.append(gained)
+            return
+
+        # Discard 3 cards from hand (as many as you can if fewer than 3)
+        count = min(3, len(player.hand))
+        if count <= 0:
+            return
+        chosen = player.ai.choose_cards_to_discard(
+            game_state, player, list(player.hand), count, reason="sickness"
+        )
+        chosen = chosen[:count]
+        for card in chosen:
+            if card in player.hand:
+                player.hand.remove(card)
+                game_state.discard_card(player, card)

--- a/dominion/prophecies/sickness.py
+++ b/dominion/prophecies/sickness.py
@@ -11,11 +11,11 @@ from .registry import register
 class Sickness(Prophecy):
     name: str = "Sickness"
     description: str = (
-        "While active: at the end of each player's turn (start of cleanup), "
-        "they gain a Curse onto their deck OR discard 3 cards."
+        "While active: at the start of each player's turn, they gain a Curse "
+        "onto their deck OR discard 3 cards."
     )
 
-    def on_cleanup_start(self, game_state, player) -> None:
+    def on_turn_start(self, game_state, player) -> None:
         from dominion.cards.registry import get_card
 
         choice = player.ai.choose_sickness_mode(game_state, player)

--- a/tests/test_continue_event.py
+++ b/tests/test_continue_event.py
@@ -1,16 +1,16 @@
-"""Tests for the Continue event from Plunder.
+"""Tests for the Continue event from Rising Sun.
 
-Continue's text: "$8: gain a non-Victory non-Command card costing up to $4,
-then play it." Two invariants under test:
+Continue's text: "$8: Once per turn. Gain an Action card costing up to $4
+that isn't an Attack card; return to your Action phase; play it. +1 Action,
++1 Buy."
 
-1. The "play it" clause applies to *any* gained card type (Action or
-   Treasure), not just Actions. A gained Silver should be played and add
-   its $2 to the player's coin pool.
-2. The play step must locate the gained card across all post-gain zones,
-   not just ``discard``. If a top-deck reaction (Royal Seal, Insignia, …)
-   places the gain on top of the deck, Continue must still find it there
-   and move it cleanly into ``in_play`` — leaving the same object in two
-   zones would corrupt later cleanup and draw.
+Notable invariants under test:
+
+1. Only Action cards (not Treasures, not Attacks) are valid targets.
+2. The buy is once-per-turn (a player flag prevents repeats within a turn).
+3. The play step locates the gained card across all post-gain zones (deck,
+   discard, hand) so reactions like Insignia or Villa don't leave the card
+   double-tracked.
 """
 
 from dominion.cards.registry import get_card
@@ -49,20 +49,37 @@ class _FixedTargetAI:
 def _new_state(target_name: str) -> tuple[GameState, PlayerState]:
     state = GameState(players=[])
     state.players = [PlayerState(_FixedTargetAI(target_name))]
-    # Include Villa in the kingdom so Continue can target it when asked.
     state.setup_supply([get_card("Village"), get_card("Villa")])
     state.players[0].coins = 8
     return state, state.players[0]
 
 
-def test_continue_plays_a_gained_treasure():
-    """Gaining Silver via Continue should add $2 to the coin pool."""
-    state, player = _new_state("Silver")
-    coins_before = player.coins
+def test_continue_plays_a_gained_action():
+    """Gaining Village via Continue should add it to in_play."""
+    state, player = _new_state("Village")
     Continue().on_buy(state, player)
-    # Silver is in_play and contributed +$2.
-    assert any(c.name == "Silver" for c in player.in_play), "Silver should be in_play after Continue"
-    assert player.coins == coins_before + 2, f"Silver should add $2; got {player.coins - coins_before}"
+    villages_in_play = [c for c in player.in_play if c.name == "Village"]
+    assert len(villages_in_play) == 1, "Village should be in_play after Continue"
+
+
+def test_continue_grants_action_and_buy():
+    """Continue grants +1 Action and +1 Buy regardless of what was gained."""
+    state, player = _new_state("Village")
+    actions_before = player.actions
+    buys_before = player.buys
+    Continue().on_buy(state, player)
+    # +1 Action from Continue itself, +2 from Village's play, -0 (gain doesn't
+    # consume an action).
+    assert player.actions >= actions_before + 1
+    assert player.buys == buys_before + 1
+
+
+def test_continue_marks_used_for_turn():
+    """Continue is once-per-turn — a second buy would be blocked."""
+    state, player = _new_state("Village")
+    Continue().on_buy(state, player)
+    assert player.continue_used_this_turn is True
+    assert Continue().may_be_bought(state, player) is False
 
 
 def test_continue_does_not_duplicate_topdecked_gains():
@@ -70,18 +87,16 @@ def test_continue_does_not_duplicate_topdecked_gains():
     cleanly without leaving the same object in both deck and in_play."""
     state, player = _new_state("Village")
     player.insignia_active = True
-    # Make the AI accept top-decking.
     player.ai.should_topdeck_with_insignia = lambda *a, **k: True
 
     Continue().on_buy(state, player)
 
-    # Locate the Village. It should be in_play exactly once and not in deck.
     villages_in_play = [c for c in player.in_play if c.name == "Village"]
     villages_in_deck = [c for c in player.deck if c.name == "Village"]
     villages_in_discard = [c for c in player.discard if c.name == "Village"]
-    assert len(villages_in_play) == 1, f"Village should be in_play once; in_play has {len(villages_in_play)}"
-    assert villages_in_deck == [], f"Village should not be left on deck; got {len(villages_in_deck)}"
-    assert villages_in_discard == [], f"Village should not be in discard pre-cleanup; got {len(villages_in_discard)}"
+    assert len(villages_in_play) == 1
+    assert villages_in_deck == []
+    assert villages_in_discard == []
 
 
 def test_continue_finds_gain_in_hand_for_villa():
@@ -91,8 +106,8 @@ def test_continue_finds_gain_in_hand_for_villa():
 
     villas_in_play = [c for c in player.in_play if c.name == "Villa"]
     villas_in_hand = [c for c in player.hand if c.name == "Villa"]
-    assert len(villas_in_play) == 1, "Villa should be in_play after Continue plays it"
-    assert villas_in_hand == [], "Villa should not be left in hand"
+    assert len(villas_in_play) == 1
+    assert villas_in_hand == []
 
 
 def test_continue_skips_play_if_gain_was_intercepted():
@@ -100,19 +115,15 @@ def test_continue_skips_play_if_gain_was_intercepted():
     not blindly append the card to in_play."""
     state, player = _new_state("Village")
 
-    # Patch gain_card to drop the card on the floor (simulating a Watchtower
-    # trash reaction) so the returned object lives in no normal zone.
     real_gain = state.gain_card
     intercepted: list = []
 
     def fake_gain(p, card, to_deck=False):
         intercepted.append(card)
-        # Don't add to any zone — caller must handle this gracefully.
         return card
 
     state.gain_card = fake_gain  # type: ignore[assignment]
 
-    # Should not raise, and Village should not appear in in_play (we skipped play).
     Continue().on_buy(state, player)
     assert not any(c.name == "Village" for c in player.in_play)
-    state.gain_card = real_gain  # restore (not strictly needed, fresh state)
+    state.gain_card = real_gain

--- a/tests/test_dark_ages_extra_cards.py
+++ b/tests/test_dark_ages_extra_cards.py
@@ -347,7 +347,7 @@ def test_samurai_skips_attack_for_small_hand():
     assert len(victim.hand) == 3  # unchanged
 
 
-def test_samurai_does_not_attack_four_card_hand():
+def test_samurai_trims_four_card_hand_to_three():
     ai1 = GainFirstBuyAI()
     ai2 = DummyAI()
     state = GameState(players=[])
@@ -365,8 +365,7 @@ def test_samurai_does_not_attack_four_card_hand():
     attacker.in_play.append(samurai)
     samurai.on_play(state)
 
-    # Samurai only attacks opponents with 5+ cards; a 4-card hand is immune.
-    assert len(victim.hand) == 4
+    assert len(victim.hand) == 3
 
 
 def test_samurai_on_duration_grants_one_coin_and_persists():

--- a/tests/test_rising_sun_cards.py
+++ b/tests/test_rising_sun_cards.py
@@ -643,3 +643,87 @@ def test_sickness_curse_or_discard():
     state.prophecy.on_cleanup_start(state, player)
     # Curse should have gone to deck (top)
     assert any(c.name == "Curse" for c in player.deck), "Curse should be on deck"
+
+
+# ---------------------------------------------------------------------------
+# Code review fixes (round 2)
+# ---------------------------------------------------------------------------
+
+
+def test_daimyo_pending_resets_at_turn_start():
+    """If Daimyo is the last Action played, the pending replay must NOT
+    leak into the next turn — Daimyo's text says 'this turn'.
+    """
+    state, player = _setup()
+    daimyo = get_card("Daimyo")
+    player.in_play = [daimyo]
+    player.deck = [get_card("Copper") for _ in range(5)]
+    daimyo.on_play(state)
+    assert player.daimyo_pending == 1, "Daimyo registers a pending replay"
+
+    # Simulate turn boundary by calling handle_start_phase
+    state.phase = "start"
+    state.handle_start_phase()
+    assert player.daimyo_pending == 0, "pending replay must clear at turn start"
+
+
+def test_divine_wind_preserves_non_kingdom_support_piles():
+    """Divine Wind only removes the original 10 Kingdom piles, not Ruins/
+    Spoils/etc. that were added via get_additional_piles.
+    """
+    state = GameState(players=[])
+    # Marauder's get_additional_piles adds Ruins and Spoils
+    state.initialize_game(
+        [_GainFirstAI()],
+        [get_card("Marauder"), get_card("Village")],
+    )
+    assert "Ruins" in state.supply, "setup adds Ruins via Marauder"
+    assert "Spoils" in state.supply, "setup adds Spoils via Marauder"
+
+    dw = get_prophecy("Divine Wind")
+    dw.activate(state)
+
+    # Marauder and Village should be gone (they were Kingdom piles)
+    assert "Marauder" not in state.supply
+    assert "Village" not in state.supply
+    # Support piles must remain
+    assert "Ruins" in state.supply, "Divine Wind should leave Ruins alone"
+    assert "Spoils" in state.supply, "Divine Wind should leave Spoils alone"
+    # Basic piles must remain
+    for basic in ("Copper", "Silver", "Gold", "Estate", "Duchy", "Province", "Curse"):
+        assert basic in state.supply, f"{basic} should still be in supply"
+
+
+def test_approaching_army_adds_attack_companion_piles():
+    """If Approaching Army adds Marauder, the Ruins and Spoils piles it
+    needs must also be created (otherwise gained Marauders/Loots break).
+    """
+    state = GameState(players=[])
+    # Use a kingdom with no Marauder so Approaching Army can add it
+    state.initialize_game([_GainFirstAI()], [get_card("Village")])
+
+    # Force Marauder selection by clearing the supply of any other Attacks
+    # and pre-validating Marauder is the candidate
+    aa = get_prophecy("Approaching Army")
+    # Force pick Marauder by ensuring it's the first eligible Attack found
+    # We just call setup directly; whichever Attack it picks must bring
+    # additional piles if it has any.
+    aa.setup(state)
+
+    # Find the added Attack pile (anything that wasn't there before this call)
+    added_attack = None
+    for name in state.supply:
+        try:
+            card = get_card(name)
+            if card.is_attack and name not in {"Village"}:
+                added_attack = card
+                break
+        except ValueError:
+            continue
+    assert added_attack is not None, "Approaching Army should have added an Attack pile"
+
+    # Whatever it added, every additional pile it declared should now exist.
+    for pile in added_attack.get_additional_piles():
+        assert pile in state.supply, (
+            f"{added_attack.name} requires pile {pile} but it wasn't added"
+        )

--- a/tests/test_rising_sun_cards.py
+++ b/tests/test_rising_sun_cards.py
@@ -450,6 +450,48 @@ def test_continue_is_once_per_turn():
     assert Continue().may_be_bought(state, player) is False
 
 
+def test_continue_returns_to_action_phase_for_more_plays():
+    """After Continue's gain plays, the player should be back in Action phase
+    and able to play remaining Actions from hand."""
+    state, player = _setup()
+    state.supply["Village"] = 10
+    # Hand: another Village ready to play after Continue resolves
+    player.hand = [get_card("Village")]
+    player.deck = [get_card("Copper") for _ in range(10)]
+    player.in_play = []
+    player.actions = 0  # only Continue's +1 Action enables hand play
+
+    coins_before = player.coins
+    actions_before = player.actions
+    get_event("Continue").on_buy(state, player)
+
+    # The gained Village played (in_play count), and the Village from hand
+    # also played because handle_action_phase ran after returning to Action.
+    village_plays = sum(1 for c in player.in_play if c.name == "Village")
+    assert village_plays == 2, f"expected 2 Villages in play, got {village_plays}"
+    assert state.phase == "buy", "should be back in Buy phase after Continue"
+
+
+def test_continue_fires_prophecy_hooks_on_gained_play():
+    """Great Leader is active: each Action play grants +1 Action. Continue's
+    play of the gained card must trigger the Prophecy hook just like a
+    normal Action-phase play would."""
+    state, player = _setup()
+    state.prophecy = get_prophecy("Great Leader")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+    state.supply["Village"] = 10
+    player.hand = []
+    player.in_play = []
+    player.deck = [get_card("Copper") for _ in range(5)]
+    actions_before = player.actions
+
+    get_event("Continue").on_buy(state, player)
+    # Continue: +1 Action; gained Village plays (+2 Actions); Great Leader
+    # fires after the play (+1 Action). Net = +4 actions over baseline.
+    assert player.actions >= actions_before + 4
+
+
 def test_kintsugi_requires_gold_for_gain():
     state, player = _setup()
     player.kintsugi_has_gained_gold = False

--- a/tests/test_rising_sun_cards.py
+++ b/tests/test_rising_sun_cards.py
@@ -554,20 +554,29 @@ def test_great_leader_grants_action_after_each_action_play():
     assert player.actions == actions_before + 3
 
 
-def test_good_harvest_first_treasure_per_turn():
+def test_good_harvest_first_of_each_treasure_name():
+    """Good Harvest fires the first time each differently-named Treasure
+    plays. Per rulebook: 4 Coppers + 1 Silver = +2 Buys, +$2 total."""
     state, player = _setup()
     state.prophecy = get_prophecy("Good Harvest")
     state.prophecy.is_active = True
     state.sun_tokens = 0
+    state.prophecy.on_turn_start(state, player)
 
     silver = get_card("Silver")
+    copper = get_card("Copper")
     coins_before = player.coins
+    buys_before = player.buys
+
+    # First Silver triggers
     state.prophecy.on_play_treasure(state, player, silver)
-    assert player.coins == coins_before + 1
-    assert player.buys >= 2  # +1 Buy
+    # Second Silver does NOT trigger (same name)
     state.prophecy.on_play_treasure(state, player, silver)
-    # No further bonus on the second treasure
-    assert player.coins == coins_before + 1
+    # First Copper triggers (different name)
+    state.prophecy.on_play_treasure(state, player, copper)
+
+    assert player.coins == coins_before + 2, "Silver and Copper each grant +$1"
+    assert player.buys == buys_before + 2, "Silver and Copper each grant +1 Buy"
 
 
 def test_bureaucracy_grants_copper_on_coin_cost_gain():
@@ -632,7 +641,9 @@ def test_growth_chains_treasure_gains():
     assert player.discard, "Growth should have gained a cheaper card"
 
 
-def test_sickness_curse_or_discard():
+def test_sickness_curse_or_discard_at_turn_start():
+    """Sickness fires at the start of each player's turn (per card text),
+    not at cleanup."""
     state, player = _setup()
     state.prophecy = get_prophecy("Sickness")
     state.prophecy.is_active = True
@@ -640,7 +651,7 @@ def test_sickness_curse_or_discard():
     state.supply["Curse"] = 30
     player.hand = [get_card("Estate") for _ in range(2)]  # only 2 junk → curse mode
 
-    state.prophecy.on_cleanup_start(state, player)
+    state.prophecy.on_turn_start(state, player)
     # Curse should have gone to deck (top)
     assert any(c.name == "Curse" for c in player.deck), "Curse should be on deck"
 
@@ -727,3 +738,60 @@ def test_approaching_army_adds_attack_companion_piles():
         assert pile in state.supply, (
             f"{added_attack.name} requires pile {pile} but it wasn't added"
         )
+
+
+def test_harsh_winter_first_on_turn_gain_places_two_debt_on_pile():
+    """Per card text: when you gain a card on your turn, if there's debt
+    on its pile, take it; otherwise put 2 Debt on the pile."""
+    state, player = _setup()
+    state.prophecy = get_prophecy("Harsh Winter")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+
+    village = get_card("Village")
+    state.prophecy.on_gain(state, player, village)
+    # First gain: pile had 0 debt → 2 placed
+    assert state.harsh_winter_debt.get("Village") == 2
+    # Player took no debt
+    assert player.debt == 0
+
+
+def test_harsh_winter_second_on_turn_gain_takes_pile_debt():
+    state, player = _setup()
+    state.prophecy = get_prophecy("Harsh Winter")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+
+    village = get_card("Village")
+    state.prophecy.on_gain(state, player, village)  # places 2 debt
+    state.prophecy.on_gain(state, player, village)  # takes those 2
+
+    assert state.harsh_winter_debt.get("Village", 0) == 0
+    assert player.debt == 2
+
+
+def test_harsh_winter_off_turn_gain_does_nothing():
+    state = _two_player_setup()
+    state.prophecy = get_prophecy("Harsh Winter")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+    p1, p2 = state.players
+    # Active turn = p1; p2 gains while not their turn
+    state.current_player_index = 0
+    village = get_card("Village")
+    state.prophecy.on_gain(state, p2, village)
+    assert state.harsh_winter_debt.get("Village", 0) == 0
+    assert p2.debt == 0
+
+
+def test_panic_grants_two_buys_per_treasure_play():
+    state, player = _setup()
+    state.prophecy = get_prophecy("Panic")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+
+    silver = get_card("Silver")
+    buys_before = player.buys
+    state.prophecy.on_play_treasure(state, player, silver)
+    assert player.buys == buys_before + 2
+    assert player.panic_active is True

--- a/tests/test_rising_sun_cards.py
+++ b/tests/test_rising_sun_cards.py
@@ -795,3 +795,47 @@ def test_panic_grants_two_buys_per_treasure_play():
     state.prophecy.on_play_treasure(state, player, silver)
     assert player.buys == buys_before + 2
     assert player.panic_active is True
+
+
+def test_riverboat_fires_prophecy_hooks_on_set_aside_play():
+    """Riverboat plays the set-aside card directly during the duration phase;
+    Great Leader (active) should still grant +1 Action after that play."""
+    state = GameState(players=[])
+    festival = get_card("Festival")
+    state.initialize_game(
+        [_GainFirstAI()],
+        [get_card("Village")],
+        riverboat_set_aside=festival,
+    )
+    state.prophecy = get_prophecy("Great Leader")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+
+    player = state.players[0]
+    riverboat = get_card("Riverboat")
+    player.duration = [riverboat]
+    riverboat.duration_persistent = True
+    actions_before = player.actions
+
+    riverboat.on_duration(state)
+    # Festival gives +2 Actions; Great Leader adds +1 after the play.
+    assert player.actions == actions_before + 3
+
+
+def test_practice_fires_prophecy_hooks_on_each_play():
+    """Practice plays the chosen Action twice; Great Leader should grant
+    +1 Action after each of those plays."""
+    state, player = _setup()
+    state.prophecy = get_prophecy("Great Leader")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+
+    village = get_card("Village")  # +1 Card +2 Actions
+    player.hand = [village]
+    player.deck = [get_card("Copper") for _ in range(10)]
+    actions_before = player.actions
+
+    get_event("Practice").on_buy(state, player)
+    # Village played twice → +4 Actions from Village; Great Leader fires
+    # twice → +2 Actions. Net +6 over baseline.
+    assert player.actions == actions_before + 6

--- a/tests/test_rising_sun_cards.py
+++ b/tests/test_rising_sun_cards.py
@@ -1,0 +1,603 @@
+"""Tests for Rising Sun kingdom cards, events, and prophecies."""
+
+from typing import Optional
+
+from dominion.cards.base_card import Card, CardType
+from dominion.cards.registry import get_card
+from dominion.events.registry import get_event
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from dominion.prophecies import get_prophecy
+
+from tests.utils import ChooseFirstActionAI, DummyAI
+
+
+class _GainFirstAI(ChooseFirstActionAI):
+    def choose_buy(self, state, choices):
+        for c in choices:
+            if c is not None:
+                return c
+        return None
+
+    def choose_card_to_trash(self, state, choices):
+        for c in choices:
+            if c is not None:
+                return c
+        return None
+
+    def choose_treasure(self, state, choices):
+        for c in choices:
+            if c is not None:
+                return c
+        return None
+
+
+def _setup(ai=None):
+    if ai is None:
+        ai = _GainFirstAI()
+    state = GameState(players=[])
+    state.initialize_game([ai], [get_card("Village")])
+    return state, state.players[0]
+
+
+def _two_player_setup():
+    state = GameState(players=[])
+    state.initialize_game([_GainFirstAI(), DummyAI()], [get_card("Village")])
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Kingdom cards
+# ---------------------------------------------------------------------------
+
+
+def test_alley_draws_action_and_discards():
+    state, player = _setup()
+    alley = get_card("Alley")
+    player.hand = [alley, get_card("Estate"), get_card("Copper")]
+    player.in_play = []
+    player.deck = [get_card("Silver"), get_card("Gold")]
+    player.actions = 1
+
+    # Simulate playing Alley from hand
+    player.hand.remove(alley)
+    player.in_play.append(alley)
+    alley.on_play(state)
+
+    # 2 cards left after removing Alley + 1 draw - 1 discard = 2
+    assert len(player.hand) == 2
+    # An Estate or Copper got discarded
+    assert any(c.name in ("Estate", "Copper") for c in player.discard)
+
+
+def test_artist_counts_other_cards_in_play():
+    state, player = _setup()
+    artist = get_card("Artist")
+    player.in_play = [get_card("Village"), get_card("Smithy"), artist]
+    player.duration = []
+    player.hand = []
+    player.deck = [get_card("Copper") for _ in range(5)]
+
+    artist.on_play(state)
+    # 3 cards in play (Village, Smithy, Artist). Only one Artist → counts itself
+    # → draw 3.
+    assert len(player.hand) == 3
+
+
+def test_change_with_debt_gives_three_coins():
+    state, player = _setup()
+    change = get_card("Change")
+    player.debt = 4
+    player.coins = 0
+    player.hand = [change]
+    player.in_play = []
+
+    player.hand.remove(change)
+    player.in_play.append(change)
+    change.on_play(state)
+
+    assert player.coins == 3
+    assert player.debt == 4  # debt unchanged by Change
+
+
+def test_craftsman_takes_debt_and_gains_up_to_5():
+    """Craftsman: take 2 Debt, gain a card costing up to $5 (excluding debt-cost cards)."""
+    state, player = _setup()
+    craftsman = get_card("Craftsman")
+    player.in_play = [craftsman]
+    debt_before = player.debt
+
+    state.supply["Mountain Shrine"] = 10  # debt-cost; not eligible
+    state.supply["Village"] = 10  # $3, eligible
+    state.supply["Silver"] = 40
+    craftsman.on_play(state)
+    # Craftsman takes 2 Debt
+    assert player.debt == debt_before + 2
+    # And a $5-or-less card was gained (Mountain Shrine cannot be picked)
+    assert not any(c.name == "Mountain Shrine" for c in player.discard)
+
+
+def test_daimyo_replays_next_action():
+    state, player = _setup()
+    daimyo = get_card("Daimyo")
+    village = get_card("Village")
+    player.hand = [daimyo, village]
+    player.in_play = []
+    player.deck = [get_card("Copper") for _ in range(10)]
+    player.actions = 1
+
+    # Play Daimyo
+    player.hand.remove(daimyo)
+    player.in_play.append(daimyo)
+    daimyo.on_play(state)
+    assert player.daimyo_pending == 1
+
+    # The action phase loop normally handles the replay; simulate it.
+    player.hand.remove(village)
+    player.in_play.append(village)
+    actions_before = player.actions
+    daimyo_replays = player.daimyo_pending
+    player.daimyo_pending = 0
+    plays = 1 + daimyo_replays
+    for _ in range(plays):
+        village.on_play(state)
+    # Village gives +2 actions per play, played twice
+    assert player.actions == actions_before + 4
+
+
+def test_fishmonger_basic_stats():
+    state, player = _setup()
+    fish = get_card("Fishmonger")
+    player.in_play = [fish]
+    fish.on_play(state)
+    assert player.coins == 1
+    assert player.buys == 2  # base 1 + Fishmonger's +1
+
+
+def test_gold_mine_optionally_gains_gold_with_debt():
+    state, player = _setup()
+    gold_mine = get_card("Gold Mine")
+    player.in_play = [gold_mine]
+    state.supply["Gold"] = 30
+    debt_before = player.debt
+    gold_count_before = sum(1 for c in player.discard if c.name == "Gold")
+    gold_mine.on_play(state)
+    after = sum(1 for c in player.discard if c.name == "Gold")
+    if after > gold_count_before:
+        assert player.debt >= debt_before + 4
+
+
+def test_litter_basic_stats():
+    state, player = _setup()
+    litter = get_card("Litter")
+    player.in_play = [litter]
+    player.deck = [get_card("Copper") for _ in range(5)]
+    actions_before = player.actions
+    debt_before = player.debt
+    litter.on_play(state)
+    # +2 Cards, +2 Actions, +1 Debt (NOT +1 Buy)
+    assert player.actions == actions_before + 2
+    assert player.debt == debt_before + 1
+
+
+def test_ninja_attacks_opponents():
+    state = _two_player_setup()
+    attacker, victim = state.players
+    ninja = get_card("Ninja")
+    attacker.in_play = [ninja]
+    victim.hand = [get_card("Copper") for _ in range(5)]
+    attacker.deck = [get_card("Copper") for _ in range(5)]
+    state.current_player_index = 0
+
+    ninja.on_play(state)
+    assert len(victim.hand) == 3
+
+
+def test_poet_puts_cheap_card_in_hand():
+    state, player = _setup()
+    poet = get_card("Poet")
+    cheap_card = get_card("Estate")  # costs 2
+    player.hand = []
+    player.deck = [cheap_card]
+    player.in_play = [poet]
+
+    poet.on_play(state)
+    # +1 Card draws Estate. Then Poet reveals top of deck (now empty); no
+    # further hand growth. Estate must be in hand from the +1 Card draw.
+    assert any(c.name == "Estate" for c in player.hand)
+
+
+def test_rice_treasure_counts_types():
+    state, player = _setup()
+    rice = get_card("Rice")
+    village = get_card("Village")  # ACTION
+    silver = get_card("Silver")  # TREASURE
+    player.in_play = [village, silver]
+    player.duration = []
+
+    rice.on_play(state)
+    # Types in play before Rice itself: ACTION, TREASURE → 2.
+    # Rice adds itself (TREASURE already counted).
+    assert player.coins >= 2
+
+
+def test_rice_broker_treasure_action_double_draws():
+    state, player = _setup()
+    rice_broker = get_card("Rice Broker")
+    # Crown is an Action+Treasure
+    crown = get_card("Crown")
+    player.hand = [crown]
+    player.in_play = [rice_broker]
+    player.deck = [get_card("Copper") for _ in range(10)]
+
+    rice_broker.on_play(state)
+    # +2 then +5 = 7 cards drawn
+    assert len(player.hand) == 7
+
+
+def test_riverboat_plays_set_aside_next_turn():
+    state = GameState(players=[])
+    festival = get_card("Festival")
+    state.initialize_game(
+        [_GainFirstAI()],
+        [get_card("Riverboat"), get_card("Village")],
+        riverboat_set_aside=festival,
+    )
+    player = state.players[0]
+    riverboat = get_card("Riverboat")
+    player.in_play = [riverboat]
+    player.duration = []
+    player.actions = 0
+    player.coins = 0
+    player.buys = 1
+
+    riverboat.on_play(state)
+    # Riverboat goes into duration
+    assert riverboat in player.duration
+    # On next turn, festival plays
+    coins_before = player.coins
+    actions_before = player.actions
+    riverboat.on_duration(state)
+    # Festival gives +2 Actions, +1 Buy, +$2
+    assert player.actions == actions_before + 2
+    assert player.coins == coins_before + 2
+
+
+def test_ronin_draws_to_seven():
+    state, player = _setup()
+    ronin = get_card("Ronin")
+    player.hand = [get_card("Copper") for _ in range(2)]
+    player.deck = [get_card("Silver") for _ in range(10)]
+    player.in_play = [ronin]
+
+    coins_before = player.coins
+    ronin.on_play(state)
+    # Per rulebook, Ronin draws until 7 in hand. No +$.
+    assert len(player.hand) == 7
+    assert player.coins == coins_before
+
+
+def test_root_cellar_basic_stats():
+    state, player = _setup()
+    root = get_card("Root Cellar")
+    player.in_play = [root]
+    player.deck = [get_card("Copper") for _ in range(10)]
+    debt_before = player.debt
+    actions_before = player.actions
+    hand_before = len(player.hand)
+    root.on_play(state)
+    # +3 Cards, +1 Action, +3 Debt
+    assert len(player.hand) == hand_before + 3
+    assert player.actions == actions_before + 1
+    assert player.debt == debt_before + 3
+
+
+def test_rustic_village_omen_reduces_sun():
+    state = GameState(players=[])
+    state.initialize_game([_GainFirstAI()], [get_card("Rustic Village")])
+    player = state.players[0]
+    assert state.prophecy is not None
+    assert state.sun_tokens == 5  # 1 player → defaults to 5
+
+    rv = get_card("Rustic Village")
+    player.hand = [rv]
+    player.in_play = []
+    player.deck = [get_card("Copper") for _ in range(5)]
+
+    player.hand.remove(rv)
+    player.in_play.append(rv)
+    rv.on_play(state)
+    assert state.sun_tokens == 4
+
+
+def test_snake_witch_curses_opponents_when_unique():
+    state = _two_player_setup()
+    attacker, victim = state.players
+    snake = get_card("Snake Witch")
+    attacker.hand = [snake, get_card("Copper")]
+    attacker.deck = [get_card("Estate")]
+    attacker.in_play = []
+    state.current_player_index = 0
+
+    attacker.hand.remove(snake)
+    attacker.in_play.append(snake)
+    snake.on_play(state)
+    # All hand names different (Estate after +1 Card, Copper) → return Snake
+    # Witch to its pile and curse opponents.
+    if all(False for c in attacker.in_play if c.name == "Snake Witch"):
+        # Returned to pile
+        assert any(c.name == "Curse" for c in victim.discard)
+
+
+def test_tanuki_remodels():
+    state, player = _setup()
+    tanuki = get_card("Tanuki")
+    estate = get_card("Estate")  # cost 2
+    player.hand = [estate]
+    player.in_play = [tanuki]
+    state.supply["Silver"] = 40
+    state.supply["Gold"] = 30
+    state.supply["Village"] = 10
+
+    tanuki.on_play(state)
+    # Trashed Estate ($2) → gain card up to $4. AI (_GainFirstAI) picks first.
+    assert any(c.name == "Estate" for c in state.trash)
+
+
+def test_tea_house_basic_stats():
+    state = GameState(players=[])
+    state.initialize_game([_GainFirstAI()], [get_card("Tea House")])
+    player = state.players[0]
+    tea = get_card("Tea House")
+    player.hand = [tea]
+    player.in_play = []
+    player.deck = [get_card("Copper") for _ in range(5)]
+
+    sun_before = state.sun_tokens
+    player.hand.remove(tea)
+    player.in_play.append(tea)
+    tea.on_play(state)
+    assert player.coins == 2
+    assert state.sun_tokens == sun_before - 1
+
+
+# ---------------------------------------------------------------------------
+# Shadow card mechanic
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_cards_shuffle_to_bottom():
+    state, player = _setup()
+    fish = get_card("Fishmonger")
+    village = get_card("Village")
+    player.discard = [fish, village]
+    player.deck = []
+
+    player.shuffle_discard_into_deck()
+    # Shadow card (Fishmonger) is at the bottom (index 0)
+    assert player.deck[0] is fish
+
+
+def test_card_type_includes_shadow_and_omen():
+    """Make sure CardType.SHADOW and CardType.OMEN are recognized."""
+    fish = get_card("Fishmonger")
+    rustic = get_card("Rustic Village")
+    assert fish.is_shadow
+    assert rustic.is_omen
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+
+def test_amass_blocks_when_action_in_play():
+    state, player = _setup()
+    player.in_play = [get_card("Village")]
+    player.coins = 2
+    state.supply["Smithy"] = 10
+    Amass = get_event("Amass").__class__
+    Amass().on_buy(state, player)
+    # Smithy was not gained (Village blocks Amass)
+    assert not any(c.name == "Smithy" for c in player.discard)
+
+
+def test_amass_gains_action_when_no_actions_in_play():
+    state, player = _setup()
+    player.in_play = []
+    player.duration = []
+    player.coins = 2
+    state.supply["Smithy"] = 10
+    get_event("Amass").on_buy(state, player)
+    # Some Action card was gained
+    assert any(c.is_action for c in player.discard)
+
+
+def test_practice_plays_action_twice():
+    state, player = _setup()
+    village = get_card("Village")
+    player.hand = [village]
+    player.in_play = []
+    player.actions = 1
+    player.deck = [get_card("Copper") for _ in range(5)]
+
+    actions_before = player.actions
+    get_event("Practice").on_buy(state, player)
+    # Village played twice → +4 actions, +2 cards
+    assert player.actions == actions_before + 4
+    assert len(player.hand) == 2
+
+
+def test_sea_trade_draws_per_action_and_trashes():
+    state, player = _setup()
+    village = get_card("Village")
+    village2 = get_card("Village")
+    player.in_play = [village, village2]
+    player.deck = [get_card("Copper") for _ in range(5)]
+    player.hand = [get_card("Copper")]  # something to trash
+    get_event("Sea Trade").on_buy(state, player)
+    # 2 Action cards in play → drew 2, may trash up to 2.
+    assert any(c.name == "Copper" for c in state.trash)
+
+
+def test_continue_is_once_per_turn():
+    state, player = _setup()
+    player.coins = 16
+    state.supply["Village"] = 10
+    Continue = get_event("Continue").__class__
+    Continue().on_buy(state, player)
+    assert player.continue_used_this_turn is True
+    assert Continue().may_be_bought(state, player) is False
+
+
+def test_kintsugi_requires_gold_for_gain():
+    state, player = _setup()
+    player.kintsugi_has_gained_gold = False
+    player.hand = [get_card("Estate")]
+    player.in_play = []
+    state.supply["Silver"] = 40
+    get_event("Kintsugi").on_buy(state, player)
+    # No Silver gained because we haven't gained a Gold this game
+    silvers_in_discard = sum(1 for c in player.discard if c.name == "Silver")
+    assert silvers_in_discard == 0
+
+
+# ---------------------------------------------------------------------------
+# Prophecies
+# ---------------------------------------------------------------------------
+
+
+def test_prophecy_setup_with_omen_in_supply():
+    state = GameState(players=[])
+    state.initialize_game([_GainFirstAI()], [get_card("Rustic Village")])
+    assert state.prophecy is not None
+    assert state.sun_tokens == 5
+
+
+def test_omen_play_removes_sun_token():
+    state, player = _setup()
+    state.prophecy = get_prophecy("Approaching Army")
+    state.sun_tokens = 5
+    state.prophecy.is_active = False
+
+    rv = get_card("Rustic Village")
+    player.in_play.append(rv)
+    rv.on_play(state)
+    assert state.sun_tokens == 4
+
+
+def test_prophecy_activates_when_last_sun_removed():
+    state, player = _setup()
+    state.prophecy = get_prophecy("Great Leader")
+    state.sun_tokens = 1
+    state.prophecy.is_active = False
+
+    state.remove_sun_token(1)
+    assert state.sun_tokens == 0
+    assert state.prophecy.is_active is True
+
+
+def test_great_leader_grants_action_after_each_action_play():
+    state, player = _setup()
+    state.prophecy = get_prophecy("Great Leader")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+
+    village = get_card("Village")
+    player.in_play.append(village)
+    actions_before = player.actions
+    village.on_play(state)
+    state.prophecy.on_play_action(state, player, village)
+    # Village gives +2 actions, then Great Leader adds +1
+    assert player.actions == actions_before + 3
+
+
+def test_good_harvest_first_treasure_per_turn():
+    state, player = _setup()
+    state.prophecy = get_prophecy("Good Harvest")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+
+    silver = get_card("Silver")
+    coins_before = player.coins
+    state.prophecy.on_play_treasure(state, player, silver)
+    assert player.coins == coins_before + 1
+    assert player.buys >= 2  # +1 Buy
+    state.prophecy.on_play_treasure(state, player, silver)
+    # No further bonus on the second treasure
+    assert player.coins == coins_before + 1
+
+
+def test_bureaucracy_grants_copper_on_coin_cost_gain():
+    state, player = _setup()
+    state.prophecy = get_prophecy("Bureaucracy")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+    state.supply["Copper"] = 10
+    state.supply["Village"] = 10
+
+    state.prophecy.on_gain(state, player, get_card("Village"))
+    assert any(c.name == "Copper" for c in player.discard)
+
+
+def test_progress_topdecks_gains():
+    state, player = _setup()
+    state.prophecy = get_prophecy("Progress")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+    village = get_card("Village")
+    player.discard.append(village)
+    state.prophecy.on_gain(state, player, village)
+    assert player.deck[-1] is village
+
+
+def test_flourishing_trade_lowers_costs():
+    state, player = _setup()
+    state.prophecy = get_prophecy("Flourishing Trade")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+
+    village = get_card("Village")
+    cost = state.get_card_cost(player, village)
+    assert cost == max(0, village.cost.coins - 1)
+
+
+def test_kind_emperor_gains_action_to_hand_on_turn_start():
+    state, player = _setup()
+    state.prophecy = get_prophecy("Kind Emperor")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+    state.supply["Village"] = 10
+
+    hand_size_before = len(player.hand)
+    state.prophecy.on_turn_start(state, player)
+    # An action should have been gained directly to hand
+    assert len(player.hand) == hand_size_before + 1
+
+
+def test_growth_chains_treasure_gains():
+    state, player = _setup()
+    state.prophecy = get_prophecy("Growth")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+    # Gaining Gold ($6) → must gain a cheaper card
+    state.supply["Silver"] = 40
+    state.supply["Copper"] = 30
+    state.supply["Gold"] = 30
+    gold = get_card("Gold")
+    state.prophecy.on_gain(state, player, gold)
+    # Some cheaper card was gained
+    assert player.discard, "Growth should have gained a cheaper card"
+
+
+def test_sickness_curse_or_discard():
+    state, player = _setup()
+    state.prophecy = get_prophecy("Sickness")
+    state.prophecy.is_active = True
+    state.sun_tokens = 0
+    state.supply["Curse"] = 30
+    player.hand = [get_card("Estate") for _ in range(2)]  # only 2 junk → curse mode
+
+    state.prophecy.on_cleanup_start(state, player)
+    # Curse should have gone to deck (top)
+    assert any(c.name == "Curse" for c in player.deck), "Curse should be on deck"

--- a/tests/test_treasure_cards_registry.py
+++ b/tests/test_treasure_cards_registry.py
@@ -48,6 +48,7 @@ EXPECTED_TREASURE_CARDS = {
     "Coronet",
     "Huge Turnip",
     "Pickaxe",
+    "Rice",
 }
 
 MULTI_TYPE_TREASURES = {


### PR DESCRIPTION
## Summary
- Adds 23 new Kingdom cards, 9 Events, and all 15 Prophecies from Dominion: Rising Sun, on top of the 2 cards already stubbed in
- Builds the new mechanics it depends on: Sun tokens, the Prophecy class with full hook surface, Shadow play-from-deck + bottom-of-deck shuffle, automatic +1 Sun on Omens, Riverboat set-aside slot, Daimyo replay counter, Harsh Winter per-pile debt
- Relocates Samurai from Allies to Rising Sun (it was misfiled there at the wrong cost) and corrects Aristocrat's pre-existing $5 cost to the official $3
- Rewrites the Plunder-flavored Continue event to its actual Rising Sun text ($8 Debt, once per turn, gains an Action up to $4)

All costs and effects were cross-checked against the official Dominion Strategy Wiki rather than guessed.

## Files of note
- `dominion/prophecies/` — new package with `Prophecy` base + 15 subclasses, each registered via `@register`
- `dominion/cards/rising_sun/` — 25 card files (23 new + Samurai + the existing 2)
- `dominion/events/rising_sun_events.py` — 9 new events
- `dominion/game/game_state.py` — wiring for sun tokens, prophecy hooks (play/gain/turn-start/cleanup/cost), Shadow card play-from-deck, Daimyo replay, Riverboat set-aside, Foresight stash, Panic-cleanup return-to-pile
- `dominion/cards/base_card.py` — `CardType.SHADOW`, `CardType.OMEN`, automatic +1 Sun on Omen play

## Test plan
- [x] `pytest tests/` — 377 passed (38 new in `test_rising_sun_cards.py`)
- [x] Smoke-test: 60-turn game with a Rising Sun kingdom + 6 Rising Sun events runs cleanly
- [x] Continue's old behavior re-tested under the corrected Rising Sun rules
- [x] Existing Samurai tests updated for the corrected $6 cost and "discard down to 3" semantics (no 5+ guard)

## Caveats
- Receive Tribute now requires you to have gained 3+ cards this turn first (this matches the wiki text and was missed in the first pass)
- Divine Wind randomly re-deals 10 fresh Kingdom piles when it activates — it doesn't try to coordinate with whatever drove the original kingdom selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)