### PR TITLE
Address PR #182 review feedback (intrigue)

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -891,6 +891,38 @@ class AI(ABC):
         """
         return any(card.name == "Estate" for card in player.hand)
 
+    def should_trash_mining_village(
+        self, state: GameState, player: PlayerState
+    ) -> bool:
+        """Decide whether to trash Mining Village for +$2.
+
+        Mining Village is normally more valuable as a Village body, so
+        the default keeps it. Trash only when the +$2 unlocks a key
+        gain this turn (Province / Colony / Duchy in late game, or
+        Gold) and we have enough actions to keep the chain going
+        without this Village.
+        """
+        # If we'd waste actions by keeping it, lean toward trashing.
+        plenty_of_actions = player.actions >= 1 and not any(
+            c.is_action for c in player.hand
+        )
+        coins = player.coins + 2
+
+        # Rough late-game/closing-buy heuristic.
+        province_cost = 8
+        if player.coins < province_cost <= coins and state.supply.get("Province", 0) > 0:
+            return True
+        colony_cost = 11
+        if player.coins < colony_cost <= coins and state.supply.get("Colony", 0) > 0:
+            return True
+
+        # If Village body is dead weight (no remaining actions in hand
+        # and we already have spare actions), the +$2 is pure upside.
+        if plenty_of_actions and player.coins < 6 <= coins:
+            return True
+
+        return False
+
     def should_reveal_diplomat(
         self, state: GameState, player: PlayerState
     ) -> bool:
@@ -907,7 +939,15 @@ class AI(ABC):
     ) -> Optional[Card]:
         """Pick a card from hand to insert anywhere in the deck.
 
-        Default: top-deck the best Action so it's drawn next.
+        Secret Passage's placement is mandatory: with a non-empty hand, a
+        card must be moved into the deck. We therefore always return a
+        choice when one is available.
+
+        Default priority:
+            1. Top-deck the best Action so it's drawn next.
+            2. Otherwise top-deck the most valuable non-Copper Treasure.
+            3. Otherwise (only junk in hand) bury the worst junk card,
+               which the position hook places at the bottom of the deck.
         """
         if not choices:
             return None
@@ -917,7 +957,16 @@ class AI(ABC):
         treasures = [c for c in choices if c.is_treasure and c.name != "Copper"]
         if treasures:
             return max(treasures, key=lambda c: (c.cost.coins, c.name))
-        return None
+        # Hand is only Coppers / Curses / cheap Victories. The placement
+        # is still mandatory, so pick the worst junk to bury at the
+        # bottom (handled by ``choose_secret_passage_position``).
+        junk_priority = {"Curse": 0, "Copper": 1}
+
+        def junk_rank(card: Card) -> tuple:
+            base = junk_priority.get(card.name, 2)
+            return (base, card.cost.coins, card.name)
+
+        return min(choices, key=junk_rank)
 
     def choose_secret_passage_position(
         self,
@@ -930,8 +979,17 @@ class AI(ABC):
 
         ``deck_size`` is the size of the deck before insertion. Index 0
         means the bottom; ``deck_size`` means the top (drawn first).
-        Default: top of deck.
+
+        Default: top-deck Actions and good Treasures so they're drawn
+        next; bury junk (Curses, Coppers, cheap Victories) at the
+        bottom so it doesn't clog the next reshuffle's top.
         """
+        is_junk = (
+            card.name in {"Curse", "Copper", "Estate", "Hovel", "Overgrown Estate"}
+            or (card.is_victory and not card.is_action and card.cost.coins <= 2)
+        )
+        if is_junk:
+            return 0
         return deck_size
 
     def choose_courtier_options(
@@ -1071,14 +1129,21 @@ class AI(ABC):
         return max(candidates, key=lambda c: (c.is_action, c.cost.coins, c.name))
 
     def should_discard_secret_chamber(
-        self, state: GameState, player: PlayerState
+        self, state: GameState, player: PlayerState, reveal_count: int = 0
     ) -> bool:
         """Decide whether to reveal Secret Chamber as a Reaction to an Attack.
 
-        Default: reveal — drawing 2 then putting 2 back has limited
-        downside and bypasses the attack's hand-disruption.
+        ``reveal_count`` is how many times Secret Chamber has already
+        been revealed against the current Attack trigger; the rules
+        permit additional reveals but the engine asks again before
+        each one.
+
+        Default: reveal once per Attack — drawing 2 then putting 2 back
+        cycles cards and bypasses the attack's hand-disruption. After
+        the first reveal the net effect is zero hand-size change, so
+        further reveals only waste shuffles and are skipped by default.
         """
-        return True
+        return reveal_count == 0
 
     def choose_secret_chamber_discards(
         self, state: GameState, player: PlayerState

--- a/dominion/cards/intrigue/mining_village.py
+++ b/dominion/cards/intrigue/mining_village.py
@@ -18,7 +18,7 @@ class MiningVillage(Card):
         player = game_state.current_player
         # The card has been moved from hand into player.in_play before
         # play_effect runs. Decide whether to trash it for +$2.
-        if not self._should_self_trash(player):
+        if not self._should_self_trash(game_state, player):
             return
 
         # Find this exact instance in play and trash it.
@@ -29,8 +29,17 @@ class MiningVillage(Card):
                 player.coins += 2
                 return
 
-    def _should_self_trash(self, player) -> bool:
-        # Default: never self-trash. Mining Village is a Village body
-        # that's normally more useful than a one-shot +$2; only specific
-        # AIs/strategies should opt in by overriding this.
-        return False
+    def _should_self_trash(self, game_state, player) -> bool:
+        """Ask the AI whether to trash this Mining Village for +$2.
+
+        The AI hook lives on ``BaseAI.should_trash_mining_village`` so
+        strategies can opt in (e.g., when the +$2 closes out a Province
+        buy or the Village body is no longer needed for actions).
+        """
+        ai = getattr(player, "ai", None)
+        if ai is None:
+            return False
+        hook = getattr(ai, "should_trash_mining_village", None)
+        if hook is None:
+            return False
+        return bool(hook(game_state, player))

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -2798,69 +2798,92 @@ class GameState:
         attack_fn(target)
 
     def _maybe_react_diplomat(self, player: PlayerState) -> None:
-        """Resolve Diplomat reactions: with hand of 5+, draw 2 then discard 3."""
-        # Diplomat is a Reaction-Action; can only react if it's in hand.
-        diplomats = [card for card in player.hand if card.name == "Diplomat"]
-        if not diplomats:
-            return
-        if len(player.hand) < 5:
-            return
-        if not player.ai.should_reveal_diplomat(self, player):
-            return
+        """Resolve Diplomat reactions: with hand of 5+, draw 2 then discard 3.
 
-        self.log_callback(
-            ("action", player.ai.name, "reveals Diplomat to react", {})
-        )
-        self.draw_cards(player, 2)
-        # Now discard 3 chosen cards.
-        discards = player.ai.choose_cards_to_discard(
-            self, player, list(player.hand), 3, reason="diplomat"
-        )
-        actually_discarded: list[Card] = []
-        for card in discards[:3]:
-            if card in player.hand:
-                player.hand.remove(card)
-                self.discard_card(player, card)
-                actually_discarded.append(card)
-        # If the AI returned fewer than 3 picks, fall back to forcing
-        # discards (the rule text says "discard 3").
-        while len(actually_discarded) < 3 and player.hand:
-            fallback = min(player.hand, key=lambda c: (c.cost.coins, c.name))
-            player.hand.remove(fallback)
-            self.discard_card(player, fallback)
-            actually_discarded.append(fallback)
+        The Reaction is legal to reveal repeatedly while the hand still
+        has 5+ cards and a Diplomat in it (including re-revealing the
+        same copy). We loop until the AI declines, the hand drops
+        below 5, or no Diplomat is available — with a hard safety cap
+        to prevent any pathological infinite loop.
+        """
+        max_reveals = 32  # safety bound; well above any realistic deck.
+        for _ in range(max_reveals):
+            if not any(card.name == "Diplomat" for card in player.hand):
+                return
+            if len(player.hand) < 5:
+                return
+            if not player.ai.should_reveal_diplomat(self, player):
+                return
+
+            self.log_callback(
+                ("action", player.ai.name, "reveals Diplomat to react", {})
+            )
+            self.draw_cards(player, 2)
+            # Now discard 3 chosen cards.
+            discards = player.ai.choose_cards_to_discard(
+                self, player, list(player.hand), 3, reason="diplomat"
+            )
+            actually_discarded: list[Card] = []
+            for card in discards[:3]:
+                if card in player.hand:
+                    player.hand.remove(card)
+                    self.discard_card(player, card)
+                    actually_discarded.append(card)
+            # If the AI returned fewer than 3 picks, fall back to forcing
+            # discards (the rule text says "discard 3").
+            while len(actually_discarded) < 3 and player.hand:
+                fallback = min(player.hand, key=lambda c: (c.cost.coins, c.name))
+                player.hand.remove(fallback)
+                self.discard_card(player, fallback)
+                actually_discarded.append(fallback)
 
     def _maybe_react_secret_chamber(self, player: PlayerState) -> None:
-        """Resolve Secret Chamber reactions: +2 cards, then put 2 onto deck."""
-        chambers = [card for card in player.hand if card.name == "Secret Chamber"]
-        if not chambers:
-            return
-        if not player.ai.should_discard_secret_chamber(self, player):
-            return
+        """Resolve Secret Chamber reactions: +2 cards, then put 2 onto deck.
 
-        self.log_callback(
-            ("action", player.ai.name, "reveals Secret Chamber to react", {})
-        )
-        self.draw_cards(player, 2)
-        if not player.hand:
-            return
-        topdeck_picks = player.ai.choose_secret_chamber_topdeck(
-            self, player, list(player.hand)
-        )
-        placed = 0
-        for card in topdeck_picks:
-            if placed >= 2:
-                break
-            if card in player.hand:
-                player.hand.remove(card)
-                player.deck.append(card)
+        The Reaction can be revealed multiple times for one Attack
+        trigger (and may interleave with other Reactions drawn during
+        resolution). Loop until the AI declines or no Secret Chamber
+        remains in hand, with a safety cap.
+        """
+        max_reveals = 32  # safety bound.
+        reveal_count = 0
+        for _ in range(max_reveals):
+            if not any(card.name == "Secret Chamber" for card in player.hand):
+                return
+            try:
+                want_reveal = player.ai.should_discard_secret_chamber(
+                    self, player, reveal_count=reveal_count
+                )
+            except TypeError:
+                # Older AI overrides may not accept reveal_count.
+                want_reveal = player.ai.should_discard_secret_chamber(self, player)
+            if not want_reveal:
+                return
+            reveal_count += 1
+
+            self.log_callback(
+                ("action", player.ai.name, "reveals Secret Chamber to react", {})
+            )
+            self.draw_cards(player, 2)
+            if not player.hand:
+                return
+            topdeck_picks = player.ai.choose_secret_chamber_topdeck(
+                self, player, list(player.hand)
+            )
+            placed = 0
+            for card in topdeck_picks:
+                if placed >= 2:
+                    break
+                if card in player.hand:
+                    player.hand.remove(card)
+                    player.deck.append(card)
+                    placed += 1
+            # If AI didn't pick enough, top-deck cheapest cards.
+            while placed < 2 and player.hand:
+                fallback = min(player.hand, key=lambda c: (c.cost.coins, c.name))
+                player.hand.remove(fallback)
+                player.deck.append(fallback)
                 placed += 1
-        # If AI didn't pick enough, top-deck cheapest cards.
-        while placed < 2 and player.hand:
-            fallback = min(player.hand, key=lambda c: (c.cost.coins, c.name))
-            player.hand.remove(fallback)
-            player.deck.append(fallback)
-            placed += 1
 
     def _player_blocks_attack(
         self,

--- a/tests/test_intrigue_cards.py
+++ b/tests/test_intrigue_cards.py
@@ -764,3 +764,192 @@ def test_tribute_two_same_named_only_one_bonus():
 
     # Two Golds revealed but only one distinct-name bonus.
     assert p1.coins == 2
+
+
+# ---------------------------------------------------------------------------
+# PR #182 review-feedback follow-ups
+# ---------------------------------------------------------------------------
+
+
+def test_secret_passage_buries_junk_when_only_junk_in_hand():
+    """Secret Passage's placement is mandatory: if hand has only junk
+    (Coppers/Estates), the default AI must still pick a card and
+    place it (at the bottom of the deck)."""
+    state = GameState(players=[])
+    state.initialize_game([ChooseFirstActionAI()], [get_card("Secret Passage")])
+
+    player = state.players[0]
+    sp = get_card("Secret Passage")
+
+    # Hand and deck contain only junk; nothing valuable to top-deck.
+    # After +2 draw the hand will be all Coppers/Estates.
+    player.hand = [get_card("Estate"), get_card("Copper")]
+    player.deck = [get_card("Copper"), get_card("Estate")]
+    player.discard = []
+
+    sp.on_play(state)
+
+    # +2 cards then +1 action; one card must be placed back into the deck.
+    # Before play: hand=2, deck=2. After +2 draw: hand=4, deck=0.
+    # After mandatory placement: hand=3, deck=1.
+    assert len(player.hand) == 3
+    assert len(player.deck) == 1
+    # The placed card must be one of the junk cards.
+    assert player.deck[0].name in {"Estate", "Copper"}
+
+
+def test_mining_village_can_self_trash_via_ai_hook():
+    """Mining Village's optional +$2 self-trash must be reachable when
+    an AI's ``should_trash_mining_village`` returns True."""
+    from dominion.ai.base_ai import AI
+
+    class TrashMVAI(ChooseFirstActionAI):
+        def should_trash_mining_village(self, state, player):
+            return True
+
+    state = GameState(players=[])
+    state.initialize_game([TrashMVAI()], [get_card("Mining Village")])
+
+    player = state.players[0]
+    mv = get_card("Mining Village")
+
+    player.hand = []
+    player.deck = [get_card("Copper")]
+    player.coins = 0
+    # Engine moves the card into play before play_effect runs;
+    # simulate that here since we're invoking on_play directly.
+    player.in_play.append(mv)
+
+    mv.on_play(state)
+
+    # +1 Card +2 Actions, then opt-in self-trash for +$2.
+    assert player.coins == 2
+    # Mining Village is no longer in play (it was trashed).
+    assert not any(c.name == "Mining Village" for c in player.in_play)
+    assert any(c.name == "Mining Village" for c in state.trash)
+
+
+def test_diplomat_can_react_multiple_times_per_attack():
+    """Diplomat is a Reaction-Action; with a large enough hand it can
+    react more than once to the same Attack trigger. Each reveal
+    draws 2 and discards 3, so the hand naturally tapers."""
+
+    class AlwaysDiplomatAI(ChooseFirstActionAI):
+        # Inherit default should_reveal_diplomat (>=5 hand size).
+        pass
+
+    state = GameState(players=[])
+    state.initialize_game([AlwaysDiplomatAI()], [get_card("Diplomat")])
+
+    player = state.players[0]
+    # Start with two Diplomats and enough chaff for 5+ hand cards.
+    player.hand = [
+        get_card("Diplomat"),
+        get_card("Diplomat"),
+        get_card("Copper"),
+        get_card("Copper"),
+        get_card("Copper"),
+        get_card("Copper"),
+        get_card("Copper"),
+    ]
+    # Plenty of cards in deck to draw from across multiple reactions.
+    player.deck = [get_card("Copper") for _ in range(20)]
+    player.discard = []
+
+    # Track how many "reveals Diplomat" log entries appear.
+    reveal_log: list = []
+
+    original_log = state.log_callback
+
+    def spy(entry):
+        if (
+            isinstance(entry, tuple)
+            and len(entry) >= 3
+            and isinstance(entry[2], str)
+            and "reveals Diplomat" in entry[2]
+        ):
+            reveal_log.append(entry)
+        original_log(entry)
+
+    state.log_callback = spy
+
+    state._maybe_react_diplomat(player)
+
+    # Expect at least 2 reveals before the hand drops below 5.
+    assert len(reveal_log) >= 2
+
+
+def test_secret_chamber_default_reacts_once_per_attack():
+    """Default Secret Chamber AI reveals exactly once per Attack
+    trigger (additional reveals are net-zero, so the default skips
+    them) — but the engine permits more if an AI opts in."""
+
+    state = GameState(players=[])
+    state.initialize_game([ChooseFirstActionAI()], [get_card("Secret Chamber")])
+
+    player = state.players[0]
+    player.hand = [get_card("Secret Chamber"), get_card("Copper"), get_card("Copper")]
+    player.deck = [get_card("Copper") for _ in range(10)]
+    player.discard = []
+
+    reveal_log: list = []
+    original_log = state.log_callback
+
+    def spy(entry):
+        if (
+            isinstance(entry, tuple)
+            and len(entry) >= 3
+            and isinstance(entry[2], str)
+            and "reveals Secret Chamber" in entry[2]
+        ):
+            reveal_log.append(entry)
+        original_log(entry)
+
+    state.log_callback = spy
+
+    state._maybe_react_secret_chamber(player)
+
+    assert len(reveal_log) == 1
+
+
+def test_secret_chamber_can_react_multiple_times_when_ai_opts_in():
+    """An AI that always wants to reveal Secret Chamber should be
+    able to react multiple times per Attack trigger."""
+
+    class AlwaysChamberAI(ChooseFirstActionAI):
+        def should_discard_secret_chamber(self, state, player, reveal_count=0):
+            # Cap at 3 reveals to keep the test bounded.
+            return reveal_count < 3
+
+        def choose_secret_chamber_topdeck(self, state, player, choices):
+            # Keep the Secret Chamber in hand by top-decking other
+            # cards instead, so it can react again.
+            non_chamber = [c for c in choices if c.name != "Secret Chamber"]
+            return non_chamber[:2]
+
+    state = GameState(players=[])
+    state.initialize_game([AlwaysChamberAI()], [get_card("Secret Chamber")])
+
+    player = state.players[0]
+    player.hand = [get_card("Secret Chamber"), get_card("Copper"), get_card("Copper")]
+    player.deck = [get_card("Copper") for _ in range(20)]
+    player.discard = []
+
+    reveal_log: list = []
+    original_log = state.log_callback
+
+    def spy(entry):
+        if (
+            isinstance(entry, tuple)
+            and len(entry) >= 3
+            and isinstance(entry[2], str)
+            and "reveals Secret Chamber" in entry[2]
+        ):
+            reveal_log.append(entry)
+        original_log(entry)
+
+    state.log_callback = spy
+
+    state._maybe_react_secret_chamber(player)
+
+    assert len(reveal_log) == 3


### PR DESCRIPTION
## Summary

Follow-up to merged PR #182 (Implement remaining Intrigue cards + bug fixes), addressing all four review comments:

- **Secret Passage (P1):** the default ``choose_card_to_place_for_secret_passage`` returned ``None`` whenever the hand had no Action and no non-Copper Treasure, which let ``play_effect`` skip the mandatory placement. Now the default always returns a card when the hand is non-empty (best Action > best non-Copper Treasure > worst junk to bury at the bottom of the deck).
- **Mining Village (P2):** ``_should_self_trash`` was hardcoded to ``False`` with no runtime path to ``True``, so the printed +$2 was unreachable. Added a ``BaseAI.should_trash_mining_village`` hook with a sensible default (trash to close out a Province/Colony buy or when the Village body is dead weight) and routed the card through it.
- **Diplomat (P2):** ``_maybe_react_diplomat`` only resolved one reveal. The Reaction is legal to repeat while the hand still has 5+ cards. Now loops while legal; the draw-2/discard-3 mechanic naturally tapers the hand. A safety cap prevents pathological loops.
- **Secret Chamber (P2):** likewise looped to allow multiple reveals per Attack trigger. Default ``should_discard_secret_chamber`` now takes ``reveal_count`` and reveals once per attack (subsequent reveals are net-zero), but AIs can opt in to more reveals.

## Test plan
- [x] Added 5 regression tests in ``tests/test_intrigue_cards.py`` covering all four behaviors (junk-only Secret Passage, Mining Village hook opt-in, Diplomat multi-reveal, Secret Chamber default-once-per-attack, Secret Chamber multi-reveal opt-in).
- [x] ``pytest -x -q`` green: 980 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)