### PR TITLE
Implement Guilds overpay mechanic + Doctor/Herald/Masterpiece/Stonemason on-buy effects

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -1154,3 +1154,103 @@ class AI(ABC):
     ) -> bool:
         """Hook for AIs that may want to skip Charlatan's Curse attack."""
         return True
+
+    # ------------------------------------------------------------------
+    # Guilds — Overpay decision hooks
+    # ------------------------------------------------------------------
+
+    def choose_overpay_amount(
+        self,
+        state: GameState,
+        player: PlayerState,
+        card: Card,
+        max_amount: int,
+    ) -> int:
+        """How many coins to overpay when buying ``card``.
+
+        ``max_amount`` is capped at the player's available coins after the
+        printed cost has already been paid. Default heuristic per Guilds
+        overpay card:
+
+        * Masterpiece: spend everything — each $1 turns into a Silver gain.
+        * Stonemason: spend $3, $4, or $5 to gain two solid Action cards.
+        * Doctor: spend up to $2 if there's likely junk on top of the deck.
+        * Herald: spend up to $2 if the discard pile holds useful Actions.
+
+        Subclasses may override with stronger strategies.
+        """
+        if max_amount <= 0:
+            return 0
+
+        name = getattr(card, "name", "")
+        if name == "Masterpiece":
+            # Each $1 overpaid → Silver gain. Always strictly positive.
+            return max_amount
+        if name == "Stonemason":
+            # Want exactly $3 or $4 (Witch / Smithy / Wharf etc.). Don't go
+            # under $3 since $2 Actions are usually weak.
+            for target in (5, 4, 3):
+                if max_amount >= target:
+                    return target
+            return 0
+        if name == "Doctor":
+            # Each $1 lets us peek the top of the deck and trash junk. Be
+            # mildly aggressive when junk is plausibly present.
+            junk_in_deck = sum(
+                1
+                for c in player.deck + player.discard
+                if c.name in {"Curse", "Copper", "Estate"}
+            )
+            if junk_in_deck >= 3:
+                return min(max_amount, 2)
+            if junk_in_deck >= 1:
+                return min(max_amount, 1)
+            return 0
+        if name == "Herald":
+            # Topdeck up to N cards from discard. Worth overpaying when the
+            # discard has Actions worth replaying immediately.
+            actions_in_discard = sum(1 for c in player.discard if c.is_action)
+            return min(max_amount, actions_in_discard, 2)
+        return 0
+
+    def choose_doctor_overpay_action(
+        self,
+        state: GameState,
+        player: PlayerState,
+        card: Card,
+    ) -> str:
+        """Pick what Doctor's overpay does to the peeked top-of-deck card.
+
+        Returns one of: 'trash', 'discard', 'topdeck'. Default: trash junk
+        (Curse, Copper, Estate, low-cost non-Action Victory), discard
+        otherwise unhelpful Victory cards in the early game, and topdeck
+        anything else so we draw it next turn.
+        """
+        if card.name in {"Curse", "Copper", "Estate", "Hovel", "Overgrown Estate"}:
+            return "trash"
+        if card.is_victory and not card.is_action and card.cost.coins <= 2:
+            return "trash"
+        if card.is_victory and not card.is_action:
+            return "discard"
+        return "topdeck"
+
+    def choose_herald_overpay_topdeck(
+        self,
+        state: GameState,
+        player: PlayerState,
+        choices: list[Card],
+    ) -> Optional[Card]:
+        """Pick a card from discard to put on top of deck via Herald overpay.
+
+        Returns ``None`` to skip. Default: prefer the most expensive Action,
+        then the most expensive Treasure (skipping Copper).
+        """
+        if not choices:
+            return None
+        actions = [c for c in choices if c.is_action]
+        if actions:
+            return max(actions, key=lambda c: (c.cost.coins, c.stats.cards, c.name))
+        treasures = [c for c in choices if c.is_treasure and c.name != "Copper"]
+        if treasures:
+            return max(treasures, key=lambda c: (c.cost.coins, c.name))
+        return None

--- a/dominion/cards/base_card.py
+++ b/dominion/cards/base_card.py
@@ -138,6 +138,18 @@ class Card:
         """Effects that happen when card is bought. Override in subclasses."""
         pass
 
+    def may_overpay(self, game_state) -> bool:
+        """Whether this card supports the Guilds Overpay mechanic when bought.
+
+        Default False. Override on cards that allow overpay (Doctor, Herald,
+        Masterpiece, Stonemason).
+        """
+        return False
+
+    def on_overpay(self, game_state, player, amount: int) -> None:
+        """Effects when this card is bought with overpay. Override in subclasses."""
+        pass
+
     def on_gain(self, game_state, player):
         """Effects that happen when card is gained."""
         if self.is_action and getattr(player, "collection_played", 0) > 0:

--- a/dominion/cards/guilds/doctor.py
+++ b/dominion/cards/guilds/doctor.py
@@ -45,3 +45,29 @@ class Doctor(Card):
         if player.count_in_deck("Copper"):
             return "Copper"
         return "Estate"
+
+    # --- Guilds Overpay ------------------------------------------------
+
+    def may_overpay(self, game_state) -> bool:
+        return True
+
+    def on_overpay(self, game_state, player, amount: int) -> None:
+        """For each $1 overpaid, peek the top card and trash/discard/topdeck it."""
+        if amount <= 0:
+            return
+
+        for _ in range(amount):
+            if not player.deck and player.discard:
+                player.shuffle_discard_into_deck()
+            if not player.deck:
+                return
+
+            top = player.deck.pop()
+            decision = player.ai.choose_doctor_overpay_action(game_state, player, top)
+
+            if decision == "trash":
+                game_state.trash_card(player, top)
+            elif decision == "discard":
+                game_state.discard_card(player, top)
+            else:  # "topdeck" or any unknown answer → put it back
+                player.deck.append(top)

--- a/dominion/cards/guilds/herald.py
+++ b/dominion/cards/guilds/herald.py
@@ -26,3 +26,24 @@ class Herald(Card):
             card.on_play(game_state)
         else:
             game_state.discard_card(player, card)
+
+    # --- Guilds Overpay ------------------------------------------------
+
+    def may_overpay(self, game_state) -> bool:
+        return True
+
+    def on_overpay(self, game_state, player, amount: int) -> None:
+        """For each $1 overpaid, may pick a card from discard to topdeck."""
+        if amount <= 0:
+            return
+
+        for _ in range(amount):
+            if not player.discard:
+                return
+            choice = player.ai.choose_herald_overpay_topdeck(
+                game_state, player, list(player.discard)
+            )
+            if choice is None or choice not in player.discard:
+                return
+            player.discard.remove(choice)
+            player.deck.append(choice)

--- a/dominion/cards/guilds/masterpiece.py
+++ b/dominion/cards/guilds/masterpiece.py
@@ -2,12 +2,26 @@ from ..base_card import Card, CardCost, CardStats, CardType
 
 
 class Masterpiece(Card):
-    """Simple treasure representing the Guilds overpay card."""
+    """Guilds overpay Treasure — each $1 overpaid gains a Silver."""
 
     def __init__(self):
         super().__init__(
             name="Masterpiece",
-            cost=CardCost(coins=5),
+            cost=CardCost(coins=3),
             stats=CardStats(coins=1),
             types=[CardType.TREASURE],
         )
+
+    def may_overpay(self, game_state) -> bool:
+        return True
+
+    def on_overpay(self, game_state, player, amount: int) -> None:
+        if amount <= 0:
+            return
+        from ..registry import get_card
+
+        for _ in range(amount):
+            if game_state.supply.get("Silver", 0) <= 0:
+                break
+            game_state.supply["Silver"] -= 1
+            game_state.gain_card(player, get_card("Silver"))

--- a/dominion/cards/guilds/stonemason.py
+++ b/dominion/cards/guilds/stonemason.py
@@ -48,3 +48,44 @@ class Stonemason(Card):
             game_state.supply[card.name] -= 1
             game_state.gain_card(player, card)
             gained += 1
+
+    # --- Guilds Overpay ------------------------------------------------
+
+    def may_overpay(self, game_state) -> bool:
+        return True
+
+    def on_overpay(self, game_state, player, amount: int) -> None:
+        """Gain 2 Action cards each costing exactly ``amount`` coins."""
+        if amount <= 0:
+            return
+        from ..registry import get_card
+
+        def list_candidates() -> list[Card]:
+            cards: list[Card] = []
+            for name, count in game_state.supply.items():
+                if count <= 0:
+                    continue
+                card = get_card(name)
+                if not card.is_action:
+                    continue
+                if card.cost.coins != amount:
+                    continue
+                if card.cost.potions > 0 or card.cost.debt > 0:
+                    continue
+                cards.append(card)
+            return cards
+
+        for _ in range(2):
+            candidates = list_candidates()
+            if not candidates:
+                return
+            candidates.sort(
+                key=lambda c: (
+                    c.stats.cards * 2 + c.stats.actions + c.stats.coins,
+                    c.name,
+                ),
+                reverse=True,
+            )
+            chosen = candidates[0]
+            game_state.supply[chosen.name] -= 1
+            game_state.gain_card(player, get_card(chosen.name))

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -797,6 +797,31 @@ class GameState:
             player.coins -= coins_spent
             player.coin_tokens -= tokens_spent
 
+            # Guilds Overpay: ask the AI whether to pay extra coins on top of
+            # the printed cost. Only Cards that opt in via ``may_overpay``
+            # (e.g. Doctor, Herald, Masterpiece, Stonemason) trigger this.
+            overpay_amount = 0
+            if (
+                not getattr(choice, "is_event", False)
+                and not getattr(choice, "is_project", False)
+                and choice.may_overpay(self)
+                and player.coins > 0
+            ):
+                max_overpay = max(0, player.coins)
+                if max_overpay > 0:
+                    chosen = player.ai.choose_overpay_amount(self, player, choice, max_overpay)
+                    overpay_amount = max(0, min(int(chosen or 0), max_overpay))
+                    if overpay_amount > 0:
+                        player.coins -= overpay_amount
+                        player.coins_spent_this_turn += overpay_amount
+                        self.log_callback(
+                            (
+                                "action",
+                                player.ai.name,
+                                f"overpays {overpay_amount} for {choice}",
+                                {"overpay": overpay_amount, "remaining_coins": player.coins},
+                            )
+                        )
 
             if getattr(choice, "is_event", False):
                 choice.on_buy(self, player)
@@ -809,6 +834,9 @@ class GameState:
                 self.log_callback(("supply_change", choice.name, -1, self.supply[choice.name]))
                 choice.on_buy(self)
                 gained_card = self.gain_card(player, choice)
+
+                if overpay_amount > 0:
+                    choice.on_overpay(self, player, overpay_amount)
 
                 self._handle_on_buy_in_play_effects(player, choice, gained_card)
                 self._apply_embargo_tokens(player, choice.name)

--- a/tests/test_guilds_overpay.py
+++ b/tests/test_guilds_overpay.py
@@ -1,0 +1,297 @@
+"""Tests for the Guilds Overpay mechanic + the four affected cards.
+
+Covers:
+- Buying Masterpiece with overpay actually gains Silvers.
+- Buying Stonemason with overpay gains 2 Action cards each costing exactly N.
+- Buying Doctor with overpay peeks the top of deck and trashes/discards/topdecks.
+- Buying Herald with overpay topdecks cards from the discard pile.
+- Buying without overpay still works (overpay defaults 0).
+- Cards that don't support overpay never trigger the AI hook.
+- Overpay capped at available coins.
+- Overpay never fires on plain gain (only on buy).
+"""
+
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+from tests.utils import DummyAI
+
+
+class OverpayingAI(DummyAI):
+    """AI that records overpay decisions and applies a configurable amount."""
+
+    def __init__(
+        self,
+        overpay: int = 0,
+        doctor_action: str = "trash",
+        target_card: str = "",
+    ):
+        super().__init__()
+        self.overpay_amount_to_use = overpay
+        self.doctor_action = doctor_action
+        self.target_card = target_card
+        self.overpay_calls: list[tuple] = []
+
+    def choose_buy(self, state, choices):
+        for c in choices:
+            if c is not None and c.name == self.target_card:
+                return c
+        return None
+
+    def choose_overpay_amount(self, state, player, card, max_amount):
+        self.overpay_calls.append((card.name, max_amount))
+        return min(self.overpay_amount_to_use, max_amount)
+
+    def choose_doctor_overpay_action(self, state, player, card):
+        return self.doctor_action
+
+    def choose_herald_overpay_topdeck(self, state, player, choices):
+        return choices[0] if choices else None
+
+
+def _make_state(ai=None):
+    ai = ai or OverpayingAI()
+    player = PlayerState(ai)
+    state = GameState(players=[player])
+    state.setup_supply([])
+    player.hand = []
+    player.deck = []
+    player.discard = []
+    player.in_play = []
+    player.duration = []
+    player.actions = 0
+    player.buys = 1
+    player.coins = 0
+    player.coin_tokens = 0
+    state.current_player_index = 0
+    state.phase = "buy"
+    return state, player
+
+
+# --- Base hooks -------------------------------------------------------------
+
+
+def test_default_card_does_not_allow_overpay():
+    """Plain cards should not allow overpay; the AI hook isn't called."""
+
+    ai = OverpayingAI(overpay=5, target_card="Silver")
+    state, player = _make_state(ai)
+    player.coins = 10
+
+    state.handle_buy_phase()
+
+    assert ai.overpay_calls == [], (
+        f"overpay hook should not fire on Silver, got {ai.overpay_calls}"
+    )
+    assert any(c.name == "Silver" for c in player.discard)
+
+
+# --- Masterpiece ------------------------------------------------------------
+
+
+def test_masterpiece_overpay_three_gains_three_silvers():
+    """Buying Masterpiece with $3 overpay gains exactly 3 Silvers in discard."""
+
+    ai = OverpayingAI(overpay=3, target_card="Masterpiece")
+    state, player = _make_state(ai)
+    state.supply["Masterpiece"] = 10
+    player.coins = 6  # cost $3 + overpay $3
+
+    state.handle_buy_phase()
+
+    silvers = sum(1 for c in player.discard if c.name == "Silver")
+    assert silvers == 3, f"expected 3 Silvers from $3 overpay, got {silvers}"
+    assert any(c.name == "Masterpiece" for c in player.discard)
+    assert player.coins == 0
+
+
+def test_masterpiece_no_overpay_gains_only_the_card():
+    ai = OverpayingAI(overpay=0, target_card="Masterpiece")
+    state, player = _make_state(ai)
+    state.supply["Masterpiece"] = 10
+    player.coins = 3
+
+    state.handle_buy_phase()
+
+    assert sum(1 for c in player.discard if c.name == "Silver") == 0
+    assert any(c.name == "Masterpiece" for c in player.discard)
+
+
+def test_masterpiece_overpay_calls_ai_with_correct_max():
+    """Overpay max should be the player's coins remaining after the printed cost."""
+    ai = OverpayingAI(overpay=2, target_card="Masterpiece")
+    state, player = _make_state(ai)
+    state.supply["Masterpiece"] = 10
+    player.coins = 7  # cost $3, leaves $4 max overpay
+
+    state.handle_buy_phase()
+
+    assert ai.overpay_calls == [("Masterpiece", 4)]
+
+
+# --- Stonemason -------------------------------------------------------------
+
+
+def test_stonemason_overpay_gains_two_actions_at_exact_cost():
+    """Buying Stonemason with $4 overpay gains 2 Action cards each cost $4."""
+
+    ai = OverpayingAI(overpay=4, target_card="Stonemason")
+    state, player = _make_state(ai)
+    state.supply["Stonemason"] = 10
+    state.supply["Smithy"] = 10  # Action, costs $4
+    player.coins = 6  # cost $2 + overpay $4
+
+    state.handle_buy_phase()
+
+    smithies = sum(1 for c in player.discard if c.name == "Smithy")
+    assert smithies == 2, f"expected 2 Smithies (cost $4 Actions), got {smithies}"
+    assert any(c.name == "Stonemason" for c in player.discard)
+
+
+def test_stonemason_no_overpay_does_not_gain_extras():
+    ai = OverpayingAI(overpay=0, target_card="Stonemason")
+    state, player = _make_state(ai)
+    state.supply["Stonemason"] = 10
+    state.supply["Smithy"] = 10
+    player.coins = 2
+
+    state.handle_buy_phase()
+    assert sum(1 for c in player.discard if c.name == "Smithy") == 0
+    assert any(c.name == "Stonemason" for c in player.discard)
+
+
+def test_stonemason_overpay_with_no_matching_actions_gains_nothing_extra():
+    """If no Action card costs exactly $N, overpay still goes through."""
+    ai = OverpayingAI(overpay=7, target_card="Stonemason")
+    state, player = _make_state(ai)
+    state.supply["Stonemason"] = 10
+    # No Action cards in the kingdom — only basic cards which are mostly
+    # Treasures / Victory. There's no $7 Action available.
+    player.coins = 9
+
+    state.handle_buy_phase()
+    # Stonemason still bought, no extra Action gains, coins fully spent.
+    assert any(c.name == "Stonemason" for c in player.discard)
+    assert player.coins == 0
+
+
+# --- Doctor -----------------------------------------------------------------
+
+
+def test_doctor_overpay_one_trashes_top_card_when_ai_picks_trash():
+    ai = OverpayingAI(overpay=1, doctor_action="trash", target_card="Doctor")
+    state, player = _make_state(ai)
+    state.supply["Doctor"] = 10
+
+    junk = get_card("Curse")
+    player.deck = [junk]
+    player.coins = 4
+
+    state.handle_buy_phase()
+
+    assert junk in state.trash
+    assert junk not in player.deck
+    assert junk not in player.discard
+
+
+def test_doctor_overpay_topdeck_keeps_card_on_deck():
+    ai = OverpayingAI(overpay=1, doctor_action="topdeck", target_card="Doctor")
+    state, player = _make_state(ai)
+    state.supply["Doctor"] = 10
+
+    gold = get_card("Gold")
+    player.deck = [gold]
+    player.coins = 4
+
+    state.handle_buy_phase()
+
+    assert gold in player.deck
+    assert gold not in state.trash
+    assert gold not in player.discard
+
+
+def test_doctor_overpay_discard_moves_to_discard():
+    ai = OverpayingAI(overpay=1, doctor_action="discard", target_card="Doctor")
+    state, player = _make_state(ai)
+    state.supply["Doctor"] = 10
+
+    estate = get_card("Estate")
+    player.deck = [estate]
+    player.coins = 4
+
+    state.handle_buy_phase()
+    assert estate in player.discard
+    assert estate not in player.deck
+    assert estate not in state.trash
+
+
+# --- Herald -----------------------------------------------------------------
+
+
+def test_herald_overpay_two_topdecks_two_cards_from_discard():
+    ai = OverpayingAI(overpay=2, target_card="Herald")
+    state, player = _make_state(ai)
+    state.supply["Herald"] = 10
+
+    smithy = get_card("Smithy")
+    village = get_card("Village")
+    player.discard = [smithy, village]
+    player.coins = 6
+
+    state.handle_buy_phase()
+
+    assert smithy in player.deck
+    assert village in player.deck
+    assert smithy not in player.discard
+    assert village not in player.discard
+
+
+def test_herald_overpay_zero_does_nothing_to_discard():
+    ai = OverpayingAI(overpay=0, target_card="Herald")
+    state, player = _make_state(ai)
+    state.supply["Herald"] = 10
+
+    smithy = get_card("Smithy")
+    player.discard = [smithy]
+    player.coins = 4
+
+    state.handle_buy_phase()
+    assert smithy in player.discard
+    assert smithy not in player.deck
+
+
+# --- Buy hook safety --------------------------------------------------------
+
+
+def test_overpay_capped_at_available_coins():
+    """Even if AI returns a huge number, overpay cannot exceed available coins."""
+
+    class GreedyOverpay(OverpayingAI):
+        def choose_overpay_amount(self, state, player, card, max_amount):
+            self.overpay_calls.append((card.name, max_amount))
+            return 999
+
+    ai = GreedyOverpay(target_card="Masterpiece")
+    state, player = _make_state(ai)
+    state.supply["Masterpiece"] = 10
+    player.coins = 5  # cost $3, leaves $2
+
+    state.handle_buy_phase()
+
+    silvers = sum(1 for c in player.discard if c.name == "Silver")
+    assert silvers == 2, f"expected 2 Silvers (capped overpay), got {silvers}"
+    assert player.coins == 0
+
+
+def test_overpay_does_not_fire_on_gain_only_on_buy():
+    """Direct gain_card (not via buy) should never trigger overpay."""
+    ai = OverpayingAI(overpay=3, target_card="Masterpiece")
+    state, player = _make_state(ai)
+    state.supply["Masterpiece"] = 10
+    player.coins = 999
+
+    state.gain_card(player, get_card("Masterpiece"))
+
+    assert ai.overpay_calls == []
+    assert sum(1 for c in player.discard if c.name == "Silver") == 0


### PR DESCRIPTION
## Summary

Adds the Guilds **Overpay** mechanic to the buy pipeline and implements the four affected cards' on-buy effects.

* **Engine (`dominion/game/game_state.py`):** after a card's printed cost is paid, the buy phase now asks the AI for an overpay amount whenever `card.may_overpay(...)` returns True. The overpay is capped at the player's remaining coins, deducted from `player.coins`, then `card.on_overpay(state, player, amount)` runs. Plain `gain_card` is **not** affected — overpay fires only on actual buys.
* **Base hooks (`dominion/cards/base_card.py`):** new `may_overpay` (default False) and `on_overpay` (no-op) on `Card`.
* **AI hooks (`dominion/ai/base_ai.py`):** `choose_overpay_amount`, `choose_doctor_overpay_action`, `choose_herald_overpay_topdeck`. All have sensible default heuristics.
* **Cards:**
  * **Masterpiece** ($3 — fixed from $5): each $1 overpaid → gain a Silver.
  * **Stonemason**: gain 2 Action cards each costing exactly the overpay amount.
  * **Doctor**: peek top of deck once per $1 overpaid; AI picks trash / discard / topdeck.
  * **Herald**: once per $1 overpaid, AI may topdeck a card from discard.

## Test plan

- [x] `pytest` baseline passed (497 tests).
- [x] New `tests/test_guilds_overpay.py` covers each card with / without overpay, the coins cap, and the buy-only fire path.
- [x] Full suite passes (511 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)