### PR TITLE
Address PR #193 review feedback (plunder)

### DIFF
--- a/dominion/events/plunder_events.py
+++ b/dominion/events/plunder_events.py
@@ -67,14 +67,15 @@ class Deliver(Event):
         super().__init__("Deliver", CardCost(coins=2))
 
     def on_buy(self, game_state, player) -> None:
-        # Mark the player so the next gain is set aside; checked in gain_card.
-        player.deliver_pending = list(getattr(player, "deliver_pending", []))
-        # Use a sentinel to indicate one pending; gain_card doesn't currently
-        # consult deliver_pending, but a future hook can. As a simple
-        # approximation: top-deck the next gain so it lands in hand at start
-        # of next turn (after the new hand is drawn). Push a marker onto the
-        # player's topdeck_gains flag for one gain.
-        player.topdeck_gains = True
+        # Mark one pending Deliver "set aside next gain" trigger. The actual
+        # set-aside happens in GameState.gain_card via the deliver_pending
+        # counter; the card is moved to player.deliver_set_aside and placed
+        # into hand at the start of the next turn. Each Deliver buy queues
+        # exactly one gain, so multiple Delivers in a turn affect the next
+        # N gains.
+        player.deliver_pending_count = (
+            getattr(player, "deliver_pending_count", 0) + 1
+        )
 
 
 class Peril(Event):

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -877,25 +877,27 @@ class GameState:
                     # Route the gain through gain_card so on-gain hooks
                     # (gained-this-turn counters, Watchtower, Trader, Royal
                     # Seal, Allies/Landmark gain reactions, etc.) all fire
-                    # consistently with every other gain path. Then move
-                    # the gained copy from its destination zone onto the
-                    # Quartermaster mat where the card text places it.
+                    # consistently with every other gain path. The card
+                    # text places the gain on the Quartermaster mat, but
+                    # on-gain reactions that redirect the gain (Watchtower
+                    # topdeck/trash, Trader, etc.) take precedence — the
+                    # player chose those destinations. Only move to the
+                    # mat if the card landed in the default destination
+                    # (discard).
                     self.supply[pick.name] -= 1
                     gained = self.gain_card(player, get_card(pick.name))
                     if gained is None:
                         continue
                     if gained in player.discard:
+                        # Default destination — move onto QM mat per card text.
                         player.discard.remove(gained)
-                    elif gained in player.deck:
-                        player.deck.remove(gained)
-                    elif gained in player.hand:
-                        player.hand.remove(gained)
-                    else:
-                        # Card was relocated by a reaction (e.g. Watchtower
-                        # trashed it, Trader exchanged it for Silver). In
-                        # that case skip placing it on the mat.
-                        continue
-                    self.quartermaster_mats[id(player)].append(gained)
+                        self.quartermaster_mats[id(player)].append(gained)
+                    # Otherwise an on-gain reaction redirected the card
+                    # (e.g. Watchtower topdecked it to player.deck or
+                    # trashed it to self.trash, or another effect routed
+                    # it to the hand). Respect the player's choice and
+                    # leave the card where it ended up — the QM trigger
+                    # has already fired.
 
     def do_duration_phase(self):
         """Handle effects of duration cards from previous turn."""
@@ -1667,21 +1669,28 @@ class GameState:
 
         player.actions_this_turn = 0
         player.bought_this_turn = []
-        # Plunder Deliver: the "set aside the next gain THIS TURN" trigger
-        # only persists until end of turn. Cards already set aside in
-        # ``deliver_set_aside`` still return at start of next turn, but
-        # any pending-but-unfired count expires here so it cannot leak
-        # onto a future turn's gains.
-        player.deliver_pending_count = 0
 
         # Rising Sun: Prophecy cleanup-start hook (Biding Time, Sickness)
         if self.prophecy is not None and self.prophecy.is_active:
             self.prophecy.on_cleanup_start(self, player)
 
         # Rising Sun: Cards in play with cleanup-start triggers (River Shrine)
+        # and Renaissance: Improve. These hooks may gain cards which are
+        # still part of THIS turn — if the player bought Deliver and had
+        # not yet gained, those cleanup-start gains are eligible for the
+        # Deliver set-aside trigger.
         for card in list(player.in_play):
             if hasattr(card, "on_cleanup_start"):
                 card.on_cleanup_start(self)
+
+        # Plunder Deliver: the "set aside the next gain THIS TURN" trigger
+        # only persists until end of turn. Cards already set aside in
+        # ``deliver_set_aside`` still return at start of next turn, but
+        # any pending-but-unfired count expires here so it cannot leak
+        # onto a future turn's gains. Reset AFTER cleanup-start hooks so
+        # gains made by River Shrine / Improve during cleanup remain
+        # eligible for Deliver.
+        player.deliver_pending_count = 0
 
         # Allies: end-of-turn / cleanup hook.
         # Used by Coastal Haven, Family of Inventors, Island Folk,

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1667,6 +1667,12 @@ class GameState:
 
         player.actions_this_turn = 0
         player.bought_this_turn = []
+        # Plunder Deliver: the "set aside the next gain THIS TURN" trigger
+        # only persists until end of turn. Cards already set aside in
+        # ``deliver_set_aside`` still return at start of next turn, but
+        # any pending-but-unfired count expires here so it cannot leak
+        # onto a future turn's gains.
+        player.deliver_pending_count = 0
 
         # Rising Sun: Prophecy cleanup-start hook (Biding Time, Sickness)
         if self.prophecy is not None and self.prophecy.is_active:
@@ -2380,8 +2386,11 @@ class GameState:
         self._handle_mining_road_gain(player, actual_card)
 
         # Plunder Deliver event: set aside the next gain to return to hand
-        # at the start of the next turn. Only consume the pending count if
-        # the card is in a movable zone (discard/deck/hand).
+        # at the start of the next turn. The pending count is always
+        # consumed by the next gain (per "the next card you gain this
+        # turn"); if the card has been moved out of the player's zones
+        # (e.g. trashed by Watchtower or exiled), nothing is set aside
+        # but the trigger is still spent.
         self._handle_deliver_gain(player, actual_card)
         # Generic "while this is in play, when you gain a card ..." hook used
         # by Allies cards like Galleria and Skirmisher. In-play cards may
@@ -2499,13 +2508,23 @@ class GameState:
         """Handle a Deliver event "set aside next gain" trigger.
 
         Each Deliver buy queues exactly one set-aside; subsequent Delivers
-        stack. The gained card is removed from whichever zone it landed in
-        (discard, deck, or hand) and stashed on player.deliver_set_aside,
-        to be returned to hand at the start of the next turn.
+        stack. Per the rules, the trigger applies to *the next card you
+        gain this turn* — so the trigger is consumed by the very next
+        gain, even if that card has already been moved out of the
+        player's zones (e.g. trashed by Watchtower or exiled by
+        Gatekeeper). When the card is still in a movable zone (discard,
+        deck, or hand) it is stashed on ``player.deliver_set_aside`` to
+        be returned to hand at the start of the next turn; otherwise we
+        simply consume the pending count without setting anything aside.
         """
         if getattr(player, "deliver_pending_count", 0) <= 0:
             return
-        # Find the gained card in any movable zone.
+        # Always consume the trigger — Deliver locks onto the first gain
+        # this turn regardless of where it ends up.
+        player.deliver_pending_count -= 1
+        # Find the gained card in any movable zone. If we cannot find it
+        # (e.g. trashed/exiled), the trigger is still spent but there is
+        # nothing to set aside.
         if gained_card in player.discard:
             player.discard.remove(gained_card)
         elif gained_card in player.deck:
@@ -2513,11 +2532,7 @@ class GameState:
         elif gained_card in player.hand:
             player.hand.remove(gained_card)
         else:
-            # Card landed somewhere we cannot move it from (e.g. trashed
-            # by Watchtower, exiled, etc.); leave the trigger pending for
-            # a subsequent gain rather than silently consuming it.
             return
-        player.deliver_pending_count -= 1
         player.deliver_set_aside.append(gained_card)
 
     def _handle_mining_road_gain(self, player: PlayerState, gained_card: Card) -> None:

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -763,14 +763,25 @@ class GameState:
             )
         )
 
+        # Plunder per-turn flag resets. Performed BEFORE the duration phase
+        # so that any cards trashed by start-of-turn duration effects
+        # (e.g. Secluded Shrine) count toward this turn's "cards trashed
+        # this turn" total used by Crucible.
+        self.current_player.cards_trashed_this_turn = 0
+        self.current_player.mining_road_triggered = False
+        self.current_player.search_triggered = False
+        # Plunder Launch event: reset the once-per-turn lockout.
+        self.current_player.launch_used = False
+
         # Only log duration phase if there are duration cards
         if self.current_player.duration:
             self.do_duration_phase()
 
-        # Plunder per-turn flag resets.
-        self.current_player.cards_trashed_this_turn = 0
-        self.current_player.mining_road_triggered = False
-        self.current_player.search_triggered = False
+        # Plunder Deliver event: return any set-aside gains to hand.
+        deliver_set_aside = getattr(self.current_player, "deliver_set_aside", None)
+        if deliver_set_aside:
+            self.current_player.hand.extend(deliver_set_aside)
+            self.current_player.deliver_set_aside = []
 
         # Plunder Shy trait: discard Shy-pile cards in hand for +2 Cards.
         self._handle_shy_start_of_turn(self.current_player)
@@ -863,8 +874,28 @@ class GameState:
                 non_v = [c for c in candidates if not c.is_victory]
                 pick = (non_v or candidates)[0]
                 if self.supply.get(pick.name, 0) > 0:
+                    # Route the gain through gain_card so on-gain hooks
+                    # (gained-this-turn counters, Watchtower, Trader, Royal
+                    # Seal, Allies/Landmark gain reactions, etc.) all fire
+                    # consistently with every other gain path. Then move
+                    # the gained copy from its destination zone onto the
+                    # Quartermaster mat where the card text places it.
                     self.supply[pick.name] -= 1
-                    self.quartermaster_mats[id(player)].append(pick)
+                    gained = self.gain_card(player, get_card(pick.name))
+                    if gained is None:
+                        continue
+                    if gained in player.discard:
+                        player.discard.remove(gained)
+                    elif gained in player.deck:
+                        player.deck.remove(gained)
+                    elif gained in player.hand:
+                        player.hand.remove(gained)
+                    else:
+                        # Card was relocated by a reaction (e.g. Watchtower
+                        # trashed it, Trader exchanged it for Silver). In
+                        # that case skip placing it on the mat.
+                        continue
+                    self.quartermaster_mats[id(player)].append(gained)
 
     def do_duration_phase(self):
         """Handle effects of duration cards from previous turn."""
@@ -2347,6 +2378,11 @@ class GameState:
 
         # Plunder Mining Road: first Treasure gained → gain a Treasure to hand.
         self._handle_mining_road_gain(player, actual_card)
+
+        # Plunder Deliver event: set aside the next gain to return to hand
+        # at the start of the next turn. Only consume the pending count if
+        # the card is in a movable zone (discard/deck/hand).
+        self._handle_deliver_gain(player, actual_card)
         # Generic "while this is in play, when you gain a card ..." hook used
         # by Allies cards like Galleria and Skirmisher. In-play cards may
         # implement on_owner_gain(game_state, player, gained_card).
@@ -2388,11 +2424,17 @@ class GameState:
                 self.gain_card(player, get_card("Silver"))
 
         if trait == "Hasty":
+            # Hasty: gained card is set aside and played at the start of the
+            # next turn, regardless of which zone the card landed in (gains
+            # to hand via Mining Road / Artisan-style effects still trigger
+            # Hasty per the Trait's text).
             zone = None
             if gained_card in player.discard:
                 zone = player.discard
             elif gained_card in player.deck:
                 zone = player.deck
+            elif gained_card in player.hand:
+                zone = player.hand
             if zone is not None:
                 zone.remove(gained_card)
                 self.hasty_set_aside.setdefault(id(player), []).append(gained_card)
@@ -2434,12 +2476,17 @@ class GameState:
         if not pending:
             return
         landing = pending.pop(0)
+        # Locate and remove the gained card from wherever it landed
+        # (discard, deck, or hand via gain-to-hand effects). If we cannot
+        # find it, abandon the Landing Party trigger rather than re-queueing
+        # forever — the gain has already been processed by the caller.
         if gained_card in player.discard:
             player.discard.remove(gained_card)
         elif gained_card in player.deck:
             player.deck.remove(gained_card)
+        elif gained_card in player.hand:
+            player.hand.remove(gained_card)
         else:
-            pending.insert(0, landing)
             return
         if landing in player.duration:
             player.duration.remove(landing)
@@ -2447,6 +2494,31 @@ class GameState:
             player.in_play.remove(landing)
         player.deck.append(landing)
         player.deck.append(gained_card)
+
+    def _handle_deliver_gain(self, player: PlayerState, gained_card: Card) -> None:
+        """Handle a Deliver event "set aside next gain" trigger.
+
+        Each Deliver buy queues exactly one set-aside; subsequent Delivers
+        stack. The gained card is removed from whichever zone it landed in
+        (discard, deck, or hand) and stashed on player.deliver_set_aside,
+        to be returned to hand at the start of the next turn.
+        """
+        if getattr(player, "deliver_pending_count", 0) <= 0:
+            return
+        # Find the gained card in any movable zone.
+        if gained_card in player.discard:
+            player.discard.remove(gained_card)
+        elif gained_card in player.deck:
+            player.deck.remove(gained_card)
+        elif gained_card in player.hand:
+            player.hand.remove(gained_card)
+        else:
+            # Card landed somewhere we cannot move it from (e.g. trashed
+            # by Watchtower, exiled, etc.); leave the trigger pending for
+            # a subsequent gain rather than silently consuming it.
+            return
+        player.deliver_pending_count -= 1
+        player.deliver_set_aside.append(gained_card)
 
     def _handle_mining_road_gain(self, player: PlayerState, gained_card: Card) -> None:
         if player is not self.current_player:

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -112,8 +112,14 @@ class PlayerState:
     search_triggered: bool = False
     avoid_pending: int = 0
     deliver_pending: list = field(default_factory=list)
+    # Plunder Deliver event: number of upcoming gains to set aside, and the
+    # cards already set aside awaiting return-to-hand at next turn start.
+    deliver_pending_count: int = 0
+    deliver_set_aside: list = field(default_factory=list)
     bury_mat: list = field(default_factory=list)
     prepare_set_aside: list = field(default_factory=list)
+    # Plunder Launch event: once-per-turn lockout (reset at turn start).
+    launch_used: bool = False
     cage_state: object = None
     grotto_set_aside: list = field(default_factory=list)
     # Prosperity 2E: Tiara grants once-per-turn replay-treasure
@@ -263,8 +269,11 @@ class PlayerState:
         self.search_triggered = False
         self.avoid_pending = 0
         self.deliver_pending = []
+        self.deliver_pending_count = 0
+        self.deliver_set_aside = []
         self.bury_mat = []
         self.prepare_set_aside = []
+        self.launch_used = False
         self.cage_state = None
         self.grotto_set_aside = []
         self.tiara_replay_used = False

--- a/tests/test_plunder_events.py
+++ b/tests/test_plunder_events.py
@@ -321,3 +321,80 @@ def test_deliver_sets_aside_one_gain_and_returns_to_hand_next_turn():
     # Set-aside Silver returned to hand.
     assert any(c.name == "Silver" for c in player.hand)
     assert player.deliver_set_aside == []
+
+
+def test_deliver_pending_expires_at_end_of_turn():
+    """Regression for PR #206 review (P1): Deliver's "the next card you
+    gain THIS TURN" trigger must not leak across the turn boundary. If
+    the player buys Deliver and gains nothing that turn, the pending
+    counter must be cleared during cleanup so a future turn's first
+    gain is unaffected."""
+    state = _make_state(num_players=2)
+    player = state.players[0]
+    state.current_player_index = 0
+    deliver = get_event("Deliver")
+    deliver.on_buy(state, player)
+    assert player.deliver_pending_count == 1
+    # End the turn without gaining anything.
+    state.handle_cleanup_phase()
+    # Pending count must have expired with the turn.
+    assert player.deliver_pending_count == 0
+    # Cycle to player 0's next turn.
+    state.current_player_index = 1
+    state.handle_start_phase()
+    state.current_player_index = 0
+    state.handle_start_phase()
+    # First gain on the new turn must NOT be set aside — Deliver expired.
+    state.supply["Silver"] -= 1
+    state.gain_card(player, get_card("Silver"))
+    assert not any(c.name == "Silver" for c in player.deliver_set_aside)
+    assert any(c.name == "Silver" for c in player.discard)
+
+
+def test_deliver_consumes_trigger_when_gained_card_trashed_by_watchtower():
+    """Regression for PR #206 review (P2): Deliver's trigger fires on
+    "the next card you gain this turn" — even if a Watchtower reaction
+    trashes that gain (or another effect exiles it) before Deliver gets
+    to set it aside, the pending count must still decrement so Deliver
+    does not leak onto a later gain in the same turn."""
+
+    trashed_first_only = {"count": 0}
+
+    class _TrashFirstGainAI(_NullAI):
+        def choose_watchtower_reaction(self, state, player, card):
+            # Only trash the very first gain we're asked about.
+            if trashed_first_only["count"] == 0:
+                trashed_first_only["count"] += 1
+                return "trash"
+            return None
+
+    state = _make_state(num_players=2)
+    player = state.players[0]
+    player.ai = _TrashFirstGainAI()
+    state.current_player_index = 0
+    state.supply["Watchtower"] = 10
+    # Put a Watchtower in hand to react with.
+    player.hand.append(get_card("Watchtower"))
+    deliver = get_event("Deliver")
+    deliver.on_buy(state, player)
+    assert player.deliver_pending_count == 1
+    # First gain: Watchtower trashes Silver before Deliver sees a movable
+    # zone. Deliver still consumes its trigger.
+    state.supply["Silver"] -= 1
+    silver = get_card("Silver")
+    state.gain_card(player, silver)
+    assert player.deliver_pending_count == 0, (
+        "Deliver must consume its trigger even when the gained card was "
+        "trashed by Watchtower"
+    )
+    assert silver in state.trash
+    assert silver not in player.deliver_set_aside
+    # A subsequent gain in the same turn must NOT be redirected (Deliver
+    # already spent its trigger on the trashed Silver).
+    state.supply["Gold"] -= 1
+    gold = get_card("Gold")
+    state.gain_card(player, gold)
+    assert gold not in player.deliver_set_aside
+    assert gold not in state.trash
+    # Gold should land in the discard normally.
+    assert gold in player.discard

--- a/tests/test_plunder_events.py
+++ b/tests/test_plunder_events.py
@@ -266,3 +266,58 @@ def test_prosper_gains_one_of_each_loot():
     discard_names = {c.name for c in player.discard}
     for name in LOOT_CARD_NAMES:
         assert name in discard_names
+
+
+def test_launch_lockout_clears_at_turn_start():
+    """Regression for PR #193 review: launch_used must reset each turn so
+    Launch is once-per-turn rather than once-per-game."""
+    state = _make_state(num_players=2)
+    player = state.players[0]
+    state.current_player_index = 0
+    player.deck = [get_card("Copper")]
+    launch = get_event("Launch")
+    launch.on_buy(state, player)
+    assert player.launch_used is True
+    assert not launch.may_be_bought(state, player)
+    # Cycle: end turn (player 0) → next player → back to player 0.
+    state.current_player_index = 1
+    state.handle_start_phase()
+    state.current_player_index = 0
+    state.handle_start_phase()
+    # After our next turn-start, Launch should be buyable again.
+    assert player.launch_used is False
+    assert launch.may_be_bought(state, player)
+
+
+def test_deliver_sets_aside_one_gain_and_returns_to_hand_next_turn():
+    """Regression for PR #193 review: Deliver must set aside the next gained
+    card (one gain) and return it to hand at start of next turn — it must
+    not act as a broad topdeck redirect."""
+    state = _make_state(num_players=2)
+    player = state.players[0]
+    state.current_player_index = 0
+    deliver = get_event("Deliver")
+    deliver.on_buy(state, player)
+    # First gain: Silver should be set aside, not put in deck/discard.
+    state.supply["Silver"] -= 1
+    state.gain_card(player, get_card("Silver"))
+    assert any(c.name == "Silver" for c in player.deliver_set_aside)
+    assert not any(c.name == "Silver" for c in player.discard)
+    assert not any(c.name == "Silver" for c in player.deck)
+    # Second gain in same turn must NOT be redirected (only one Deliver buy).
+    state.supply["Gold"] -= 1
+    state.gain_card(player, get_card("Gold"))
+    # Gold should land in discard normally (not on deliver_set_aside, not
+    # forced to deck).
+    assert any(c.name == "Gold" for c in player.discard)
+    assert not any(c.name == "Gold" for c in player.deliver_set_aside)
+    # Pending counter consumed.
+    assert player.deliver_pending_count == 0
+    # Cycle to next turn for player 0.
+    state.current_player_index = 1
+    state.handle_start_phase()
+    state.current_player_index = 0
+    state.handle_start_phase()
+    # Set-aside Silver returned to hand.
+    assert any(c.name == "Silver" for c in player.hand)
+    assert player.deliver_set_aside == []

--- a/tests/test_plunder_kingdom_cards.py
+++ b/tests/test_plunder_kingdom_cards.py
@@ -513,3 +513,117 @@ def test_quartermaster_routes_gain_through_gain_card_hooks():
     # gain_card-side bookkeeping must have run.
     assert gained_name in player.gained_cards_this_turn
     assert player.cards_gained_this_turn >= 1
+
+
+def test_quartermaster_respects_watchtower_topdeck():
+    """Regression for PR #206 review (P2): when a Quartermaster gain
+    triggers a Watchtower topdeck reaction, the gained card must end up
+    on top of the player's deck — NOT on the Quartermaster mat. The
+    player's choice of destination via on-gain reactions takes
+    precedence over Quartermaster's "onto this" placement."""
+
+    class _TopdeckAI(_NullAI):
+        def choose_watchtower_reaction(self, state, player, card):
+            return "topdeck"
+
+    state = _make_state(num_players=2)
+    state.current_player_index = 0
+    player = state.players[0]
+    player.ai = _TopdeckAI()
+    # Watchtower must be in the player's hand to react.
+    player.hand.append(get_card("Watchtower"))
+    qm = get_card("Quartermaster")
+    qm.duration_persistent = True
+    player.duration.append(qm)
+    state.quartermaster_mats[id(player)] = []
+
+    state._handle_quartermaster_start_of_turn(player)
+
+    # QM mat should be empty: Watchtower's topdeck reaction wins.
+    mat = state.quartermaster_mats.get(id(player), [])
+    assert mat == [], (
+        "Watchtower topdeck reaction should redirect the gain off the "
+        f"Quartermaster mat; mat was {[c.name for c in mat]}"
+    )
+    # The gained card must be on top of the deck (last element).
+    assert player.deck, "Topdecked card should be in the deck"
+    top = player.deck[-1]
+    assert top.cost.coins <= 4
+    assert top.is_treasure or top.is_action or top.is_victory
+
+
+def test_quartermaster_no_watchtower_keeps_card_on_mat():
+    """Regression for PR #206 review (P2): when no on-gain reaction
+    redirects the gain, Quartermaster's normal behavior must still apply
+    — the gained card lands on the Quartermaster mat, not in the
+    discard."""
+    state = _make_state(num_players=1)
+    state.current_player_index = 0
+    player = state.players[0]
+    qm = get_card("Quartermaster")
+    qm.duration_persistent = True
+    player.duration.append(qm)
+    state.quartermaster_mats[id(player)] = []
+    pre_discard = len(player.discard)
+
+    state._handle_quartermaster_start_of_turn(player)
+
+    mat = state.quartermaster_mats.get(id(player), [])
+    assert len(mat) == 1, (
+        "Without a Watchtower redirect the gain must land on the QM mat"
+    )
+    # Card was not left in discard.
+    assert len(player.discard) == pre_discard
+
+
+def test_river_shrine_cleanup_gain_eligible_for_deliver():
+    """Regression for PR #206 review (P1): cleanup-start hooks (River
+    Shrine, Improve) gain cards that are still part of THIS turn. If the
+    player bought Deliver and had not gained yet, those cleanup-start
+    gains MUST be eligible for Deliver's "set aside the next gain this
+    turn" trigger — i.e. the deliver_pending_count reset must happen
+    AFTER cleanup-start hooks run, not before."""
+    from dominion.events.registry import get_event
+
+    class _PickSilverAI(_NullAI):
+        def choose_buy(self, state, choices):
+            for c in choices:
+                if c is not None and getattr(c, "name", "") == "Silver":
+                    return c
+            for c in choices:
+                if c is not None:
+                    return c
+            return None
+
+    state = _make_state(num_players=2)
+    state.current_player_index = 0
+    player = state.players[0]
+    player.ai = _PickSilverAI()
+    # Buy Deliver to queue a pending set-aside.
+    deliver = get_event("Deliver")
+    deliver.on_buy(state, player)
+    assert player.deliver_pending_count == 1
+    # Set up River Shrine in play with no buy-phase gains so its
+    # cleanup-start hook will fire and gain a card.
+    river = get_card("River Shrine")
+    player.in_play.append(river)
+    player.cards_gained_this_buy_phase = 0
+    state.supply["River Shrine"] = 10
+    # Run cleanup. River Shrine should gain a card during cleanup; that
+    # gain should be intercepted by Deliver and set aside.
+    pre_set_aside = list(player.deliver_set_aside)
+    state.handle_cleanup_phase()
+    # River Shrine's cleanup-start gain was set aside by Deliver.
+    assert len(player.deliver_set_aside) == len(pre_set_aside) + 1, (
+        "River Shrine's cleanup-start gain should be set aside by "
+        "Deliver — the deliver reset must run AFTER cleanup-start hooks"
+    )
+    # Pending count cleared after cleanup (turn boundary).
+    assert player.deliver_pending_count == 0
+    # Cycle to next turn for player 0; set-aside card returns to hand.
+    state.current_player_index = 1
+    state.handle_start_phase()
+    state.current_player_index = 0
+    state.handle_start_phase()
+    # The set-aside card should now be in hand.
+    assert player.deliver_set_aside == []

--- a/tests/test_plunder_kingdom_cards.py
+++ b/tests/test_plunder_kingdom_cards.py
@@ -444,3 +444,72 @@ def test_fortune_hunter_plays_treasure_from_top_of_deck():
     fh.on_play(state)
     # Silver played → +$2; plus Fortune Hunter's stat +$2 = +$4.
     assert player.coins == pre_coins + 4
+
+
+def test_landing_party_top_decks_treasure_gained_to_hand():
+    """Regression for PR #193 review: Landing Party should resolve even when
+    the gained Treasure was placed somewhere other than discard/deck (e.g.
+    Mining Road's gain-to-hand)."""
+    state = _make_state()
+    player = state.current_player
+    lp = get_card("Landing Party")
+    state.landing_party_pending.setdefault(id(player), []).append(lp)
+    player.duration.append(lp)
+    # Simulate a treasure that's already been placed in hand by some prior
+    # gain-to-hand effect; the on-gain handler still needs to find and
+    # top-deck it.
+    silver = get_card("Silver")
+    player.hand.append(silver)
+    # Invoke the gain hook directly with the in-hand card.
+    state._handle_landing_party_gain(player, silver)
+    # Silver should now be on top of the deck along with Landing Party.
+    assert silver not in player.hand
+    top_two = [c.name for c in player.deck[-2:]]
+    assert "Silver" in top_two
+    assert "Landing Party" in top_two
+
+
+def test_crucible_counts_duration_phase_trashes():
+    """Regression for PR #193 review: cards trashed during the duration
+    phase (e.g. Secluded Shrine's start-of-turn trash) must count toward
+    cards_trashed_this_turn for Crucible."""
+    state = _make_state(num_players=2)
+    state.current_player_index = 0
+    player = state.players[0]
+    # Put a Secluded Shrine in duration so the duration phase fires.
+    shrine = get_card("Secluded Shrine")
+    player.duration.append(shrine)
+    # Give the player two trashable Curses in hand for Shrine to trash.
+    player.hand = [get_card("Curse"), get_card("Curse")]
+    # Cycle: end this turn → opponent → back to player 0 (duration fires).
+    state.current_player_index = 1
+    state.handle_start_phase()
+    state.current_player_index = 0
+    state.handle_start_phase()
+    # Shrine trashed up to 2 Curses during the duration phase, AFTER the
+    # per-turn counter reset; so the count should reflect them.
+    assert player.cards_trashed_this_turn >= 1
+
+
+def test_quartermaster_routes_gain_through_gain_card_hooks():
+    """Regression for PR #193 review: Quartermaster's start-of-turn gain
+    must run through gain_card so on-gain bookkeeping (e.g.
+    cards_gained_this_turn, gained_cards_this_turn) fires."""
+    state = _make_state(num_players=2)
+    state.current_player_index = 0
+    player = state.players[0]
+    qm = get_card("Quartermaster")
+    qm.duration_persistent = True
+    player.duration.append(qm)
+    # Cycle to player 0's next turn so the start-of-turn handler fires.
+    state.current_player_index = 1
+    state.handle_start_phase()
+    state.current_player_index = 0
+    state.handle_start_phase()
+    # Quartermaster mat should have one card.
+    mat = state.quartermaster_mats.get(id(player), [])
+    assert len(mat) == 1
+    gained_name = mat[0].name
+    # gain_card-side bookkeeping must have run.
+    assert gained_name in player.gained_cards_this_turn
+    assert player.cards_gained_this_turn >= 1

--- a/tests/test_plunder_traits.py
+++ b/tests/test_plunder_traits.py
@@ -177,13 +177,36 @@ def test_hasty_sets_aside_then_plays_next_turn():
     assert any(c.name == "Village" for c in player.in_play)
 
 
+def test_hasty_sets_aside_card_gained_to_hand():
+    """Regression for PR #193 review: Hasty must trigger even when the
+    gained card lands in hand (e.g. Mining Road's gain-to-hand)."""
+    state = _make_state()
+    apply_trait(state, "Hasty", "Village")
+    player = state.current_player
+    # Simulate the gain landing in hand directly.
+    village = get_card("Village")
+    player.hand.append(village)
+    state._handle_trait_on_gain(player, village)
+    assert village not in player.hand
+    assert any(c.name == "Village" for c in state.hasty_set_aside.get(id(player), []))
+
+
 def test_inherited_replaces_starting_estate():
     state = _make_state()
-    pre_estates = sum(1 for c in state.current_player.deck if c.name == "Estate")
-    pre_villages = sum(1 for c in state.current_player.deck if c.name == "Village")
+    # Ensure at least one Estate is in the deck (initial shuffle may have
+    # dealt every starting Estate into the opening hand). Inherited only
+    # operates on the deck.
+    player = state.current_player
+    if not any(c.name == "Estate" for c in player.deck):
+        for i, c in enumerate(player.hand):
+            if c.name == "Estate":
+                player.deck.append(player.hand.pop(i))
+                break
+    pre_estates = sum(1 for c in player.deck if c.name == "Estate")
+    pre_villages = sum(1 for c in player.deck if c.name == "Village")
     apply_trait(state, "Inherited", "Village")
-    post_estates = sum(1 for c in state.current_player.deck if c.name == "Estate")
-    post_villages = sum(1 for c in state.current_player.deck if c.name == "Village")
+    post_estates = sum(1 for c in player.deck if c.name == "Estate")
+    post_villages = sum(1 for c in player.deck if c.name == "Village")
     assert post_estates == pre_estates - 1
     assert post_villages == pre_villages + 1
 


### PR DESCRIPTION
## Summary

Addresses all 6 review comments on the merged Plunder PR #193.

- **Launch (P1)**: reset `launch_used` at start-of-turn so the event is once-per-turn rather than once-per-game.
- **Crucible (P2)**: move the `cards_trashed_this_turn` reset *before* the duration phase, so trashes from start-of-turn duration effects (e.g. Secluded Shrine) count toward Crucible's payout.
- **Landing Party (P2)**: resolve when the gained Treasure lands in hand (gain-to-hand effects), not only deck/discard; remove the silent re-queue path.
- **Deliver (P1)**: replace the broad `topdeck_gains` hijack with a proper one-gain set-aside / return-to-hand mechanic using a counter and a per-player `deliver_set_aside` list, returned to hand at next turn start.
- **Quartermaster (P1)**: route the start-of-turn supply gain through `GameState.gain_card` so on-gain hooks (counters, Watchtower, Trader, Royal Seal, Allies/Landmark gain reactions, etc.) all fire.
- **Hasty trait (P2)**: set aside on-gain even when the gained card landed in hand (e.g. Mining Road's gain-to-hand), not only deck/discard.

Also hardens a brittle pre-existing test (`test_inherited_replaces_starting_estate`) that relied on the initial-shuffle dropping at least one Estate into the deck rather than the opening hand.

## Test plan
- [x] `pytest -x -q` — 981 passed
- [x] New regression tests for each of the six fixes
- [ ] Manual sanity run of a Plunder kingdom

🤖 Generated with [Claude Code](https://claude.com/claude-code)