### PR TITLE
Address PR #179 review feedback (base set)

### DIFF
--- a/dominion/cards/base_set/artisan.py
+++ b/dominion/cards/base_set/artisan.py
@@ -42,12 +42,16 @@ class Artisan(Card):
             if game_state.supply.get(chosen.name, 0) > 0:
                 game_state.supply[chosen.name] -= 1
                 gained = game_state.gain_card(player, chosen)
+                # Only redirect the gain into hand if reactions (Watchtower
+                # trash/topdeck, Royal Seal, Gatekeeper exile, etc.) haven't
+                # already moved the card object out of discard/deck. If the
+                # card is in trash/exile we must not resurrect it.
                 if gained is not None:
                     if gained in player.discard:
                         player.discard.remove(gained)
+                        player.hand.append(gained)
                     elif gained in player.deck:
                         player.deck.remove(gained)
-                    if gained not in player.hand:
                         player.hand.append(gained)
 
         # 2) Put a card from hand onto your deck.

--- a/dominion/cards/treasures.py
+++ b/dominion/cards/treasures.py
@@ -38,10 +38,12 @@ class Silver(Card):
         """Apply Merchant's "first Silver this turn = +$1" bonus."""
 
         player = game_state.current_player
+        already_played_silver = getattr(
+            player, "merchant_silver_bonus_used", False
+        )
         bonus = getattr(player, "merchant_silver_bonus", 0)
-        if bonus and not getattr(player, "merchant_silver_bonus_used", False):
+        if bonus and not already_played_silver:
             player.coins += bonus
-            player.merchant_silver_bonus_used = True
             game_state.log_callback(
                 (
                     "action",
@@ -50,6 +52,11 @@ class Silver(Card):
                     {"bonus": bonus},
                 )
             )
+        # Mark that a Silver has been played this turn even if no Merchant
+        # bonus was active. Otherwise a Silver played before any Merchant
+        # would let a later Silver (after Merchant) incorrectly claim the
+        # "first Silver this turn" bonus.
+        player.merchant_silver_bonus_used = True
 
 
 class Gold(Card):

--- a/tests/test_base_set_cards.py
+++ b/tests/test_base_set_cards.py
@@ -102,6 +102,36 @@ def test_merchant_only_first_silver_gets_bonus():
     assert player.coins - coins_before == 5
 
 
+def test_merchant_does_not_apply_to_silver_played_after_an_earlier_silver():
+    """A Silver played before any Merchant must consume the "first Silver"
+    slot, so that a later Silver played after a Merchant gets no bonus.
+    """
+
+    state = _make_state()
+    player = state.players[0]
+
+    s1 = get_card("Silver")
+    merchant = get_card("Merchant")
+    s2 = get_card("Silver")
+    player.hand = [s1, merchant, s2]
+
+    coins_before = player.coins
+
+    # Play Silver before any Merchant (e.g. via Storyteller / Black Market /
+    # Vassal-style effects in a normal turn).
+    s1.on_play(state)
+    # Now play Merchant (queues +$1 bonus).
+    play_action(state, player, merchant)
+    # Now play a second Silver.
+    s2.on_play(state)
+
+    # First Silver: +$2 (no Merchant active yet, no bonus).
+    # Merchant: +0 coins directly.
+    # Second Silver: +$2 only -- the "first Silver this turn" was already
+    # played, so the +$1 bonus must NOT apply.
+    assert player.coins - coins_before == 4
+
+
 # ---- Vassal -----------------------------------------------------------------
 
 
@@ -311,6 +341,44 @@ def test_artisan_gains_to_hand_and_topdecks_from_hand():
     # Hand should now contain the gained card (we've also topdecked one of
     # them, so net hand size = 2 + 1 gained - 1 topdecked = 2).
     assert len(player.hand) == 2 or len(player.hand) == 1
+
+
+def test_artisan_does_not_resurrect_card_trashed_by_watchtower():
+    """If Watchtower trashes Artisan's gain, the card must NOT also end up
+    in hand. The trashed instance must remain only in the trash pile.
+    """
+
+    class WatchtowerTrashAI(ChooseFirstActionAI):
+        def choose_watchtower_reaction(self, state, player, gained_card):
+            # Trash everything that Artisan tries to gain.
+            return "trash"
+
+    state = _make_state(ai_class=WatchtowerTrashAI)
+    player = state.players[0]
+
+    artisan = get_card("Artisan")
+    watchtower = get_card("Watchtower")
+    junk = get_card("Estate")
+    player.hand = [artisan, watchtower, junk]
+
+    play_action(state, player, artisan)
+
+    # The gained card should be in the trash, NOT duplicated in hand.
+    assert len(state.trash) >= 1, "expected the gained card to be trashed"
+    trashed = state.trash[-1]
+    assert trashed not in player.hand
+    assert trashed not in player.discard
+    assert trashed not in player.deck
+
+    # The same Card object must not appear simultaneously in trash and in any
+    # of the player's zones.
+    all_player_cards = (
+        player.hand + player.discard + player.deck + player.in_play
+    )
+    for trashed_card in state.trash:
+        assert trashed_card not in all_player_cards, (
+            f"trashed {trashed_card.name} also present in player zones"
+        )
 
 
 # ---- Chancellor (1E) --------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses the two unresolved Codex review comments on #179.

### P1 — `dominion/cards/base_set/artisan.py:51`
> Preserve gain-reaction outcomes when Artisan gains to hand.

**Status: fixed.** `gain_card()` runs Watchtower / Royal Seal / Gatekeeper / Trader hooks, any of which can move the gained card object out of `discard`/`deck` (into trash, exile, or onto the deck). Artisan's old code unconditionally appended the gained instance to `hand`, leaving the same `Card` object in two zones (e.g., trash *and* hand). The fix only redirects into hand when the card is still found in `discard` or `deck`; otherwise the reaction's outcome stands.

### P2 — `dominion/cards/treasures.py:36`
> Mark first Silver as consumed even without Merchant bonus.

**Status: fixed.** `merchant_silver_bonus_used` was only set when a bonus actually fired. So a turn where Silver was played before any Merchant (possible via Storyteller, Black Market, Vassal-replayed treasure-trick effects, etc.) would still let a Silver played after a later Merchant claim the +$1, violating "first Silver this turn". The flag is now set on every Silver play.

## Tests

- `test_artisan_does_not_resurrect_card_trashed_by_watchtower` — confirms a Watchtower-trashed Artisan gain stays in trash and is not also in hand/discard/deck.
- `test_merchant_does_not_apply_to_silver_played_after_an_earlier_silver` — Silver, Merchant, Silver in that order: total coin gain must be 4, not 5.

Both new tests fail on `main` and pass on this branch. Full suite: `977 passed`.

## Test plan
- [x] `pytest -x -q` (977 passed)
- [x] Verified each new test fails without its corresponding fix