### PR TITLE
Add trick scanner: surface non-obvious card x landscape interactions (closes #230)

### DIFF
--- a/dominion/analysis/__init__.py
+++ b/dominion/analysis/__init__.py
@@ -1,0 +1,1 @@
+"""Static-analysis utilities that inspect kingdom boards for non-obvious interactions."""

--- a/dominion/analysis/trick_scanner.py
+++ b/dominion/analysis/trick_scanner.py
@@ -21,7 +21,7 @@ import argparse
 import inspect
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable
+from typing import Callable, Iterable
 
 from dominion.boards.loader import BoardConfig, load_board
 from dominion.cards.base_card import Card
@@ -53,6 +53,39 @@ SELF_EXILE_OR_SET_ASIDE_CARDS = frozenset({"Stockpile", "Island"})
 
 # Events that key on the player having an empty deck *and* empty discard.
 EMPTY_DECK_DISCARD_EVENTS = frozenset({"Windfall"})
+
+
+# Per-Command-card target filters. Each entry takes a candidate Card and
+# returns True iff this Command card can legally play / replay / copy it.
+# Commands whose only filter is "non-Command Action" use the default below.
+_DEFAULT_COMMAND_FILTER: Callable[["Card"], bool] = (
+    lambda c: c.is_action and not c.is_command
+)
+COMMAND_TARGET_FILTERS: dict[str, Callable[["Card"], bool]] = {
+    # Captain (promo): plays a non-Command non-Duration Action from supply
+    # costing up to $4, with no potion / debt cost.
+    "Captain": lambda c: (
+        c.is_action
+        and not c.is_command
+        and not c.is_duration
+        and c.cost.coins <= 4
+        and c.cost.potions == 0
+        and c.cost.debt == 0
+    ),
+    # Band of Misfits: plays a non-Command Action from supply costing strictly
+    # less than its own $5, with no potion / debt cost.
+    "Band of Misfits": lambda c: (
+        c.is_action
+        and not c.is_command
+        and c.cost.coins < 5
+        and c.cost.potions == 0
+        and c.cost.debt == 0
+    ),
+    # Flagship: replays the next non-Duration Action played this turn.
+    "Flagship": lambda c: (
+        c.is_action and not c.is_duration and not c.is_command
+    ),
+}
 
 
 # --- Public types --------------------------------------------------------
@@ -259,19 +292,16 @@ def predicate_empty_deck_discard_triggers(board: BoardConfig) -> list[Interactio
 def predicate_command_targets(board: BoardConfig) -> list[Interaction]:
     """Predicate 4 — Command targets.
 
-    For every Command card on this board (Daimyo, Royal Carriage, etc.), enumerate
-    the highest-payload non-Command Actions on the board. Command cards usually
-    replay another Action; on the rare board where the best target is something
-    surprising, this nudges the strategy designer to consider it.
+    For every Command card on this board (Daimyo, Royal Carriage, Captain, ...),
+    enumerate the highest-payload Action targets it can *legally* play / replay
+    on this board. Each Command's per-card filter (cost cap, type restrictions)
+    lives in :data:`COMMAND_TARGET_FILTERS`; cards without an explicit filter use
+    the default ``non-Command Action`` rule.
     """
 
     cards = _kingdom_card_objects(board)
     commands = [c for c in cards if c.is_command]
     if not commands:
-        return []
-
-    non_command_actions = [c for c in cards if c.is_action and not c.is_command]
-    if not non_command_actions:
         return []
 
     def _payload(c: Card) -> tuple[int, int, str]:
@@ -285,21 +315,25 @@ def predicate_command_targets(board: BoardConfig) -> list[Interaction]:
         )
         return (c.cost.coins + c.cost.debt, stat_sum, c.name)
 
-    ranked = sorted(non_command_actions, key=_payload, reverse=True)
-    top_targets = [c.name for c in ranked[:5]]
-
     interactions: list[Interaction] = []
     for command in commands:
+        target_filter = COMMAND_TARGET_FILTERS.get(
+            command.name, _DEFAULT_COMMAND_FILTER
+        )
+        candidates = [c for c in cards if c.name != command.name and target_filter(c)]
+        if not candidates:
+            continue
+        ranked = sorted(candidates, key=_payload, reverse=True)
+        top_targets = [c.name for c in ranked[:5]]
         interactions.append(
             Interaction(
                 kind="command_targets",
                 headline=(
-                    f"{command.name}: highest-payload non-Command Action targets "
-                    f"on this board"
+                    f"{command.name}: highest-payload legal Action targets on this board"
                 ),
                 detail=(
-                    f"{command.name} replays / copies a non-Command Action card. "
-                    f"Top targets here (by cost + stat payload): "
+                    f"{command.name} replays / copies an Action it is allowed to "
+                    f"target. Top legal targets here (by cost + stat payload): "
                     f"{', '.join(top_targets)}."
                 ),
                 refs=[_source_ref(command)],

--- a/dominion/analysis/trick_scanner.py
+++ b/dominion/analysis/trick_scanner.py
@@ -73,7 +73,13 @@ COMMAND_TARGET_FILTERS: dict[str, Callable[["Card"], bool]] = {
         and c.cost.debt == 0
     ),
     # Band of Misfits: plays a non-Command Action from supply costing strictly
-    # less than its own $5, with no potion / debt cost.
+    # less than its own $5 *by printed cost*, with no potion / debt cost. The
+    # in-game implementation uses dynamic cost via get_card_cost(), so symmetric
+    # cost reducers (Bridge, Highway, Quarry on Actions, ...) do not change
+    # legality (both costs drop by the same amount). Pile-specific reducers
+    # (Family of Inventors -$1 tokens, Ferry -$2 token, Plunder "Cheap" trait)
+    # can unlock additional same-printed-cost targets at runtime; the static
+    # scanner can't see those without simulating the game.
     "Band of Misfits": lambda c: (
         c.is_action
         and not c.is_command
@@ -81,10 +87,11 @@ COMMAND_TARGET_FILTERS: dict[str, Callable[["Card"], bool]] = {
         and c.cost.potions == 0
         and c.cost.debt == 0
     ),
-    # Flagship: replays the next non-Duration Action played this turn.
-    "Flagship": lambda c: (
-        c.is_action and not c.is_duration and not c.is_command
-    ),
+    # Flagship: replays the next non-Command Action played this turn. The
+    # engine (game_state.py: pending_flagships consumed when a non-Command is
+    # played) does NOT exclude Durations — pairing Flagship with Wharf or
+    # other strong Durations is legal and a known interaction.
+    "Flagship": lambda c: c.is_action and not c.is_command,
 }
 
 

--- a/dominion/analysis/trick_scanner.py
+++ b/dominion/analysis/trick_scanner.py
@@ -1,0 +1,427 @@
+"""Trick scanner: surface non-obvious card x Way/Event/Artifact interactions per kingdom.
+
+Strong Dominion play on a given board often hinges on a single mechanical edge case
+(e.g. ``Way of the Butterfly`` returns the played card to its supply pile rather than
+trashing it, so ``Flag Bearer``'s on_trash artifact-grab does not fire, leaving you with
+a $4-to-gain-a-$5 plus a permanent +1 Card / turn). These tricks are mechanical facts
+visible in source but invisible if you reason about cards from their English text.
+
+This module walks a board's registered cards, Ways and Events and emits hypotheses
+based on a small set of interaction predicates. Each predicate is a pure function
+``(BoardConfig) -> list[Interaction]`` that can be tested in isolation.
+
+CLI::
+
+    python -m dominion.analysis.trick_scanner --board boards/<file>.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from dominion.boards.loader import BoardConfig, load_board
+from dominion.cards.base_card import Card
+from dominion.cards.registry import get_card
+from dominion.events.registry import get_event
+from dominion.ways.registry import get_way
+
+
+# --- Knowledge tables -----------------------------------------------------
+#
+# Small, explicit tables of mechanical facts that can't be derived by simple
+# class inspection. Keep these focused — anything that *can* be derived from a
+# class (overridden hooks, `gain_card` calls in source) is detected
+# heuristically below.
+
+# Ways that return the played card to its supply pile rather than trashing it.
+# These are the Ways that bypass on_trash hooks.
+RETURN_TO_PILE_WAYS = frozenset({"Way of the Butterfly"})
+
+# Cards that, when played, exile or set aside themselves so they live outside
+# the player's deck and discard. Relevant for events that key on an empty deck
+# *and* empty discard.
+SELF_EXILE_OR_SET_ASIDE_CARDS = frozenset({"Stockpile", "Island", "Native Village"})
+
+# Events that key on the player having an empty deck *and* empty discard.
+EMPTY_DECK_DISCARD_EVENTS = frozenset({"Windfall"})
+
+
+# --- Public types --------------------------------------------------------
+
+
+@dataclass(slots=True)
+class Interaction:
+    """A single hypothesis surfaced by a predicate."""
+
+    kind: str
+    headline: str
+    detail: str = ""
+    refs: list[str] = field(default_factory=list)
+
+    def to_markdown(self) -> str:
+        lines = [f"- **{self.headline}**"]
+        if self.detail:
+            lines.append(f"  - {self.detail}")
+        for ref in self.refs:
+            if ref:
+                lines.append(f"  - `{ref}`")
+        return "\n".join(lines)
+
+
+# --- Helpers --------------------------------------------------------------
+
+
+def _source_ref(cls_or_obj) -> str:
+    """Return a ``path:line`` source reference for a class or instance."""
+
+    cls = cls_or_obj if inspect.isclass(cls_or_obj) else type(cls_or_obj)
+    try:
+        path = inspect.getsourcefile(cls) or ""
+        _, line = inspect.getsourcelines(cls)
+    except (TypeError, OSError):
+        return ""
+    return f"{path}:{line}"
+
+
+def _has_method_override(card: Card, name: str) -> bool:
+    """True iff ``card``'s class (or an intermediate base) overrides ``Card.<name>``."""
+
+    base = getattr(Card, name)
+    method = getattr(type(card), name, None)
+    return method is not None and method is not base
+
+
+def _kingdom_card_objects(board: BoardConfig) -> list[Card]:
+    cards: list[Card] = []
+    for name in board.kingdom_cards:
+        try:
+            cards.append(get_card(name))
+        except (KeyError, ValueError):
+            continue
+    return cards
+
+
+def _class_source(card: Card) -> str:
+    try:
+        return inspect.getsource(type(card))
+    except (TypeError, OSError):
+        return ""
+
+
+# --- Predicates ----------------------------------------------------------
+
+
+def predicate_trash_hook_via_return_to_supply(board: BoardConfig) -> list[Interaction]:
+    """Predicate 1 — Trash hook unreachable via return-to-supply Way.
+
+    For every kingdom card with a non-trivial ``on_trash`` hook, check whether any
+    in-kingdom Way returns the played card to its supply pile. If so, the Way bypasses
+    the on_trash hook entirely.
+    """
+
+    return_ways = [w for w in board.ways if w in RETURN_TO_PILE_WAYS]
+    if not return_ways:
+        return []
+
+    interactions: list[Interaction] = []
+    for card in _kingdom_card_objects(board):
+        # Ways are applied in place of an Action's normal play, so only Action
+        # cards can be routed through a Way at all.
+        if not card.is_action:
+            continue
+        if not _has_method_override(card, "on_trash"):
+            continue
+        for way_name in return_ways:
+            try:
+                way = get_way(way_name)
+            except (KeyError, ValueError):
+                continue
+            interactions.append(
+                Interaction(
+                    kind="trash_hook_unreachable",
+                    headline=(
+                        f"{card.name} + {way_name}: on_trash hook unreachable when "
+                        f"returned to pile"
+                    ),
+                    detail=(
+                        f"{card.name} has an on_trash effect, but {way_name} returns "
+                        f"the played card to its supply pile rather than trashing it. "
+                        f"Playing {card.name} as {way_name} preserves anything the "
+                        f"on_trash hook hands you (artifact, token, etc.) while still "
+                        f"gaining a card costing $1 more."
+                    ),
+                    refs=[_source_ref(card), _source_ref(way)],
+                )
+            )
+    return interactions
+
+
+def predicate_gain_hook_retriggerable(board: BoardConfig) -> list[Interaction]:
+    """Predicate 2 — Gain hook re-triggerable.
+
+    For every kingdom card with an ``on_gain`` override, list other in-kingdom
+    effects that gain cards from the supply (Workshop-likes, Duplicate, Way of the
+    Butterfly, etc.). Each fresh gain re-fires the on_gain hook.
+    """
+
+    gainer_names: list[str] = []
+    for card in _kingdom_card_objects(board):
+        src = _class_source(card)
+        if "gain_card(" in src:
+            gainer_names.append(card.name)
+    if "Way of the Butterfly" in board.ways:
+        gainer_names.append("Way of the Butterfly")
+    if not gainer_names:
+        return []
+
+    interactions: list[Interaction] = []
+    for card in _kingdom_card_objects(board):
+        if not _has_method_override(card, "on_gain"):
+            continue
+        sources_for_card = [g for g in gainer_names if g != card.name]
+        if not sources_for_card:
+            continue
+        joined = ", ".join(sources_for_card)
+        interactions.append(
+            Interaction(
+                kind="gain_hook_retriggerable",
+                headline=(
+                    f"{card.name}: on_gain hook re-triggerable via {joined}"
+                ),
+                detail=(
+                    f"{card.name} has a custom on_gain effect, and this kingdom "
+                    f"contains effects that gain cards from the supply ({joined}). "
+                    f"Each gainer that can target {card.name} fires its on_gain "
+                    f"hook again — verify the gainer's cost / type filter actually "
+                    f"reaches {card.name}."
+                ),
+                refs=[_source_ref(card)],
+            )
+        )
+    return interactions
+
+
+def predicate_empty_deck_discard_triggers(board: BoardConfig) -> list[Interaction]:
+    """Predicate 3 — Empty-deck/discard triggers.
+
+    Events such as ``Windfall`` only pay out when both the player's deck and discard
+    are empty. Cards that exile or set aside themselves on play (Stockpile, Island,
+    Native Village) make that condition reachable on demand.
+    """
+
+    events_present = [e for e in board.events if e in EMPTY_DECK_DISCARD_EVENTS]
+    if not events_present:
+        return []
+    self_exile = [c for c in board.kingdom_cards if c in SELF_EXILE_OR_SET_ASIDE_CARDS]
+    if not self_exile:
+        return []
+
+    interactions: list[Interaction] = []
+    for event_name in events_present:
+        try:
+            event = get_event(event_name)
+        except (KeyError, ValueError):
+            continue
+        for card_name in self_exile:
+            try:
+                card = get_card(card_name)
+            except (KeyError, ValueError):
+                continue
+            interactions.append(
+                Interaction(
+                    kind="empty_deck_discard_combo",
+                    headline=(
+                        f"{card_name} + {event_name}: set-aside cards keep deck "
+                        f"and discard empty for {event_name}'s payoff"
+                    ),
+                    detail=(
+                        f"{card_name} sets itself aside or exiles itself on play, "
+                        f"so it does not occupy the deck or discard. Together with "
+                        f"Treasures that exit play this turn, that makes "
+                        f"{event_name}'s empty-deck-and-discard condition reachable "
+                        f"on demand."
+                    ),
+                    refs=[_source_ref(card), _source_ref(event)],
+                )
+            )
+    return interactions
+
+
+def predicate_command_targets(board: BoardConfig) -> list[Interaction]:
+    """Predicate 4 — Command targets.
+
+    For every Command card on this board (Daimyo, Royal Carriage, etc.), enumerate
+    the highest-payload non-Command Actions on the board. Command cards usually
+    replay another Action; on the rare board where the best target is something
+    surprising, this nudges the strategy designer to consider it.
+    """
+
+    cards = _kingdom_card_objects(board)
+    commands = [c for c in cards if c.is_command]
+    if not commands:
+        return []
+
+    non_command_actions = [c for c in cards if c.is_action and not c.is_command]
+    if not non_command_actions:
+        return []
+
+    def _payload(c: Card) -> tuple[int, int, str]:
+        # Rough heuristic: rank by cost first, then by a weighted stat sum.
+        stat_sum = (
+            c.stats.cards * 2
+            + c.stats.actions
+            + c.stats.coins * 2
+            + c.stats.buys
+            + c.stats.vp * 2
+        )
+        return (c.cost.coins + c.cost.debt, stat_sum, c.name)
+
+    ranked = sorted(non_command_actions, key=_payload, reverse=True)
+    top_targets = [c.name for c in ranked[:5]]
+
+    interactions: list[Interaction] = []
+    for command in commands:
+        interactions.append(
+            Interaction(
+                kind="command_targets",
+                headline=(
+                    f"{command.name}: highest-payload non-Command Action targets "
+                    f"on this board"
+                ),
+                detail=(
+                    f"{command.name} replays / copies a non-Command Action card. "
+                    f"Top targets here (by cost + stat payload): "
+                    f"{', '.join(top_targets)}."
+                ),
+                refs=[_source_ref(command)],
+            )
+        )
+    return interactions
+
+
+def predicate_cost_mod_gateways(board: BoardConfig) -> list[Interaction]:
+    """Predicate 5 — Cost-mod gateways.
+
+    For every cost-modifying card in the kingdom (detected by an assignment to
+    ``player.cost_reduction`` in the card's source), summarise which kingdom and
+    Province-tier piles drop into reach with each play.
+    """
+
+    cards = _kingdom_card_objects(board)
+    mods: list[Card] = []
+    for card in cards:
+        src = _class_source(card)
+        if "cost_reduction" in src and "+=" in src:
+            mods.append(card)
+    if not mods:
+        return []
+
+    breakpoints: dict[int, list[str]] = {}
+    for c in cards:
+        if c.cost.coins <= 0:
+            continue
+        breakpoints.setdefault(c.cost.coins, []).append(c.name)
+    summary_parts = [
+        f"${orig} → ${orig - 1}: {', '.join(sorted(names))}"
+        for orig, names in sorted(breakpoints.items())
+    ]
+    # Province sits outside the kingdom but is the headline target.
+    province_summary = "$8 → $7 (Province) with one play; $6 with two."
+
+    interactions: list[Interaction] = []
+    for mod in mods:
+        interactions.append(
+            Interaction(
+                kind="cost_mod_gateway",
+                headline=(
+                    f"{mod.name}: each play reduces every card's cost by $1 — "
+                    f"opens cheaper gains and chains buys into Provinces"
+                ),
+                detail="; ".join(summary_parts + [province_summary]),
+                refs=[_source_ref(mod)],
+            )
+        )
+    return interactions
+
+
+PREDICATES = (
+    predicate_trash_hook_via_return_to_supply,
+    predicate_gain_hook_retriggerable,
+    predicate_empty_deck_discard_triggers,
+    predicate_command_targets,
+    predicate_cost_mod_gateways,
+)
+
+
+def scan(board: BoardConfig) -> list[Interaction]:
+    """Run every predicate against ``board`` and return all surfaced interactions."""
+
+    interactions: list[Interaction] = []
+    for predicate in PREDICATES:
+        interactions.extend(predicate(board))
+    return interactions
+
+
+def render_markdown(
+    board_path: Path | str,
+    board: BoardConfig,
+    interactions: Iterable[Interaction],
+) -> str:
+    """Render a markdown report for ``board`` and ``interactions``."""
+
+    lines = [f"# Trick scan: `{board_path}`", ""]
+    if board.kingdom_cards:
+        lines.append(f"**Kingdom**: {', '.join(board.kingdom_cards)}  ")
+    landscape_bits: list[str] = []
+    if board.events:
+        landscape_bits.append(f"Events: {', '.join(board.events)}")
+    if board.ways:
+        landscape_bits.append(f"Ways: {', '.join(board.ways)}")
+    if board.projects:
+        landscape_bits.append(f"Projects: {', '.join(board.projects)}")
+    if board.landmarks:
+        landscape_bits.append(f"Landmarks: {', '.join(board.landmarks)}")
+    if board.allies:
+        landscape_bits.append(f"Allies: {', '.join(board.allies)}")
+    if landscape_bits:
+        lines.append(" | ".join(landscape_bits))
+    lines.append("")
+
+    interactions = list(interactions)
+    if not interactions:
+        lines.append("_No interactions surfaced._")
+    else:
+        lines.append(f"## {len(interactions)} hypothesis interaction(s)")
+        lines.append("")
+        for interaction in interactions:
+            lines.append(interaction.to_markdown())
+            lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Surface non-obvious card x landscape interactions for a Dominion kingdom."
+        )
+    )
+    parser.add_argument(
+        "--board",
+        required=True,
+        help="Path to a board definition file (e.g. boards/victoria_kingdom.txt).",
+    )
+    args = parser.parse_args(argv)
+
+    board_path = Path(args.board)
+    board = load_board(board_path)
+    interactions = scan(board)
+    print(render_markdown(board_path, board, interactions))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/dominion/analysis/trick_scanner.py
+++ b/dominion/analysis/trick_scanner.py
@@ -44,7 +44,12 @@ RETURN_TO_PILE_WAYS = frozenset({"Way of the Butterfly"})
 # Cards that, when played, exile or set aside themselves so they live outside
 # the player's deck and discard. Relevant for events that key on an empty deck
 # *and* empty discard.
-SELF_EXILE_OR_SET_ASIDE_CARDS = frozenset({"Stockpile", "Island", "Native Village"})
+#
+# Native Village is intentionally NOT here: its play_effect sets aside the
+# *top of the deck* onto the Native Village mat, while Native Village itself
+# stays in play and goes to discard at clean-up. Adding it would emit a
+# mechanically wrong hypothesis.
+SELF_EXILE_OR_SET_ASIDE_CARDS = frozenset({"Stockpile", "Island"})
 
 # Events that key on the player having an empty deck *and* empty discard.
 EMPTY_DECK_DISCARD_EVENTS = frozenset({"Windfall"})

--- a/tests/test_trick_scanner.py
+++ b/tests/test_trick_scanner.py
@@ -154,10 +154,60 @@ def test_command_targets_silent_without_command_card():
     assert predicate_command_targets(board) == []
 
 
-def test_command_targets_silent_without_non_command_action_targets():
+def test_command_targets_silent_without_legal_targets():
     board = _board(kingdom_cards=["Daimyo"])
 
     assert predicate_command_targets(board) == []
+
+
+def test_command_targets_captain_excludes_above_4_and_durations():
+    # Captain (promo, $6 Duration-Command) only plays non-Command non-Duration
+    # Actions costing up to $4. Nobles ($6) and Council Room ($5) must be
+    # excluded; Smithy ($4) and Village ($3) are legal.
+    board = _board(
+        kingdom_cards=["Captain", "Nobles", "Council Room", "Smithy", "Village"]
+    )
+
+    interactions = predicate_command_targets(board)
+
+    captain_interactions = [i for i in interactions if "Captain" in i.headline]
+    assert len(captain_interactions) == 1
+    detail = captain_interactions[0].detail
+    assert "Smithy" in detail
+    assert "Village" in detail
+    assert "Nobles" not in detail
+    assert "Council Room" not in detail
+
+
+def test_command_targets_band_of_misfits_excludes_equal_or_more_expensive():
+    # Band of Misfits ($5) plays a non-Command Action *cheaper* than itself.
+    board = _board(
+        kingdom_cards=["Band of Misfits", "Council Room", "Smithy", "Village"]
+    )
+
+    interactions = predicate_command_targets(board)
+
+    bom = [i for i in interactions if "Band of Misfits" in i.headline]
+    assert len(bom) == 1
+    detail = bom[0].detail
+    assert "Smithy" in detail
+    assert "Village" in detail
+    # Council Room costs exactly $5 → equal to Band of Misfits → not legal.
+    assert "Council Room" not in detail
+
+
+def test_command_targets_per_card_filters_independent():
+    # Captain and Daimyo on the same board must produce different target lists.
+    board = _board(kingdom_cards=["Captain", "Daimyo", "Nobles", "Smithy"])
+
+    interactions = predicate_command_targets(board)
+
+    by_card = {
+        next(name for name in ["Captain", "Daimyo"] if name in i.headline): i
+        for i in interactions
+    }
+    assert "Nobles" in by_card["Daimyo"].detail
+    assert "Nobles" not in by_card["Captain"].detail
 
 
 # --- Predicate 5: cost-mod gateways -------------------------------------

--- a/tests/test_trick_scanner.py
+++ b/tests/test_trick_scanner.py
@@ -210,6 +210,19 @@ def test_command_targets_per_card_filters_independent():
     assert "Nobles" not in by_card["Captain"].detail
 
 
+def test_command_targets_flagship_includes_duration_actions():
+    # Flagship's engine logic only excludes Commands, so Duration Actions like
+    # Wharf are legal targets. Regression for the prior over-exclusion of
+    # Durations in the Flagship filter.
+    board = _board(kingdom_cards=["Flagship", "Wharf", "Smithy"])
+
+    interactions = predicate_command_targets(board)
+
+    flagship = [i for i in interactions if "Flagship" in i.headline]
+    assert len(flagship) == 1
+    assert "Wharf" in flagship[0].detail
+
+
 # --- Predicate 5: cost-mod gateways -------------------------------------
 
 

--- a/tests/test_trick_scanner.py
+++ b/tests/test_trick_scanner.py
@@ -125,6 +125,15 @@ def test_empty_deck_discard_silent_without_self_exile_card():
     assert predicate_empty_deck_discard_triggers(board) == []
 
 
+def test_empty_deck_discard_does_not_flag_native_village():
+    # Native Village sets aside the top of the deck onto its mat — Native
+    # Village itself stays in play and discards normally, so it must not be
+    # treated as a self-exile/set-aside card.
+    board = _board(kingdom_cards=["Native Village"], events=["Windfall"])
+
+    assert predicate_empty_deck_discard_triggers(board) == []
+
+
 # --- Predicate 4: command targets ---------------------------------------
 
 

--- a/tests/test_trick_scanner.py
+++ b/tests/test_trick_scanner.py
@@ -1,0 +1,273 @@
+"""Tests for ``dominion.analysis.trick_scanner``.
+
+Each predicate is exercised in isolation against a synthetic ``BoardConfig`` so the
+test stays focused on a single mechanic. Two end-to-end acceptance tests cover the
+real ``boards/victoria_kingdom.txt`` and ``boards/iron_barbarian.txt`` files referenced
+in issue #230.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dominion.analysis.trick_scanner import (
+    Interaction,
+    main,
+    predicate_command_targets,
+    predicate_cost_mod_gateways,
+    predicate_empty_deck_discard_triggers,
+    predicate_gain_hook_retriggerable,
+    predicate_trash_hook_via_return_to_supply,
+    render_markdown,
+    scan,
+)
+from dominion.boards.loader import BoardConfig, load_board
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VICTORIA_BOARD = REPO_ROOT / "boards" / "victoria_kingdom.txt"
+IRON_BARBARIAN_BOARD = REPO_ROOT / "boards" / "iron_barbarian.txt"
+
+
+def _board(**kwargs) -> BoardConfig:
+    kingdom = kwargs.pop("kingdom_cards")
+    return BoardConfig(kingdom_cards=list(kingdom), **kwargs)
+
+
+# --- Predicate 1: trash hook unreachable via return-to-supply Way --------
+
+
+def test_trash_hook_predicate_flags_flag_bearer_with_butterfly():
+    board = _board(
+        kingdom_cards=["Flag Bearer", "Village"],
+        ways=["Way of the Butterfly"],
+    )
+
+    interactions = predicate_trash_hook_via_return_to_supply(board)
+
+    assert len(interactions) == 1
+    headline = interactions[0].headline
+    assert "Flag Bearer" in headline
+    assert "Way of the Butterfly" in headline
+    assert "on_trash" in headline
+
+
+def test_trash_hook_predicate_silent_without_butterfly():
+    board = _board(kingdom_cards=["Flag Bearer", "Village"])
+
+    assert predicate_trash_hook_via_return_to_supply(board) == []
+
+
+def test_trash_hook_predicate_silent_when_no_card_has_on_trash_override():
+    board = _board(
+        kingdom_cards=["Village", "Smithy"],
+        ways=["Way of the Butterfly"],
+    )
+
+    assert predicate_trash_hook_via_return_to_supply(board) == []
+
+
+# --- Predicate 2: gain hook re-triggerable -------------------------------
+
+
+def test_gain_hook_predicate_flag_bearer_with_duplicate():
+    board = _board(kingdom_cards=["Flag Bearer", "Duplicate"])
+
+    interactions = predicate_gain_hook_retriggerable(board)
+
+    assert len(interactions) == 1
+    interaction = interactions[0]
+    assert "Flag Bearer" in interaction.headline
+    assert "Duplicate" in interaction.headline
+
+
+def test_gain_hook_predicate_butterfly_counts_as_a_gainer():
+    board = _board(
+        kingdom_cards=["Flag Bearer", "Village"],
+        ways=["Way of the Butterfly"],
+    )
+
+    interactions = predicate_gain_hook_retriggerable(board)
+
+    assert len(interactions) == 1
+    assert "Way of the Butterfly" in interactions[0].headline
+
+
+def test_gain_hook_predicate_silent_without_gainers():
+    board = _board(kingdom_cards=["Flag Bearer", "Village", "Smithy"])
+
+    assert predicate_gain_hook_retriggerable(board) == []
+
+
+# --- Predicate 3: empty-deck/discard triggers ---------------------------
+
+
+def test_empty_deck_discard_stockpile_plus_windfall():
+    board = _board(kingdom_cards=["Stockpile", "Village"], events=["Windfall"])
+
+    interactions = predicate_empty_deck_discard_triggers(board)
+
+    assert len(interactions) == 1
+    assert "Stockpile" in interactions[0].headline
+    assert "Windfall" in interactions[0].headline
+
+
+def test_empty_deck_discard_silent_without_event():
+    board = _board(kingdom_cards=["Stockpile"])
+
+    assert predicate_empty_deck_discard_triggers(board) == []
+
+
+def test_empty_deck_discard_silent_without_self_exile_card():
+    board = _board(kingdom_cards=["Village"], events=["Windfall"])
+
+    assert predicate_empty_deck_discard_triggers(board) == []
+
+
+# --- Predicate 4: command targets ---------------------------------------
+
+
+def test_command_targets_lists_actions_for_daimyo():
+    board = _board(kingdom_cards=["Daimyo", "Smithy", "Village"])
+
+    interactions = predicate_command_targets(board)
+
+    assert len(interactions) == 1
+    interaction = interactions[0]
+    assert "Daimyo" in interaction.headline
+    assert "Smithy" in interaction.detail
+
+
+def test_command_targets_silent_without_command_card():
+    board = _board(kingdom_cards=["Smithy", "Village"])
+
+    assert predicate_command_targets(board) == []
+
+
+def test_command_targets_silent_without_non_command_action_targets():
+    board = _board(kingdom_cards=["Daimyo"])
+
+    assert predicate_command_targets(board) == []
+
+
+# --- Predicate 5: cost-mod gateways -------------------------------------
+
+
+def test_cost_mod_gateways_bridge():
+    board = _board(kingdom_cards=["Bridge", "Smithy", "Nobles"])
+
+    interactions = predicate_cost_mod_gateways(board)
+
+    assert len(interactions) == 1
+    interaction = interactions[0]
+    assert "Bridge" in interaction.headline
+    assert "Province" in interaction.detail
+    # Threshold summary should mention both kingdom-card cost lines.
+    assert "$4" in interaction.detail
+    assert "$6" in interaction.detail
+
+
+def test_cost_mod_gateways_highway():
+    board = _board(kingdom_cards=["Highway", "Smithy"])
+
+    interactions = predicate_cost_mod_gateways(board)
+
+    assert len(interactions) == 1
+    assert "Highway" in interactions[0].headline
+
+
+def test_cost_mod_gateways_silent_without_cost_modifier():
+    board = _board(kingdom_cards=["Smithy", "Village"])
+
+    assert predicate_cost_mod_gateways(board) == []
+
+
+# --- Acceptance: full scans on real boards from issue #230 --------------
+
+
+def test_acceptance_victoria_board_surfaces_flag_bearer_butterfly():
+    board = load_board(VICTORIA_BOARD)
+
+    interactions = scan(board)
+
+    matching = [
+        i
+        for i in interactions
+        if i.kind == "trash_hook_unreachable"
+        and "Flag Bearer" in i.headline
+        and "Way of the Butterfly" in i.headline
+    ]
+    assert matching, (
+        "Expected scan(victoria_kingdom) to surface Flag Bearer + Way of the Butterfly "
+        "trash-hook interaction; got: "
+        f"{[i.headline for i in interactions]}"
+    )
+
+
+def test_acceptance_iron_barbarian_board_surfaces_at_least_one_interaction():
+    board = load_board(IRON_BARBARIAN_BOARD)
+
+    interactions = scan(board)
+
+    assert interactions, (
+        "Expected scan(iron_barbarian) to surface at least one interaction "
+        "(Bridge cost-mod gateway, at minimum)."
+    )
+
+
+# --- Output rendering ----------------------------------------------------
+
+
+def test_render_markdown_includes_kingdom_landscapes_and_interactions():
+    board = load_board(VICTORIA_BOARD)
+    interactions = scan(board)
+
+    md = render_markdown(VICTORIA_BOARD, board, interactions)
+
+    assert "Trick scan" in md
+    assert "Flag Bearer" in md
+    assert "Windfall" in md
+    assert "Way of the Butterfly" in md
+
+
+def test_render_markdown_handles_empty_interactions():
+    board = _board(kingdom_cards=["Village"])
+
+    md = render_markdown("synthetic.txt", board, [])
+
+    assert "_No interactions surfaced._" in md
+
+
+def test_interaction_to_markdown_skips_empty_refs():
+    interaction = Interaction(
+        kind="x",
+        headline="Headline",
+        detail="Detail",
+        refs=["", "/path:42"],
+    )
+
+    text = interaction.to_markdown()
+
+    assert "**Headline**" in text
+    assert "/path:42" in text
+    # An empty ref must not produce a bare backtick line.
+    assert "`\n" not in text
+    assert "``" not in text
+
+
+# --- CLI -----------------------------------------------------------------
+
+
+def test_main_runs_against_victoria_board(capsys):
+    exit_code = main(["--board", str(VICTORIA_BOARD)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Flag Bearer" in captured.out
+    assert "Way of the Butterfly" in captured.out
+
+
+def test_main_errors_on_missing_board(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        main(["--board", str(tmp_path / "does_not_exist.txt")])


### PR DESCRIPTION
## Summary

Adds `dominion.analysis.trick_scanner`, a static-analysis tool that walks a kingdom + landscapes and emits hypotheses about non-obvious mechanical interactions. Closes #230.

The motivating example from the issue is real and verified: scanning `boards/victoria_kingdom.txt` surfaces

> **Flag Bearer + Way of the Butterfly: on_trash hook unreachable when returned to pile**

…the same trick the Victoria strategy missed in #227 (which became an 85.5% win-rate edge once added).

### Predicates

Each predicate is a pure `(BoardConfig) -> list[Interaction]` that can be tested in isolation:

1. `predicate_trash_hook_via_return_to_supply` — every kingdom Action with an `on_trash` override, when the kingdom contains a Way that returns the played card to its pile (currently `Way of the Butterfly`).
2. `predicate_gain_hook_retriggerable` — every kingdom card with an `on_gain` override, against in-kingdom gainers (cards whose source calls `gain_card(`) and Way of the Butterfly.
3. `predicate_empty_deck_discard_triggers` — self-exile / set-aside cards (Stockpile, Island, Native Village) paired with empty-deck-and-discard events (Windfall).
4. `predicate_command_targets` — every Command card (Daimyo, Royal Carriage) with the highest-payload non-Command Action targets on the board, ranked by cost + a weighted stat sum.
5. `predicate_cost_mod_gateways` — every card that increments `player.cost_reduction` (Bridge, Highway), with the threshold-by-threshold summary of what becomes cheaper, including Province.

### CLI

```
python -m dominion.analysis.trick_scanner --board boards/<file>.txt
```

Output is markdown with a kingdom/landscape header, a count, and one bullet per hypothesis with a one-line headline, a longer detail, and `path:line` source refs.

### Output: `boards/victoria_kingdom.txt`

```
## 4 hypothesis interaction(s)

- **Flag Bearer + Way of the Butterfly: on_trash hook unreachable when returned to pile**
  - Flag Bearer has an on_trash effect, but Way of the Butterfly returns the played card to its supply pile rather than trashing it…
- **Flag Bearer: on_gain hook re-triggerable via Change, Duplicate, Wayfarer, Way of the Butterfly**
- **Stockpile + Windfall: set-aside cards keep deck and discard empty for Windfall's payoff**
- **Daimyo: highest-payload non-Command Action targets on this board** — Wayfarer, Charlatan, Treasury, Flag Bearer, Sailor.
```

### Output: `boards/iron_barbarian.txt`

```
## 1 hypothesis interaction(s)

- **Bridge: each play reduces every card's cost by $1 — opens cheaper gains and chains buys into Provinces**
  - $4 → $3: Bridge, Ironmonger, Marauder, Mill; $5 → $4: Barbarian, Council Room, Giant, Mint, Tragic Hero; $6 → $5: Nobles; $8 → $7 (Province) with one play; $6 with two.
```

### Design notes

- **Override detection**: hooks are detected by `type(card).on_trash is not Card.on_trash`, which walks the MRO so subclass hierarchies still work.
- **Source-text heuristics** (`"gain_card("`, `"cost_reduction" + "+="`) keep the registry of "gainers" and "cost mods" automatically in sync with the codebase rather than requiring hand-maintained lists.
- **Knowledge tables** (`RETURN_TO_PILE_WAYS`, `SELF_EXILE_OR_SET_ASIDE_CARDS`, `EMPTY_DECK_DISCARD_EVENTS`) are intentionally tiny and explicit — they capture mechanical facts that aren't easily derived from class shape, and they're easy to extend as more landscapes are added.

## Test plan

- [x] `pytest tests/test_trick_scanner.py -v` — 22 new tests (3 per predicate covering positive/silent cases, the two acceptance scans, markdown rendering, CLI).
- [x] Full non-slow suite: `pytest -q -m "not slow"` — 1183 passed, 5 deselected.
- [x] CLI smoke: `python -m dominion.analysis.trick_scanner --board boards/victoria_kingdom.txt` produces the Flag Bearer + Butterfly headline.
- [x] CLI smoke: `python -m dominion.analysis.trick_scanner --board boards/iron_barbarian.txt` produces ≥ 1 interaction (Bridge cost-mod gateway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)