### PR TITLE
Address PR #185 review feedback (cornucopia)

### DIFF
--- a/dominion/cards/base_card.py
+++ b/dominion/cards/base_card.py
@@ -235,6 +235,19 @@ class Card:
         """Return additional supply piles required by this card."""
         return {}
 
+    def get_additional_non_supply_piles(self) -> dict[str, int]:
+        """Return additional non-Supply piles required by this card.
+
+        These piles live alongside the Supply (so cards can be looked up and
+        gained from them via ``state.supply``) but they must NOT count toward
+        the three-empty-piles game-end condition. Examples: Tournament Prize
+        piles, Madman, Mercenary, Spirits, Wishes, Bats, Zombies, Horses,
+        Spoils. Currently used by Tournament; older callers still register
+        their non-Supply piles directly in ``state.supply`` without flagging
+        them, which is a known limitation tracked separately.
+        """
+        return {}
+
     def __str__(self) -> str:
         return self.name
 

--- a/dominion/cards/cornucopia/tournament.py
+++ b/dominion/cards/cornucopia/tournament.py
@@ -21,8 +21,12 @@ class Tournament(Card):
             types=[CardType.ACTION],
         )
 
-    def get_additional_piles(self) -> dict[str, int]:
-        # Each Prize is a single non-supply card forming the Prize pile.
+    def get_additional_non_supply_piles(self) -> dict[str, int]:
+        # Each Prize is a single non-Supply card forming the Prize pile.
+        # Prizes live in ``state.supply`` for lookup/gain convenience but
+        # they are non-Supply and must not count toward the three-empty-
+        # piles game-end condition (handled via
+        # ``GameState.non_supply_pile_names``).
         return {name: 1 for name in PRIZE_CARD_NAMES}
 
     def play_effect(self, game_state):

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -70,6 +70,12 @@ class GameState:
     # Ruins, Spoils, or Horse.
     original_kingdom_pile_names: set = field(default_factory=set)
 
+    # Names of piles in ``self.supply`` that are non-Supply (e.g. Cornucopia
+    # Tournament Prizes). These are excluded from the three-empty-piles
+    # game-end condition because emptying a non-Supply pile is not, by the
+    # rules, an empty Supply pile.
+    non_supply_pile_names: set = field(default_factory=set)
+
     # Cornucopia: Young Witch designates an extra $2/$3 Kingdom pile as the
     # Bane. A card from that pile, revealed from hand, blocks a Young Witch
     # attack against the holder.
@@ -402,6 +408,12 @@ class GameState:
                 if name not in self.supply:
                     self.supply[name] = count
 
+            non_supply_extras = card.get_additional_non_supply_piles()
+            for name, count in non_supply_extras.items():
+                if name not in self.supply:
+                    self.supply[name] = count
+                self.non_supply_pile_names.add(name)
+
             if card.name == "Baker":
                 self.baker_in_supply = True
 
@@ -576,6 +588,12 @@ class GameState:
         empties = 0
         for name in list(self.supply.keys()):
             if name in counted:
+                continue
+            # Non-Supply piles (e.g. Tournament Prizes) live in self.supply
+            # for lookup convenience but must not advance the three-empty-
+            # piles end condition.
+            if name in self.non_supply_pile_names:
+                counted.add(name)
                 continue
             card = get_card(name)
             if isinstance(card, WizardsSplitCard):

--- a/tests/test_cornucopia_prizes_bane.py
+++ b/tests/test_cornucopia_prizes_bane.py
@@ -128,6 +128,24 @@ def test_prizes_are_not_buyable():
         assert not prize.may_be_bought(state)
 
 
+def test_prize_piles_excluded_from_three_pile_end_condition():
+    """Emptying every Prize pile must not advance the three-empty-piles
+    end condition: Prizes are non-Supply.
+    """
+    state, _ = _setup(FirstChoiceAI(), [get_card("Tournament")])
+    # Sanity: no Supply piles are empty at game start.
+    assert state.empty_piles == 0
+    # All Prize piles registered as non-Supply.
+    for name in PRIZE_CARD_NAMES:
+        assert name in state.non_supply_pile_names
+    # Empty every Prize pile (5 piles — well over 3).
+    for name in PRIZE_CARD_NAMES:
+        state.supply[name] = 0
+    # Empty piles count must still be 0 (Province pile non-empty too).
+    assert state.empty_piles == 0
+    assert not state.is_game_over()
+
+
 # ---------------------------------------------------------------------------
 # Tournament behaviour
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Exclude Tournament Prize piles from the three-empty-piles game-end check (PR #185 review feedback)
- Add `Card.get_additional_non_supply_piles()` hook and `GameState.non_supply_pile_names` so non-Supply piles can live in `state.supply` for lookup/gain without polluting end-condition counts
- Tournament now registers its 5 Prizes via the new hook

## Why
Prizes are non-Supply, but the original implementation put them in `state.supply` via `get_additional_piles()`. The global `empty_piles` property counted any zero pile in `state.supply`, so taking three Prizes alone could end a Tournament game before any real Supply pile emptied.

## Test plan
- [x] `pytest -x -q` (976 passed)
- [x] New regression test `test_prize_piles_excluded_from_three_pile_end_condition` empties every Prize pile and asserts `empty_piles == 0` and `is_game_over() is False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)