### PR TITLE
Address PR #181 review feedback (prosperity 2E)

### DIFF
--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1244,10 +1244,10 @@ class GameState:
                         on_play(self, player, choice)
 
                 # Prosperity 2E: Tiara — once per turn, when you play a
-                # Treasure, you may play it again.
+                # Treasure, you may play it again. Tiara may target itself
+                # (the once-per-turn limit is enforced by ``tiara_replay_used``).
                 if (
                     not getattr(player, "tiara_replay_used", False)
-                    and choice.name != "Tiara"
                     and any(card.name == "Tiara" for card in player.in_play)
                     and choice in player.in_play
                 ):
@@ -1654,20 +1654,6 @@ class GameState:
             if hook is not None:
                 hook(self, player)
 
-        # Prosperity 2E: Anvil and similar "when you discard this from play"
-        # cards trigger BEFORE the hand is discarded so the player can choose
-        # to discard a Treasure from their actual end-of-turn hand. Cards
-        # that opt in expose ``on_discard_from_play``; we resolve them here
-        # while leaving the card itself in play (the regular cleanup loop
-        # below will then discard it normally).
-        for card in list(player.in_play):
-            if (
-                hasattr(card, "on_discard_from_play")
-                and card not in player.duration
-                and card not in player.multiplied_durations
-            ):
-                card.on_discard_from_play(self, player)
-
         # Discard hand and in-play cards
         scheme_count = sum(1 for card in player.in_play if card.name == "Scheme")
         if scheme_count:
@@ -1684,6 +1670,89 @@ class GameState:
                     player.in_play.remove(chosen)
                 player.deck.insert(0, chosen)
 
+        # Plunder Pendant: +$1 per differently-named Treasure in play per Pendant.
+        # Calculated before any hand-mutating cleanup hooks fire.
+        pendants_in_play = [c for c in player.in_play if c.name == "Pendant"]
+        if pendants_in_play:
+            distinct_treasures = {c.name for c in player.in_play if c.is_treasure}
+            for _ in pendants_in_play:
+                player.coins += len(distinct_treasures)
+
+        # Duration cards remain in play until their lingering effects finish.
+        durations_to_keep = set(player.duration + player.multiplied_durations)
+
+        # Determine which Treasures (if any) Trickster will set aside before
+        # firing discard-from-play hooks, so we don't trigger those hooks on
+        # cards that ultimately won't be discarded this cleanup.
+        trickster_selected: list[Card] = []
+        trickster_uses = getattr(player, "trickster_uses_remaining", 0)
+        if trickster_uses > 0:
+            non_duration_in_play = [
+                card for card in player.in_play if card not in durations_to_keep
+            ]
+            treasures_in_play = [
+                card for card in non_duration_in_play if card.is_treasure
+            ]
+            if treasures_in_play:
+                max_set_aside = min(trickster_uses, len(treasures_in_play))
+                chosen = player.ai.choose_treasures_to_set_aside_with_trickster(
+                    self, player, list(treasures_in_play), max_set_aside
+                )
+                remaining_choices = list(treasures_in_play)
+                for card in chosen:
+                    if card in remaining_choices:
+                        remaining_choices.remove(card)
+                        trickster_selected.append(card)
+                if trickster_selected:
+                    player.trickster_set_aside.extend(trickster_selected)
+                    player.trickster_uses_remaining = max(
+                        0, player.trickster_uses_remaining - len(trickster_selected)
+                    )
+
+        def _will_be_discarded_from_play(card) -> bool:
+            """Return True if ``card`` will actually be discarded from play
+            during this cleanup (i.e. won't stay as a duration, get topdecked,
+            be set aside by Trickster/Tireless, or get returned to the supply
+            by Panic). Used to gate ``on_discard_from_play`` hooks so they
+            only fire for cards that genuinely get discarded."""
+            if card in durations_to_keep:
+                return False
+            if card in trickster_selected:
+                return False
+            if getattr(card, "_frog_topdeck", False):
+                return False
+            if (
+                card.name == "Walled Village"
+                and getattr(player, "walled_villages_played", 0) <= 1
+            ):
+                return False
+            if card.name == "Border Guard" and getattr(
+                card, "horn_topdeck_pending", False
+            ):
+                return False
+            if (
+                card.is_treasure
+                and getattr(player, "panic_active", False)
+                and card.name in self.supply
+            ):
+                return False
+            if card.name in self.tireless_piles:
+                return False
+            return True
+
+        # Prosperity 2E: Anvil and similar "when you discard this from play"
+        # cards trigger BEFORE the hand is discarded so the player can choose
+        # to discard a Treasure from their actual end-of-turn hand. Only fire
+        # the hook for cards that will actually be discarded from play this
+        # cleanup (filtered above) — otherwise cards like Anvil could grant
+        # their bonus while being set aside by Trickster, etc.
+        for card in list(player.in_play):
+            if (
+                hasattr(card, "on_discard_from_play")
+                and _will_be_discarded_from_play(card)
+            ):
+                card.on_discard_from_play(self, player)
+
         # Plunder Patient trait: at end of turn, mat cards from Patient pile.
         patient_pile = self.trait_piles.get("Patient")
         if patient_pile:
@@ -1693,42 +1762,15 @@ class GameState:
                 for card in patient_cards:
                     player.hand.remove(card)
 
-        # Plunder Pendant: +$1 per differently-named Treasure in play per Pendant.
-        pendants_in_play = [c for c in player.in_play if c.name == "Pendant"]
-        if pendants_in_play:
-            distinct_treasures = {c.name for c in player.in_play if c.is_treasure}
-            for _ in pendants_in_play:
-                player.coins += len(distinct_treasures)
-
         hand_cards = list(player.hand)
         player.hand = []
         self.discard_cards(player, hand_cards, from_cleanup=True)
 
-        # Duration cards remain in play until their lingering effects finish.
         in_play_cards = list(player.in_play)
         player.in_play = []
-        durations_to_keep = set(player.duration + player.multiplied_durations)
-
-        trickster_selected: list[Card] = []
-        trickster_uses = getattr(player, "trickster_uses_remaining", 0)
-        if trickster_uses > 0:
-            treasures_in_play = [card for card in in_play_cards if card.is_treasure]
-            if treasures_in_play:
-                max_set_aside = min(trickster_uses, len(treasures_in_play))
-                chosen = player.ai.choose_treasures_to_set_aside_with_trickster(
-                    self, player, list(treasures_in_play), max_set_aside
-                )
-                remaining_choices = list(treasures_in_play)
-                for card in chosen:
-                    if card in remaining_choices and card in in_play_cards:
-                        remaining_choices.remove(card)
-                        in_play_cards.remove(card)
-                        trickster_selected.append(card)
-                if trickster_selected:
-                    player.trickster_set_aside.extend(trickster_selected)
-                    player.trickster_uses_remaining = max(
-                        0, player.trickster_uses_remaining - len(trickster_selected)
-                    )
+        for card in trickster_selected:
+            if card in in_play_cards:
+                in_play_cards.remove(card)
 
         tireless_set_aside: list[Card] = []
 

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -443,6 +443,50 @@ def test_anvil_no_gain_when_no_treasure_in_hand():
     assert state.supply["Silver"] == silver_supply_before
 
 
+class AnvilTricksterAI(AnvilAI):
+    """Set aside Anvil with Trickster (when offered) and otherwise behave
+    like ``AnvilAI`` for the rest of the cleanup choices."""
+
+    def choose_treasures_to_set_aside_with_trickster(
+        self, state, player, treasures, max_count
+    ):
+        anvils = [c for c in treasures if c.name == "Anvil"]
+        return anvils[:max_count]
+
+
+def test_anvil_does_not_trigger_when_trickster_sets_it_aside():
+    """When Trickster sets Anvil aside during cleanup, Anvil's
+    ``on_discard_from_play`` hook must NOT fire (Anvil is never actually
+    discarded from play this turn)."""
+    ai = AnvilTricksterAI(gain_target="Silver")
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([get_card("Anvil"), get_card("Silver")])
+
+    anvil = get_card("Anvil")
+    copper = get_card("Copper")
+    estate = get_card("Estate")
+
+    player.in_play = [anvil]
+    player.hand = [copper, estate]
+    player.trickster_uses_remaining = 1
+
+    silver_supply_before = state.supply["Silver"]
+    state.handle_cleanup_phase()
+
+    # Anvil should be set aside (and returned to hand for next turn) — not
+    # discarded — so its bonus must not trigger and no Silver should be
+    # gained, nor should the Copper be discarded to feed Anvil's effect.
+    assert state.supply["Silver"] == silver_supply_before
+    assert any(c.name == "Anvil" for c in player.hand)
+    # Copper still cycles through cleanup (hand is discarded) but no gain
+    # was triggered from supply.
+    gained_silver = sum(
+        1 for c in player.hand + player.discard + player.deck if c.name == "Silver"
+    )
+    assert gained_silver == 0
+
+
 # ---------------------------------------------------------------------------
 # Charlatan ($5 Action-Attack)
 # ---------------------------------------------------------------------------
@@ -645,7 +689,9 @@ def test_investment_trash_treasure_grants_vp_for_distinct_treasures():
 
 class TiaraReplayAI(DummyAI):
     def should_replay_treasure_with_tiara(self, state, player, treasure):
-        return True
+        # Don't waste the once-per-turn replay on Tiara itself when better
+        # treasures are available; replay any other Treasure.
+        return treasure.name != "Tiara"
 
     def should_topdeck_with_tiara(self, state, player, gained_card):
         return True
@@ -657,6 +703,24 @@ class TiaraReplayAI(DummyAI):
                 if c is not None and c.name == name:
                     return c
         return None
+
+
+class TiaraReplayAnyAI(DummyAI):
+    """Always replay with Tiara, even Tiara itself (used to verify
+    self-replay is now permitted)."""
+
+    def should_replay_treasure_with_tiara(self, state, player, treasure):
+        return True
+
+    def should_topdeck_with_tiara(self, state, player, gained_card):
+        return True
+
+    def choose_treasure(self, state, choices):
+        # Play Tiara first so it has a chance to self-replay.
+        for c in choices:
+            if c is not None and c.name == "Tiara":
+                return c
+        return next((c for c in choices if c is not None), None)
 
 
 def test_tiara_grants_buy():
@@ -689,6 +753,30 @@ def test_tiara_replays_treasure_once_per_turn():
     # Tiara: +1 Buy, no coin. Silver: $2 (replayed once via Tiara) ⇒ $4. Copper: $1.
     # So total = 4 + 1 = 5
     assert player.coins == 5
+    assert player.tiara_replay_used
+
+
+def test_tiara_can_replay_itself():
+    """Tiara may target itself for the once-per-turn replay. The card has
+    no coin output, but replaying it grants an extra +1 Buy (and the
+    once-per-turn limit is enforced by ``tiara_replay_used``)."""
+    ai = TiaraReplayAnyAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([get_card("Tiara"), get_card("Copper")])
+
+    tiara = get_card("Tiara")
+    copper = get_card("Copper")
+    player.hand = [tiara, copper]
+    initial_buys = player.buys
+
+    state.phase = "treasure"
+    state.handle_treasure_phase()
+
+    # Tiara plays once + self-replays once (+2 Buys total). Copper: $1.
+    # No further replay because Tiara's once-per-turn limit is now used.
+    assert player.coins == 1
+    assert player.buys == initial_buys + 2
     assert player.tiara_replay_used
 
 


### PR DESCRIPTION
## Summary

Addresses the two review comments left on PR #181 (Prosperity 2E new cards + King's Court / Watchtower fixes), which was already merged.

### P1 — Trigger discard-from-play hooks only on actual discard
The `on_discard_from_play` hook ran for every card in play before Trickster's set-aside logic, Way of the Frog, Walled Village, Horn-pending Border Guard, Rising Sun Panic, and Tireless decisions resolved. That meant cards like **Anvil** could fire their cleanup bonus while being set aside by Trickster — an illegal extra trigger.

Cleanup now:
1. Computes Trickster's set-aside choice up front.
2. Gates the hook on a `_will_be_discarded_from_play(card)` predicate covering durations, Trickster set-aside, Way of the Frog, Walled Village, Horn-pending Border Guard, Panic-returned Treasures, and Tireless piles.
3. Fires `on_discard_from_play` only for cards that genuinely will be discarded from play this cleanup.

### P2 — Permit Tiara to replay itself once per turn
Removed the `choice.name != "Tiara"` guard on Tiara's once-per-turn replay. The official rule allows Tiara to replay itself; the `tiara_replay_used` flag already prevents loops.

## Test plan
- [x] `pytest -x -q` — all 977 tests pass.
- [x] New regression: `test_anvil_does_not_trigger_when_trickster_sets_it_aside`.
- [x] New regression: `test_tiara_can_replay_itself` verifies Tiara self-replay grants +2 Buys (one play + one self-replay) before `tiara_replay_used` blocks further replays.
- [x] Existing `test_tiara_replays_treasure_once_per_turn` updated so its AI doesn't waste the replay on Tiara itself when better Treasures are available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)