### PR TITLE
Address PR #184 review feedback (guilds overpay)

### DIFF
--- a/dominion/cards/promo/black_market.py
+++ b/dominion/cards/promo/black_market.py
@@ -81,10 +81,17 @@ class BlackMarket(Card):
         if player.buys > 0:
             player.buys -= 1
 
+        # Guilds Overpay: Black Market purchases trigger overpay just like a
+        # normal buy (Doctor/Herald/Masterpiece/Stonemason).
+        overpay_amount = game_state._prompt_overpay(player, card)
+
         from ..registry import get_card
 
         card.on_buy(game_state)
         gained = game_state.gain_card(player, get_card(card.name))
+
+        if overpay_amount > 0:
+            card.on_overpay(game_state, player, overpay_amount)
 
         game_state._handle_on_buy_in_play_effects(player, card, gained)
         if player.goons_played:

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1332,31 +1332,10 @@ class GameState:
             player.coins -= coins_spent
             player.coin_tokens -= tokens_spent
 
-            # Guilds Overpay: ask the AI whether to pay extra coins on top of
-            # the printed cost. Only Cards that opt in via ``may_overpay``
+            # Guilds Overpay: ask the AI whether to pay extra on top of the
+            # printed cost. Only Cards that opt in via ``may_overpay``
             # (e.g. Doctor, Herald, Masterpiece, Stonemason) trigger this.
-            overpay_amount = 0
-            if (
-                not getattr(choice, "is_event", False)
-                and not getattr(choice, "is_project", False)
-                and choice.may_overpay(self)
-                and player.coins > 0
-            ):
-                max_overpay = max(0, player.coins)
-                if max_overpay > 0:
-                    chosen = player.ai.choose_overpay_amount(self, player, choice, max_overpay)
-                    overpay_amount = max(0, min(int(chosen or 0), max_overpay))
-                    if overpay_amount > 0:
-                        player.coins -= overpay_amount
-                        player.coins_spent_this_turn += overpay_amount
-                        self.log_callback(
-                            (
-                                "action",
-                                player.ai.name,
-                                f"overpays {overpay_amount} for {choice}",
-                                {"overpay": overpay_amount, "remaining_coins": player.coins},
-                            )
-                        )
+            overpay_amount = self._prompt_overpay(player, choice)
 
             if getattr(choice, "is_event", False):
                 choice.on_buy(self, player)
@@ -1594,6 +1573,47 @@ class GameState:
 
         return affordable
 
+    def _prompt_overpay(self, player, card) -> int:
+        """Ask the AI whether to overpay when buying ``card``, deduct the cost,
+        and return the chosen amount. Does not invoke ``on_overpay`` itself —
+        callers must do that after the card is gained.
+
+        Treats ``coin_tokens`` as spendable currency alongside ``player.coins``,
+        matching how cost payment works elsewhere in the engine.
+        """
+        if getattr(card, "is_event", False) or getattr(card, "is_project", False):
+            return 0
+        if not card.may_overpay(self):
+            return 0
+
+        max_overpay = max(0, player.coins + player.coin_tokens)
+        if max_overpay <= 0:
+            return 0
+
+        chosen = player.ai.choose_overpay_amount(self, player, card, max_overpay)
+        amount = max(0, min(int(chosen or 0), max_overpay))
+        if amount <= 0:
+            return 0
+
+        coins_spent = min(player.coins, amount)
+        tokens_spent = amount - coins_spent
+        player.coins -= coins_spent
+        player.coin_tokens -= tokens_spent
+        player.coins_spent_this_turn += amount
+        self.log_callback(
+            (
+                "action",
+                player.ai.name,
+                f"overpays {amount} for {card}",
+                {
+                    "overpay": amount,
+                    "remaining_coins": player.coins,
+                    "remaining_coin_tokens": player.coin_tokens,
+                },
+            )
+        )
+        return amount
+
     def _complete_purchase(self, player, card):
         """Helper to complete a card purchase."""
         cost = self.get_card_cost(player, card)
@@ -1608,8 +1628,13 @@ class GameState:
             player.debt += card.cost.debt
         self.supply[card.name] -= 1
 
+        overpay_amount = self._prompt_overpay(player, card)
+
         card.on_buy(self)
         self.gain_card(player, card)
+
+        if overpay_amount > 0:
+            card.on_overpay(self, player, overpay_amount)
 
         if player.goons_played:
             player.vp_tokens += player.goons_played

--- a/tests/test_guilds_overpay.py
+++ b/tests/test_guilds_overpay.py
@@ -295,3 +295,77 @@ def test_overpay_does_not_fire_on_gain_only_on_buy():
 
     assert ai.overpay_calls == []
     assert sum(1 for c in player.discard if c.name == "Silver") == 0
+
+
+# --- Coin tokens as spendable overpay currency -----------------------------
+
+
+def test_overpay_can_be_paid_with_coin_tokens():
+    """Coin tokens should be spendable for overpay just like coins."""
+
+    ai = OverpayingAI(overpay=2, target_card="Masterpiece")
+    state, player = _make_state(ai)
+    state.supply["Masterpiece"] = 10
+    # Cost $3 — pay with all coins, leaving only coin tokens for overpay.
+    player.coins = 3
+    player.coin_tokens = 5
+
+    state.handle_buy_phase()
+
+    silvers = sum(1 for c in player.discard if c.name == "Silver")
+    assert silvers == 2, f"expected 2 Silvers from $2 token-overpay, got {silvers}"
+    # 2 of the 5 coin tokens were spent on overpay.
+    assert player.coin_tokens == 3
+    assert player.coins == 0
+
+
+def test_overpay_max_amount_includes_coin_tokens():
+    """The AI's max_amount should include both coins and coin tokens."""
+
+    ai = OverpayingAI(overpay=0, target_card="Masterpiece")
+    state, player = _make_state(ai)
+    state.supply["Masterpiece"] = 10
+    player.coins = 3  # exactly cost
+    player.coin_tokens = 4
+
+    state.handle_buy_phase()
+
+    # max_amount should be 0 (coins) + 4 (tokens) = 4.
+    assert ai.overpay_calls == [("Masterpiece", 4)]
+
+
+# --- Black Market: overpay must trigger via that buy path too --------------
+
+
+def test_black_market_buying_masterpiece_triggers_overpay():
+    """Buying Masterpiece via Black Market should fire overpay (not just buy phase)."""
+    from dominion.cards.promo.black_market import BlackMarket
+
+    ai = OverpayingAI(overpay=3, target_card="Masterpiece")
+    state, player = _make_state(ai)
+    state.supply["Masterpiece"] = 10
+
+    # Force Black Market to reveal Masterpiece.
+    state.black_market_deck = ["Masterpiece"]
+
+    # AI must agree to buy revealed Masterpiece.
+    def _choose_bm(state, player, choices):
+        for c in choices:
+            if c.name == "Masterpiece":
+                return c
+        return None
+
+    ai.choose_black_market_purchase = _choose_bm  # type: ignore[assignment]
+    ai.order_cards_for_black_market_bottom = (  # type: ignore[assignment]
+        lambda state, player, choices: list(choices)
+    )
+
+    player.coins = 6  # cost $3 + overpay $3
+    player.buys = 1
+
+    BlackMarket().play_effect(state)
+
+    silvers = sum(1 for c in player.discard if c.name == "Silver")
+    assert silvers == 3, f"Black Market overpay should gain 3 Silvers, got {silvers}"
+    assert any(c.name == "Masterpiece" for c in player.discard)
+    assert ai.overpay_calls and ai.overpay_calls[-1][0] == "Masterpiece"


### PR DESCRIPTION
## Summary
- Extract `_prompt_overpay` helper so overpay fires on every buy code path (fixes Black Market regression for Doctor/Herald/Masterpiece/Stonemason)
- Include `coin_tokens` in the overpay cap and allow spending tokens for overpay, matching the rest of the engine's purchase-currency handling
- Add regression tests for both fixes

Addresses both review comments on PR #184:
- P1: Apply overpay effects outside `handle_buy_phase` (Black Market)
- P1: Include coin tokens when capping overpay amount

## Test plan
- [x] `pytest -x -q` — 978 passed (3 new tests)
- [x] New: `test_overpay_can_be_paid_with_coin_tokens`
- [x] New: `test_overpay_max_amount_includes_coin_tokens`
- [x] New: `test_black_market_buying_masterpiece_triggers_overpay`