### PR TITLE
Address PR #188 review feedback (renaissance)

### DIFF
--- a/dominion/cards/renaissance/experiment.py
+++ b/dominion/cards/renaissance/experiment.py
@@ -23,9 +23,12 @@ class Experiment(Card):
     def play_effect(self, game_state):
         player = game_state.current_player
         # Return this card to its supply pile rather than discarding it.
+        # Only return if this physical copy is still in play; if a multiplier
+        # (e.g., Throne Room) replays Experiment, the second resolution should
+        # not add another phantom copy to the pile.
         if self in player.in_play:
             player.in_play.remove(self)
-        game_state.supply["Experiment"] = game_state.supply.get("Experiment", 0) + 1
+            game_state.supply["Experiment"] = game_state.supply.get("Experiment", 0) + 1
 
     def on_gain(self, game_state, player):
         super().on_gain(game_state, player)

--- a/dominion/cards/renaissance/scepter.py
+++ b/dominion/cards/renaissance/scepter.py
@@ -18,14 +18,22 @@ class Scepter(Card):
     def play_effect(self, game_state):
         player = game_state.current_player
 
-        # Find Action cards in play that aren't durations remaining for
-        # later turns (we treat any Action in play as eligible — Renaissance
-        # rules require it was played this turn, which is true for anything
-        # in player.in_play).
+        # Renaissance rules: Scepter replays an Action played THIS turn.
+        # Duration cards from prior turns linger in ``player.in_play`` but
+        # are no longer tracked in ``player.duration`` /
+        # ``player.multiplied_durations`` (they were resolved and removed
+        # at the start of this turn). Exclude them so we don't illegally
+        # replay them this turn.
+        active_durations = set(map(id, player.duration)) | set(
+            map(id, player.multiplied_durations)
+        )
         replayable = [
             c
             for c in player.in_play
-            if c.is_action and c is not self and c.name != "Scepter"
+            if c.is_action
+            and c is not self
+            and c.name != "Scepter"
+            and (not c.is_duration or id(c) in active_durations)
         ]
         if replayable:
             choice = max(

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1918,8 +1918,15 @@ class GameState:
             )
         ):
             self.fleet_extra_round_active = True
+            # Build the queue starting from the player whose turn is next
+            # (i.e. the seat after the player who triggered game end).
+            # ``current_player_index`` already points to that next seat
+            # because cleanup advances it before is_game_over runs.
+            n = len(self.players)
+            start = self.current_player_index % n if n else 0
+            ordered = [self.players[(start + i) % n] for i in range(n)]
             self.fleet_extra_players = [
-                pl for pl in self.players
+                pl for pl in ordered
                 if any(getattr(p, "name", "") == "Fleet" for p in pl.projects)
             ]
             self.log_callback("Fleet: extra round of turns for Fleet owners")

--- a/dominion/projects/sinister_plot.py
+++ b/dominion/projects/sinister_plot.py
@@ -19,9 +19,10 @@ class SinisterPlot(Project):
         # The AI may override later; default keeps us building cards for
         # explosive draws.
         if self.tokens >= 3:
-            # Remove a token, then +X Cards where X = remaining tokens.
-            self.tokens -= 1
-            if self.tokens > 0:
-                game_state.draw_cards(player, self.tokens)
+            # Cash in: remove ALL tokens and +X Cards where X = tokens removed.
+            cashed = self.tokens
+            self.tokens = 0
+            if cashed > 0:
+                game_state.draw_cards(player, cashed)
         else:
             self.tokens += 1

--- a/tests/test_renaissance_projects.py
+++ b/tests/test_renaissance_projects.py
@@ -138,11 +138,11 @@ def test_sinister_plot_stockpiles_then_draws():
         state.handle_start_phase()
         state.phase = "start"
     assert project.tokens == 3
-    # 4th turn-start: remove a token, then +2 Cards.
+    # 4th turn-start: remove ALL tokens and +X Cards where X = tokens removed.
     p.hand = []
     state.handle_start_phase()
-    assert project.tokens == 2
-    assert len(p.hand) >= 2
+    assert project.tokens == 0
+    assert len(p.hand) >= 3
 
 
 def test_academy_grants_villager_on_action_gain():


### PR DESCRIPTION
## Summary

Addresses the four review comments left on the merged PR #188 (Renaissance implementation).

- **Sinister Plot (P1)**: Cash out ALL tokens at once. The old code removed a single token then drew based on the remaining count, leaving tokens behind and under-drawing.
- **Experiment (P1)**: Only return the card to its supply pile when it's actually still in `in_play`. Multiplier-replay (e.g., Throne Room) no longer creates phantom copies in the pile.
- **Scepter (P1)**: Exclude prior-turn Duration cards from replay choices. Durations from earlier turns linger in `player.in_play` but are no longer tracked in `player.duration` / `player.multiplied_durations`, so only Actions played this turn remain eligible per Renaissance rules.
- **Fleet (P2)**: Build the bonus-round queue starting from the seat after the player who ended the game (cleanup already advances `current_player_index` before `is_game_over` runs), restoring correct turn order in multi-Fleet-owner endgames.

Also updated `test_sinister_plot_stockpiles_then_draws` to assert the corrected rule (token count goes to 0; +3 Cards drawn).

## Test plan
- [x] `pytest -x -q` — 975 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)