### PR TITLE
Fix Nocturne non-Supply piles and Lost in the Woods

### DIFF
--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -766,9 +766,17 @@ class GameState:
             # The River's Gift +1 Card was already delivered at end of last
             # turn during cleanup. No discard — Boon stays set aside.
 
-        # Nocturne — Lost in the Woods (Fool): receive a Boon
-        if getattr(player, "lost_in_the_woods", False):
-            self.receive_boon(player)
+        # Nocturne — Lost in the Woods (Fool): may discard a card to receive a Boon
+        if getattr(player, "lost_in_the_woods", False) and player.hand:
+            chosen = player.ai.choose_cards_to_discard(
+                self, player, list(player.hand), 1, reason="lost_in_the_woods"
+            )
+            if chosen:
+                card = chosen[0]
+                if card in player.hand:
+                    player.hand.remove(card)
+                    self.discard_card(player, card)
+                    self.receive_boon(player)
 
         # Nocturne — Blessed Village pending Boons
         for _ in range(getattr(player, "pending_blessed_boons", 0)):
@@ -3755,11 +3763,13 @@ class GameState:
             for name, count in extras.items():
                 if name not in self.supply:
                     self.supply[name] = count
+                self.non_supply_pile_names.add(name)
         needs_boons = any(getattr(c, "uses_boons", False) for c in kingdom_cards)
         if needs_boons and "Will-o'-Wisp" not in self.supply:
             try:
                 wisp = get_card("Will-o'-Wisp")
                 self.supply["Will-o'-Wisp"] = wisp.starting_supply(self)
+                self.non_supply_pile_names.add("Will-o'-Wisp")
             except ValueError:
                 pass
     def _apply_adventures_attack_on_buy(

--- a/tests/test_nocturne_boons.py
+++ b/tests/test_nocturne_boons.py
@@ -50,6 +50,66 @@ def _setup_state(ai=None):
     return state, state.players[0]
 
 
+class _LostInWoodsDiscardAI(DummyAI):
+    """Always discards the first available card for Lost in the Woods."""
+
+    def choose_cards_to_discard(self, state, player, choices, count, *, reason=None):
+        if reason == "lost_in_the_woods" and choices:
+            return [choices[0]]
+        return []
+
+
+class _LostInWoodsDeclineAI(DummyAI):
+    """Always declines the Lost-in-the-Woods discard option."""
+
+    def choose_cards_to_discard(self, state, player, choices, count, *, reason=None):
+        return []
+
+
+def test_lost_in_the_woods_discards_card_to_receive_boon():
+    """When player has Lost in the Woods, start-of-turn must offer the
+    discard-a-card-to-receive-a-Boon choice. If AI elects to discard, the
+    chosen card moves to discard and a Boon is resolved."""
+    state, player = _setup_state(_LostInWoodsDiscardAI())
+    player.lost_in_the_woods = True
+    copper = get_card("Copper")
+    player.hand = [copper]
+    player.discard = []
+    state.boons_deck = ["The Mountain's Gift"]  # +Silver
+    silver_before = state.supply["Silver"]
+    state.handle_start_phase()
+    assert copper not in player.hand
+    assert copper in player.discard
+    assert state.supply["Silver"] == silver_before - 1
+
+
+def test_lost_in_the_woods_decline_skips_boon_and_discard():
+    """When AI declines, no card is discarded and no Boon is received."""
+    state, player = _setup_state(_LostInWoodsDeclineAI())
+    player.lost_in_the_woods = True
+    copper = get_card("Copper")
+    player.hand = [copper]
+    player.discard = []
+    state.boons_deck = ["The Mountain's Gift"]
+    silver_before = state.supply["Silver"]
+    state.handle_start_phase()
+    assert copper in player.hand
+    assert copper not in player.discard
+    assert state.supply["Silver"] == silver_before
+
+
+def test_lost_in_the_woods_with_empty_hand_skips():
+    """With no cards to discard, the option is unavailable and no Boon is
+    received."""
+    state, player = _setup_state(_LostInWoodsDiscardAI())
+    player.lost_in_the_woods = True
+    player.hand = []
+    state.boons_deck = ["The Mountain's Gift"]
+    silver_before = state.supply["Silver"]
+    state.handle_start_phase()
+    assert state.supply["Silver"] == silver_before
+
+
 def test_create_boons_deck_has_all_twelve():
     deck = create_boons_deck()
     assert len(deck) == 12

--- a/tests/test_nocturne_spirits.py
+++ b/tests/test_nocturne_spirits.py
@@ -147,3 +147,44 @@ def test_zombie_spy_discards_junk():
     # Silver was drawn into hand by +1 Card. Then Estate is on top (looked at)
     # and discarded since it's a Victory.
     assert any(c.name == "Estate" for c in player.discard)
+
+
+def test_nocturne_extras_register_as_non_supply():
+    """Bat/Imp/Wish/Will-o'-Wisp/Ghost piles are non-Supply and must be
+    registered in ``non_supply_pile_names`` so they don't count toward the
+    three-empty-piles end-of-game condition."""
+    state = GameState(players=[])
+    state.log_callback = lambda *_: None
+    kingdom = [
+        get_card("Vampire"),       # adds Bat
+        get_card("Pixie"),         # adds Wish (Pixie also uses_boons)
+        get_card("Devil's Workshop"),  # adds Imp
+        get_card("Exorcist"),      # adds Will-o'-Wisp, Imp, Ghost
+    ]
+    state._setup_nocturne_extras(kingdom)
+    for name in ("Bat", "Wish", "Imp", "Will-o'-Wisp", "Ghost"):
+        assert name in state.supply, f"{name} should be in supply for lookup"
+        assert name in state.non_supply_pile_names, (
+            f"{name} must be a non-Supply pile (not counted toward 3-empty)"
+        )
+
+
+def test_emptied_non_supply_piles_do_not_advance_empty_count():
+    """Three emptied non-Supply piles must NOT trigger the 3-empty end-game
+    condition on their own."""
+    state = GameState(players=[])
+    state.log_callback = lambda *_: None
+    state.supply = {
+        "Copper": 30, "Silver": 20, "Gold": 10,
+        "Estate": 8, "Duchy": 8, "Province": 8, "Curse": 10,
+    }
+    state._setup_nocturne_extras([
+        get_card("Vampire"),
+        get_card("Pixie"),
+        get_card("Devil's Workshop"),
+    ])
+    # Empty all three non-Supply piles.
+    for name in ("Bat", "Wish", "Imp"):
+        assert name in state.supply
+        state.supply[name] = 0
+    assert state.empty_piles == 0


### PR DESCRIPTION
## Summary

Two Nocturne infrastructure bugs surfaced during a review of Night-card support:

- **Non-Supply piles counted toward 3-empty.** `Bat`, `Imp`, `Wish`, `Ghost`, and `Will-o'-Wisp` piles were added to `self.supply` (so they could be looked up) but never registered in `non_supply_pile_names`. Emptying them therefore advanced the three-empty-piles end-of-game condition, which is incorrect.
- **Lost in the Woods gave a free Boon every turn.** The start-of-turn handler unconditionally called `receive_boon(player)` whenever `lost_in_the_woods` was set. The rules-correct behavior is "you *may* discard a card to receive a Boon."

## Changes

- `_setup_nocturne_extras` now adds each `nocturne_piles` entry (and the auto-added Will-o'-Wisp) to `non_supply_pile_names`.
- `handle_start_phase` asks the AI via `choose_cards_to_discard(..., count=1, reason=\"lost_in_the_woods\")`. Discarding triggers the Boon; declining (or having no hand) skips it.

## Test plan

- [x] New test: `_setup_nocturne_extras` registers Bat/Imp/Wish/Ghost/Will-o'-Wisp as non-Supply.
- [x] New test: emptying three non-Supply piles does not advance `empty_piles`.
- [x] New test: Lost in the Woods discards a chosen card and receives a Boon.
- [x] New test: declining the choice keeps hand intact and grants no Boon.
- [x] New test: empty hand skips the option entirely.
- [x] Full suite: `python -m pytest` — 1108 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)