### PR TITLE
Block auto-merge when review threads are unresolved

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -61,15 +61,20 @@ jobs:
             exit 0
           fi
 
-          unresolved=$(gh api graphql -f query='
-            query($owner:String!,$name:String!,$num:Int!){
+          # Paginate so that PRs with >100 review threads are handled correctly.
+          unresolved=$(gh api graphql --paginate -f query='
+            query($owner:String!,$name:String!,$num:Int!,$endCursor:String){
               repository(owner:$owner,name:$name){
                 pullRequest(number:$num){
-                  reviewThreads(first:100){nodes{isResolved}}
+                  reviewThreads(first:100, after:$endCursor){
+                    nodes{isResolved}
+                    pageInfo{hasNextPage,endCursor}
+                  }
                 }
               }
             }' -F owner="${REPO%/*}" -F name="${REPO#*/}" -F num="$PR" \
-            --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length')
+            --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length' \
+            | awk 'BEGIN{s=0} {s+=$1} END{print s}')
           if [[ "${unresolved:-0}" -gt 0 ]]; then
             echo "PR #${PR} has ${unresolved} unresolved review thread(s) — skipping."
             exit 0
@@ -143,15 +148,20 @@ jobs:
               continue
             fi
 
-            unresolved=$(gh api graphql -f query='
-              query($owner:String!,$name:String!,$num:Int!){
+            # Paginate so that PRs with >100 review threads are handled correctly.
+            unresolved=$(gh api graphql --paginate -f query='
+              query($owner:String!,$name:String!,$num:Int!,$endCursor:String){
                 repository(owner:$owner,name:$name){
                   pullRequest(number:$num){
-                    reviewThreads(first:100){nodes{isResolved}}
+                    reviewThreads(first:100, after:$endCursor){
+                      nodes{isResolved}
+                      pageInfo{hasNextPage,endCursor}
+                    }
                   }
                 }
               }' -F owner="${REPO%/*}" -F name="${REPO#*/}" -F num="$pr" \
-              --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length')
+              --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length' \
+              | awk 'BEGIN{s=0} {s+=$1} END{print s}')
             if [[ "${unresolved:-0}" -gt 0 ]]; then
               echo "PR #${pr}: ${unresolved} unresolved review thread(s) — skipping."
               continue

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,7 +3,11 @@ name: Auto Merge
 # Enables auto-merge on a PR when a trusted actor (the repo owner or
 # the Codex review bot) signals approval via:
 #   - a 👍 reaction on the PR (polled), or
-#   - a 👍 comment on the PR (event-driven).
+#   - a comment on the PR whose body is exactly 👍 (event-driven).
+#
+# Before enabling auto-merge, the workflow verifies that the PR has no
+# unresolved review threads — otherwise correction comments left by
+# Codex (or any reviewer) would be ignored and merged over.
 #
 # Auto-merge itself defers to GitHub's branch protection — the PR will
 # only actually merge once required status checks (test, lint) pass.
@@ -40,12 +44,37 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.issue.number }}
+          BODY: ${{ github.event.comment.body }}
         run: |
+          # Require the comment body to be exactly 👍 (whitespace tolerated).
+          # `contains(...)` at job level is a coarse pre-filter — a comment
+          # like "👍 but please fix X first" must NOT trigger a merge.
+          body_stripped=$(printf '%s' "$BODY" | tr -d '[:space:]')
+          if [[ "$body_stripped" != "👍" ]]; then
+            echo "Comment body is not exactly 👍 (got: $(printf '%q' "$BODY")) — skipping."
+            exit 0
+          fi
+
           base=$(gh pr view "$PR" --repo "$REPO" --json baseRefName -q .baseRefName)
           if [[ "$base" != "main" ]]; then
             echo "PR #${PR} targets '${base}', not main — skipping."
             exit 0
           fi
+
+          unresolved=$(gh api graphql -f query='
+            query($owner:String!,$name:String!,$num:Int!){
+              repository(owner:$owner,name:$name){
+                pullRequest(number:$num){
+                  reviewThreads(first:100){nodes{isResolved}}
+                }
+              }
+            }' -F owner="${REPO%/*}" -F name="${REPO#*/}" -F num="$PR" \
+            --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length')
+          if [[ "${unresolved:-0}" -gt 0 ]]; then
+            echo "PR #${PR} has ${unresolved} unresolved review thread(s) — skipping."
+            exit 0
+          fi
+
           title=$(gh pr view "$PR" --repo "$REPO" --json title -q .title)
           gh pr merge "$PR" --repo "$REPO" --squash --auto --delete-branch \
             --subject "${title} (#${PR})"
@@ -113,6 +142,21 @@ jobs:
               echo "PR #${pr}: targets '${base}', not main — skipping."
               continue
             fi
+
+            unresolved=$(gh api graphql -f query='
+              query($owner:String!,$name:String!,$num:Int!){
+                repository(owner:$owner,name:$name){
+                  pullRequest(number:$num){
+                    reviewThreads(first:100){nodes{isResolved}}
+                  }
+                }
+              }' -F owner="${REPO%/*}" -F name="${REPO#*/}" -F num="$pr" \
+              --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length')
+            if [[ "${unresolved:-0}" -gt 0 ]]; then
+              echo "PR #${pr}: ${unresolved} unresolved review thread(s) — skipping."
+              continue
+            fi
+
             title=$(gh pr view "$pr" --repo "$REPO" --json title -q .title)
             gh pr merge "$pr" --repo "$REPO" --squash --auto --delete-branch \
               --subject "${title} (#${pr})" \


### PR DESCRIPTION
## Summary

The auto-merge workflow has been merging PRs that still had unaddressed Codex review suggestions. Two bugs combined to cause this:

1. **It only checked the codex `+1` reaction on the PR body, not whether any review threads were still open.** Codex's `+1` reaction means "I have no new suggestions on the latest commit" — that is not the same as "all prior correction threads are resolved." So a PR could collect P1/P2 inline corrections, get a fix push that happened to draw no new comments, receive a fresh `+1`, and be merged with the original threads still open.

   PR #176 is a concrete case: at merge time it had 14 unresolved review threads — verified via the GraphQL query this PR adds.

2. **The thumbsup-comment job matched `contains(comment.body, '👍')`.** A comment like *"I 👍'd this earlier but please fix X first"* would trigger an auto-merge attempt. The body needs to be exactly the emoji.

## Changes

- Both jobs now query `pullRequest.reviewThreads { isResolved }` via GraphQL before enabling auto-merge and skip any PR with `>0` unresolved threads.
- The thumbsup-comment step now strips whitespace from the comment body and requires it to equal `👍` exactly. The job-level `contains(...)` filter remains as a cheap pre-filter to avoid spinning up runners for unrelated comments.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Body-equality logic validated locally against: bare `👍`, `👍\n`, ` 👍 `, `👍 but fix X`, `Looks good 👍`, `👍👍` — only the first three match.
- [x] GraphQL query validated against a real PR (#176 returns `14` unresolved threads).
- [ ] Next scheduled run confirms behavior on live PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)