### PR TITLE
Address PR #180 review feedback (seaside)

### DIFF
--- a/dominion/cards/seaside/sea_chart.py
+++ b/dominion/cards/seaside/sea_chart.py
@@ -44,7 +44,17 @@ class SeaChart(Card):
         # "Put it into your hand if you don't have a copy of it in play."
         # Sea Chart itself counts as "in play", so revealing another Sea
         # Chart fails the condition. Any non-matching card is put into hand.
-        has_copy_in_play = any(c.name == top.name for c in player.in_play)
+        # Duration cards remain "in play" while sitting in ``player.duration``
+        # (and ``player.multiplied_durations`` when re-played by Throne-style
+        # effects), so include those zones in the check.
+        in_play_zones = (
+            player.in_play,
+            player.duration,
+            player.multiplied_durations,
+        )
+        has_copy_in_play = any(
+            c.name == top.name for zone in in_play_zones for c in zone
+        )
         if not has_copy_in_play:
             player.deck.pop()
             player.hand.append(top)

--- a/tests/test_seaside_cards.py
+++ b/tests/test_seaside_cards.py
@@ -1010,6 +1010,57 @@ def test_sea_chart_revealed_card_stays_when_matching_copy_in_play():
     assert player.deck and player.deck[-1] is village_top
 
 
+def test_sea_chart_treats_duration_cards_as_in_play():
+    """Duration cards still sitting in ``player.duration`` count as "in play"
+    for Sea Chart's matching check, so revealing the same card type leaves
+    the deck topdeck untouched.
+    """
+    state = _make_state()
+    player = state.players[0]
+
+    sea_chart = get_card("Sea Chart")
+    # A previously played Caravan that is still active sits in duration.
+    caravan_in_duration = get_card("Caravan")
+    player.duration = [caravan_in_duration]
+
+    revealed_caravan = get_card("Caravan")
+    drawn_first = get_card("Copper")
+    player.deck = [revealed_caravan, drawn_first]  # top=drawn_first
+    player.hand = [sea_chart]
+
+    play_action(state, player, sea_chart)
+
+    # +1 Card drew Copper.
+    assert drawn_first in player.hand
+    # Caravan in duration counts as "in play", so the revealed Caravan is
+    # NOT moved to hand and stays on top of the deck.
+    assert revealed_caravan not in player.hand
+    assert player.deck and player.deck[-1] is revealed_caravan
+
+
+def test_sea_chart_treats_multiplied_durations_as_in_play():
+    """Cards in ``player.multiplied_durations`` (Throne-Room-replayed
+    durations) also count as "in play" for Sea Chart.
+    """
+    state = _make_state()
+    player = state.players[0]
+
+    sea_chart = get_card("Sea Chart")
+    wharf_replayed = get_card("Wharf")
+    player.multiplied_durations = [wharf_replayed]
+
+    revealed_wharf = get_card("Wharf")
+    drawn_first = get_card("Copper")
+    player.deck = [revealed_wharf, drawn_first]
+    player.hand = [sea_chart]
+
+    play_action(state, player, sea_chart)
+
+    assert drawn_first in player.hand
+    assert revealed_wharf not in player.hand
+    assert player.deck and player.deck[-1] is revealed_wharf
+
+
 # -- Lighthouse vs Witch -----------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Sea Chart's "copy in play" check now also looks at `player.duration` and `player.multiplied_durations`, not just `player.in_play`. Duration cards live in those zones while still in play, so before this fix a Caravan (or any Duration) lingering from last turn would not satisfy the check, and Sea Chart would incorrectly pull a freshly revealed copy of that card into hand.
- Adds two regression tests: Caravan in `duration` and Wharf in `multiplied_durations`.

## Test plan
- [x] `pytest -x -q` (977 passed)

Addresses the P1 review comment on #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)