### PR TITLE
Make choose_way decisions evolvable via way_policy (closes #231)

### DIFF
--- a/dominion/optimal_strategy_runner.py
+++ b/dominion/optimal_strategy_runner.py
@@ -3,7 +3,7 @@ import importlib.util
 
 from dominion.simulation.genetic_trainer import GeneticTrainer
 from dominion.simulation.strategy_battle import StrategyBattle
-from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
 
 
 def train_optimal_strategy():
@@ -90,8 +90,31 @@ def train_optimal_strategy():
             lines.append("        ]")
             return lines
 
+        def format_way_policy(rules: list[WayRule]) -> list[str]:
+            lines = ["        self.way_policy = ["]
+            for rule in rules:
+                cond_source = (
+                    getattr(rule.condition, "_source", None) if rule.condition else None
+                )
+                if cond_source:
+                    lines.append(
+                        f"            WayRule({rule.card_name!r}, {rule.way_name!r}, {cond_source}),"
+                    )
+                else:
+                    lines.append(
+                        f"            WayRule({rule.card_name!r}, {rule.way_name!r}),"
+                    )
+            lines.append("        ]")
+            return lines
+
+        needs_way_rule = bool(getattr(strategy, "way_policy", None))
+        import_line = (
+            "from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule"
+            if needs_way_rule
+            else "from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule"
+        )
         lines = [
-            "from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule",
+            import_line,
             "",
             "",
             "class OptimalStrategy(EnhancedStrategy):",
@@ -110,6 +133,8 @@ def train_optimal_strategy():
             lines.extend(format_list("trash_priority", strategy.trash_priority))
         if getattr(strategy, "discard_priority", None):
             lines.extend(format_list("discard_priority", strategy.discard_priority))
+        if needs_way_rule:
+            lines.extend(format_way_policy(strategy.way_policy))
 
         lines.append("")
         lines.append("def create_optimal_strategy() -> EnhancedStrategy:")

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -8,7 +8,7 @@ import coloredlogs
 from dominion.boards.loader import BoardConfig
 from dominion.simulation.game_logger import GameLogger
 from dominion.simulation.strategy_battle import StrategyBattle
-from dominion.strategy.enhanced_strategy import PriorityRule
+from dominion.strategy.enhanced_strategy import PriorityRule, WayRule
 from dominion.strategy.strategies.base_strategy import BaseStrategy
 
 log = logging.getLogger(__name__)
@@ -91,6 +91,13 @@ class GeneticTrainer:
                     self._kingdom_treasure_cards.append(card_name)
             except ValueError:
                 pass
+
+        # Cache way names available on the board (for way_policy mutations).
+        # Only populated when the board declares any Ways; otherwise way_policy
+        # mutators are no-ops since there's nothing to bind a rule to.
+        self._kingdom_ways: list[str] = []
+        if board_config is not None and board_config.ways:
+            self._kingdom_ways = list(board_config.ways)
 
     # Probability that ``_random_condition_with_compound`` wraps a normally
     # sampled inner condition in ``and_(card_in_play(X), inner)``. Tunable.
@@ -217,6 +224,21 @@ class GeneticTrainer:
             return PriorityRule.excess_actions(op, amount)
         return None
 
+    def _random_way_rule(self) -> Optional[WayRule]:
+        """Build a random :class:`WayRule` over this kingdom's actions and ways.
+
+        Returns ``None`` when the board has no ways (so callers can skip the
+        rule cleanly without growing way_policy with stub entries).
+        """
+        if not self._kingdom_ways or not self._kingdom_action_cards:
+            return None
+        card = random.choice(self._kingdom_action_cards)
+        way = random.choice(self._kingdom_ways)
+        condition = None
+        if random.random() < 0.5:
+            condition = self._random_condition_with_compound()
+        return WayRule(card, way, condition)
+
     def create_random_strategy(self) -> BaseStrategy:
         """Create a random strategy"""
         strategy = BaseStrategy()
@@ -272,6 +294,16 @@ class GeneticTrainer:
             PriorityRule("Estate", PriorityRule.provinces_left(">", 4)),
             PriorityRule("Copper", PriorityRule.has_cards(["Silver", "Gold"], 3)),
         ]
+
+        # Seed a small number of way_policy rules when the board has ways.
+        # Without seeding, no individual would ever try a non-default Way and
+        # the mutation-only path would discover them only by chance.
+        strategy.way_policy = []
+        if self._kingdom_ways:
+            for _ in range(random.randint(0, 2)):
+                rule = self._random_way_rule()
+                if rule is not None:
+                    strategy.way_policy.append(rule)
 
         return self._normalize(strategy)
 
@@ -407,6 +439,12 @@ class GeneticTrainer:
         if random.random() < 0.5:
             child.treasure_priority = deepcopy(parent2.treasure_priority)
 
+        # Crossover way_policy: 50/50 take parent2's whole list (way_policy is
+        # typically short, so single-point splice is overkill).
+        parent2_way_policy = getattr(parent2, "way_policy", None)
+        if parent2_way_policy and random.random() < 0.5:
+            child.way_policy = deepcopy(parent2_way_policy)
+
         return child
 
     def _mutate(self, strategy: BaseStrategy) -> BaseStrategy:
@@ -522,6 +560,49 @@ class GeneticTrainer:
                         elif priority.card_name == "Copper":
                             min_treasures = random.randint(2, 4)
                             priority.condition = PriorityRule.has_cards(["Silver", "Gold"], min_treasures)
+
+        # --- Mutate way_policy ---
+        # Only meaningful when the board has Ways. Skipped otherwise so the
+        # mutator can't grow way_policy on boards where the rules can never fire.
+        if getattr(strategy, "way_policy", None) is None:
+            strategy.way_policy = []
+
+        if self._kingdom_ways and self._kingdom_action_cards:
+            # Condition tweaks on existing way rules (drop / replace / add fresh)
+            for rule in strategy.way_policy:
+                if random.random() < self.mutation_rate and random.random() < 0.3:
+                    if rule.condition is None:
+                        rule.condition = self._random_condition_with_compound()
+                    else:
+                        if random.random() < 0.5:
+                            rule.condition = None
+                        else:
+                            rule.condition = self._random_condition_with_compound()
+
+            # Insert: try a fresh (card, way) rule
+            if random.random() < self.mutation_rate:
+                new_rule = self._random_way_rule()
+                if new_rule is not None:
+                    pos = random.randint(0, len(strategy.way_policy))
+                    strategy.way_policy.insert(pos, new_rule)
+
+            # Reorder: swap two adjacent rules
+            if random.random() < self.mutation_rate and len(strategy.way_policy) >= 2:
+                i = random.randint(0, len(strategy.way_policy) - 2)
+                strategy.way_policy[i], strategy.way_policy[i + 1] = (
+                    strategy.way_policy[i + 1],
+                    strategy.way_policy[i],
+                )
+
+            # Retarget: change the way_name on an existing rule
+            if random.random() < self.mutation_rate * 0.5 and strategy.way_policy:
+                rule = random.choice(strategy.way_policy)
+                rule.way_name = random.choice(self._kingdom_ways)
+
+            # Remove a rule occasionally to keep the genome lean
+            if random.random() < self.mutation_rate * 0.3 and strategy.way_policy:
+                i = random.randint(0, len(strategy.way_policy) - 1)
+                strategy.way_policy.pop(i)
 
         return strategy
 

--- a/dominion/strategy/enhanced_strategy.py
+++ b/dominion/strategy/enhanced_strategy.py
@@ -260,6 +260,21 @@ class PriorityRule:
         return PriorityRule._tag_source(fn, f"PriorityRule.or_({sources})")
 
 
+@dataclass
+class WayRule:
+    """A rule selecting a Way to use when playing a particular card.
+
+    When the engine asks ``choose_way`` for ``card``, the strategy walks
+    ``way_policy`` in order and picks the first rule whose ``card_name``
+    matches the played card, whose ``condition`` (if any) passes, and whose
+    ``way_name`` is in the list of available Ways for the kingdom.
+    """
+
+    card_name: str
+    way_name: str
+    condition: Optional[Callable[["GameState", "PlayerState"], bool]] = None
+
+
 class EnhancedStrategy:
     """Base strategy container.
 
@@ -276,6 +291,7 @@ class EnhancedStrategy:
         self.action_priority: list[PriorityRule] = []
         self.trash_priority: list[PriorityRule] = []
         self.treasure_priority: list[PriorityRule] = []
+        self.way_policy: list[WayRule] = []
 
     # ------------------------------------------------------------------
     def _choose_from_priority(
@@ -392,7 +408,27 @@ class EnhancedStrategy:
         return self._choose_from_priority(self.trash_priority, choices, state, player)
 
     def choose_way(self, state, player, card, ways):
-        """Default: butterfly Trail into the highest-priority $5 target."""
+        """Consult ``way_policy`` first; fall back to hardcoded Trail/Butterfly.
+
+        Each :class:`WayRule` matches when (a) its ``card_name`` equals the
+        played card, (b) its ``condition`` (if any) passes, and (c) the named
+        Way is present in ``ways``. The first matching rule wins.
+        """
+        for rule in self.way_policy:
+            if rule.card_name != card.name:
+                continue
+            cond = rule.condition
+            if cond is not None:
+                try:
+                    if not cond(state, player):
+                        continue
+                except Exception:
+                    continue
+            for w in ways:
+                if w is not None and getattr(w, "name", None) == rule.way_name:
+                    return w
+
+        # Fallback: butterfly Trail into the highest-priority +$1 target.
         if card.name != "Trail":
             return None
         target = self._best_butterfly_target(state, player, card.cost.coins + 1)

--- a/dominion/strategy/genome_simplification.py
+++ b/dominion/strategy/genome_simplification.py
@@ -32,10 +32,10 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Iterable, Optional
 
-from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
 
 
-def _condition_signature(rule: PriorityRule) -> Optional[str]:
+def _condition_signature(rule) -> Optional[str]:
     """Stable string identity for a rule's condition; None if unconditional."""
     cond = rule.condition
     if cond is None:
@@ -68,6 +68,37 @@ def _simplify_priority_list(rules: Iterable[PriorityRule]) -> list[PriorityRule]
     return output
 
 
+def _simplify_way_policy(rules: Iterable[WayRule]) -> list[WayRule]:
+    """Apply dedupe + (card_name, way_name)-scoped unconditional dominance.
+
+    Two rules with the same ``(card_name, way_name, condition)`` collapse to
+    the first. Once an unconditional rule for ``(card_name, way_name)`` is
+    seen, every later rule with that same pair is dropped — but rules with a
+    different ``way_name`` for the same card are preserved, since they may
+    fire when the unconditional rule's Way is unavailable in the kingdom.
+    """
+    seen_signatures: set[tuple[str, str, Optional[str]]] = set()
+    pairs_with_unconditional: set[tuple[str, str]] = set()
+    output: list[WayRule] = []
+
+    for rule in rules:
+        pair = (rule.card_name, rule.way_name)
+        if pair in pairs_with_unconditional:
+            continue
+
+        sig = (rule.card_name, rule.way_name, _condition_signature(rule))
+        if sig in seen_signatures:
+            continue
+
+        output.append(rule)
+        seen_signatures.add(sig)
+
+        if rule.condition is None:
+            pairs_with_unconditional.add(pair)
+
+    return output
+
+
 def simplify_strategy(strategy: EnhancedStrategy) -> EnhancedStrategy:
     """Return a deep copy of ``strategy`` with each priority list simplified.
 
@@ -80,4 +111,6 @@ def simplify_strategy(strategy: EnhancedStrategy) -> EnhancedStrategy:
     out.action_priority = _simplify_priority_list(out.action_priority)
     out.treasure_priority = _simplify_priority_list(out.treasure_priority)
     out.trash_priority = _simplify_priority_list(out.trash_priority)
+    if getattr(out, "way_policy", None):
+        out.way_policy = _simplify_way_policy(out.way_policy)
     return out

--- a/dominion/strategy/strategies/base_strategy.py
+++ b/dominion/strategy/strategies/base_strategy.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List
 
-from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
 
 
 @dataclass
@@ -19,3 +19,4 @@ class BaseStrategy(EnhancedStrategy):
         self.action_priority: List[PriorityRule] = []
         self.trash_priority: List[PriorityRule] = []
         self.treasure_priority: List[PriorityRule] = []
+        self.way_policy: List[WayRule] = []

--- a/runner.py
+++ b/runner.py
@@ -9,7 +9,7 @@ import yaml
 
 from dominion.boards.loader import BoardConfig, load_board
 from dominion.simulation.genetic_trainer import GeneticTrainer
-from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
 
 logger = logging.getLogger(__name__)
 coloredlogs.install(level="INFO", logger=logger)
@@ -47,8 +47,29 @@ def save_strategy_as_python(strategy: EnhancedStrategy, path: Path, class_name: 
         lines.append("        ]")
         return lines
 
+    def format_way_policy(rules: list[WayRule]) -> list[str]:
+        lines = ["        self.way_policy = ["]
+        for rule in rules:
+            cond_source = getattr(rule.condition, "_source", None) if rule.condition else None
+            if cond_source:
+                lines.append(
+                    f"            WayRule({rule.card_name!r}, {rule.way_name!r}, {cond_source}),"
+                )
+            else:
+                lines.append(
+                    f"            WayRule({rule.card_name!r}, {rule.way_name!r}),"
+                )
+        lines.append("        ]")
+        return lines
+
+    needs_way_rule = bool(getattr(strategy, "way_policy", None))
+    import_line = (
+        "from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule"
+        if needs_way_rule
+        else "from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule"
+    )
     lines = [
-        "from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule",
+        import_line,
         "",
         "",
         f"class {class_name}(EnhancedStrategy):",
@@ -74,6 +95,9 @@ def save_strategy_as_python(strategy: EnhancedStrategy, path: Path, class_name: 
         lines.append("")
     if getattr(strategy, "discard_priority", None):
         lines.extend(format_list("discard_priority", strategy.discard_priority))
+        lines.append("")
+    if needs_way_rule:
+        lines.extend(format_way_policy(strategy.way_policy))
         lines.append("")
 
     lines.extend(

--- a/tests/test_way_policy.py
+++ b/tests/test_way_policy.py
@@ -1,0 +1,284 @@
+"""Tests for evolvable Way selection (issue #231).
+
+Covers:
+- ``EnhancedStrategy.choose_way`` consults ``way_policy`` and respects
+  conditions, card matching, and Way availability.
+- ``GeneticTrainer`` seeds and mutates ``way_policy`` only when the board
+  declares Ways.
+- Genome simplification deduplicates ``way_policy`` and applies
+  ``(card_name, way_name)``-scoped unconditional dominance without
+  collapsing alternatives that target a different Way.
+- Round-tripping a strategy through ``runner.save_strategy_as_python``
+  preserves ``way_policy``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from dominion.boards.loader import BoardConfig
+from dominion.simulation.genetic_trainer import GeneticTrainer
+from dominion.strategy.enhanced_strategy import (
+    EnhancedStrategy,
+    PriorityRule,
+    WayRule,
+)
+from dominion.strategy.genome_simplification import simplify_strategy
+from dominion.strategy.strategies.base_strategy import BaseStrategy
+from dominion.ways.butterfly import WayOfTheButterfly
+from dominion.ways.mole import WayOfTheMole
+
+import runner
+
+
+# ---------------------------------------------------------------------------
+# choose_way honors way_policy
+# ---------------------------------------------------------------------------
+
+
+def _played_card(name: str, coins: int = 4) -> SimpleNamespace:
+    cost = SimpleNamespace(coins=coins)
+    return SimpleNamespace(name=name, cost=cost)
+
+
+class TestChooseWayHonorsPolicy:
+    def test_unconditional_rule_picks_named_way(self):
+        strategy = EnhancedStrategy()
+        strategy.way_policy = [WayRule("Flag Bearer", "Way of the Butterfly")]
+        ways = [WayOfTheButterfly(), WayOfTheMole(), None]
+
+        chosen = strategy.choose_way(
+            state=None, player=None, card=_played_card("Flag Bearer"), ways=ways
+        )
+        assert chosen is not None and chosen.name == "Way of the Butterfly"
+
+    def test_returns_none_when_card_doesnt_match(self):
+        strategy = EnhancedStrategy()
+        strategy.way_policy = [WayRule("Flag Bearer", "Way of the Butterfly")]
+        chosen = strategy.choose_way(
+            state=None,
+            player=None,
+            card=_played_card("Village"),
+            ways=[WayOfTheButterfly(), None],
+        )
+        assert chosen is None
+
+    def test_skips_rule_when_named_way_unavailable(self):
+        strategy = EnhancedStrategy()
+        strategy.way_policy = [
+            WayRule("Flag Bearer", "Way of the Butterfly"),
+            WayRule("Flag Bearer", "Way of the Mole"),
+        ]
+        # Butterfly not in this kingdom — should fall through to Mole rule.
+        ways = [WayOfTheMole(), None]
+        chosen = strategy.choose_way(
+            state=None, player=None, card=_played_card("Flag Bearer"), ways=ways
+        )
+        assert chosen is not None and chosen.name == "Way of the Mole"
+
+    def test_condition_gating_blocks_then_allows(self):
+        strategy = EnhancedStrategy()
+        # Condition takes (state, player); use a state-driven flag.
+        cond = lambda s, _p: bool(s.allow_butterfly)
+        strategy.way_policy = [WayRule("Flag Bearer", "Way of the Butterfly", cond)]
+        ways = [WayOfTheButterfly(), None]
+        card = _played_card("Flag Bearer")
+
+        blocked_state = SimpleNamespace(allow_butterfly=False)
+        assert strategy.choose_way(blocked_state, None, card, ways) is None
+
+        allowed_state = SimpleNamespace(allow_butterfly=True)
+        chosen = strategy.choose_way(allowed_state, None, card, ways)
+        assert chosen is not None and chosen.name == "Way of the Butterfly"
+
+    def test_falls_back_to_trail_butterfly_when_policy_empty(self):
+        """The pre-existing Trail/Butterfly trick must keep working when
+        ``way_policy`` is empty — old strategies depend on it."""
+        strategy = EnhancedStrategy()
+        # A gain_priority entry costing $5 lets _best_butterfly_target succeed.
+        # We simulate by stubbing _best_butterfly_target directly.
+        strategy._best_butterfly_target = lambda *_: "Smithy"
+
+        ways = [WayOfTheButterfly(), None]
+        chosen = strategy.choose_way(
+            state=None, player=None, card=_played_card("Trail"), ways=ways
+        )
+        assert chosen is not None and chosen.name == "Way of the Butterfly"
+
+
+# ---------------------------------------------------------------------------
+# Genome simplification
+# ---------------------------------------------------------------------------
+
+
+class TestSimplifyWayPolicy:
+    def _make(self, way_policy):
+        s = BaseStrategy()
+        s.way_policy = list(way_policy)
+        return s
+
+    def test_dedupes_identical_rules(self):
+        cond = PriorityRule.turn_number("<=", 8)
+        s = self._make(
+            [
+                WayRule("Flag Bearer", "Way of the Butterfly", cond),
+                WayRule(
+                    "Flag Bearer",
+                    "Way of the Butterfly",
+                    PriorityRule.turn_number("<=", 8),
+                ),
+            ]
+        )
+        out = simplify_strategy(s)
+        assert len(out.way_policy) == 1
+
+    def test_unconditional_dominates_same_card_and_way(self):
+        s = self._make(
+            [
+                WayRule("Flag Bearer", "Way of the Butterfly"),
+                WayRule(
+                    "Flag Bearer",
+                    "Way of the Butterfly",
+                    PriorityRule.turn_number("<=", 5),
+                ),
+            ]
+        )
+        out = simplify_strategy(s)
+        assert len(out.way_policy) == 1
+        assert out.way_policy[0].condition is None
+
+    def test_unconditional_does_not_dominate_different_way(self):
+        # Different Ways for the same card represent different choices —
+        # the second rule may fire if the first Way isn't in the kingdom.
+        s = self._make(
+            [
+                WayRule("Flag Bearer", "Way of the Butterfly"),
+                WayRule("Flag Bearer", "Way of the Mole"),
+            ]
+        )
+        out = simplify_strategy(s)
+        assert len(out.way_policy) == 2
+
+
+# ---------------------------------------------------------------------------
+# Genetic trainer integration
+# ---------------------------------------------------------------------------
+
+
+class TestGeneticTrainerWayPolicy:
+    def test_no_way_policy_when_board_has_no_ways(self):
+        trainer = GeneticTrainer(
+            kingdom_cards=["Village", "Smithy", "Witch"],
+            population_size=1,
+            generations=1,
+        )
+        strategy = trainer.create_random_strategy()
+        assert strategy.way_policy == []
+
+    def test_seeds_way_policy_when_board_has_ways(self):
+        # Seed RNG via repeated trials; with 0..2 random rules per strategy
+        # we just need to see a nonempty list among many tries.
+        board = BoardConfig(
+            kingdom_cards=["Flag Bearer", "Village", "Smithy"],
+            ways=["Way of the Butterfly", "Way of the Mole"],
+        )
+        trainer = GeneticTrainer(
+            kingdom_cards=board.kingdom_cards,
+            population_size=1,
+            generations=1,
+            board_config=board,
+        )
+        # Try many strategies — at least one should seed a way_policy rule.
+        seeded = any(
+            trainer.create_random_strategy().way_policy for _ in range(50)
+        )
+        assert seeded, "expected create_random_strategy to occasionally seed way_policy"
+
+    def test_random_way_rule_returns_none_without_ways(self):
+        trainer = GeneticTrainer(
+            kingdom_cards=["Village"],
+            population_size=1,
+            generations=1,
+        )
+        assert trainer._random_way_rule() is None
+
+    def test_random_way_rule_uses_kingdom_ways_only(self):
+        board = BoardConfig(
+            kingdom_cards=["Flag Bearer", "Village"],
+            ways=["Way of the Butterfly"],
+        )
+        trainer = GeneticTrainer(
+            kingdom_cards=board.kingdom_cards,
+            population_size=1,
+            generations=1,
+            board_config=board,
+        )
+        for _ in range(20):
+            rule = trainer._random_way_rule()
+            assert rule is not None
+            assert rule.way_name == "Way of the Butterfly"
+            assert rule.card_name in trainer._kingdom_action_cards
+
+
+# ---------------------------------------------------------------------------
+# Round-trip serialization
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTripSerialization:
+    def test_way_policy_serializes_and_reloads(self, tmp_path: Path):
+        strategy = BaseStrategy()
+        strategy.name = "RoundTrip"
+        strategy.gain_priority = [PriorityRule("Province")]
+        strategy.treasure_priority = [PriorityRule("Gold")]
+        strategy.way_policy = [
+            WayRule("Flag Bearer", "Way of the Butterfly"),
+            WayRule(
+                "Village",
+                "Way of the Mole",
+                PriorityRule.turn_number("<=", 5),
+            ),
+        ]
+
+        path = tmp_path / "round_trip_strategy.py"
+        runner.save_strategy_as_python(strategy, path, class_name="RoundTrip")
+
+        # Import the generated module fresh and instantiate.
+        spec = importlib.util.spec_from_file_location("round_trip_strategy", path)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["round_trip_strategy"] = module
+        try:
+            spec.loader.exec_module(module)
+            reloaded = module.RoundTrip()
+        finally:
+            sys.modules.pop("round_trip_strategy", None)
+
+        assert len(reloaded.way_policy) == 2
+        first, second = reloaded.way_policy
+        assert (first.card_name, first.way_name, first.condition) == (
+            "Flag Bearer",
+            "Way of the Butterfly",
+            None,
+        )
+        assert (second.card_name, second.way_name) == ("Village", "Way of the Mole")
+        assert second.condition is not None
+        # The reloaded condition should evaluate the same way as a fresh one.
+        state = SimpleNamespace(turn_number=3)
+        assert second.condition(state, None) is True
+        late_state = SimpleNamespace(turn_number=10)
+        assert second.condition(late_state, None) is False
+
+    def test_serialized_file_omits_way_rule_import_when_empty(self, tmp_path: Path):
+        strategy = BaseStrategy()
+        strategy.name = "NoWays"
+        strategy.gain_priority = [PriorityRule("Province")]
+        path = tmp_path / "no_ways_strategy.py"
+        runner.save_strategy_as_python(strategy, path, class_name="NoWays")
+        text = path.read_text()
+        assert "WayRule" not in text


### PR DESCRIPTION
## Summary

Adds a declarative `way_policy: list[WayRule]` to `EnhancedStrategy` so the genetic evolver can discover non-Trail Way usage (e.g. Flag Bearer + Way of the Butterfly on the Victoria board). `choose_way` walks `way_policy` first and falls back to the existing hardcoded Trail/Butterfly logic, so existing hand-tuned strategies are unaffected.

## Changes

- **`enhanced_strategy.py`** — new `WayRule(card_name, way_name, condition)` dataclass; `way_policy` field on `EnhancedStrategy`; `choose_way` consults the policy first.
- **`base_strategy.py`** — initializes `way_policy` for `BaseStrategy`.
- **`genome_simplification.py`** — dedupes `way_policy` and applies `(card_name, way_name)`-scoped unconditional dominance (different Ways for the same card are preserved as alternatives).
- **`genetic_trainer.py`** — caches `board_config.ways`, seeds 0–2 random way rules per individual when the board has Ways, adds insert/remove/swap/condition-tweak/retarget mutators, and crosses `way_policy` over.
- **`runner.py`** & **`optimal_strategy_runner.py`** — emit `WayRule` lines (and the `WayRule` import) in `save_strategy_as_python` so evolved strategies round-trip through `generated_strategies/`.
- **`tests/test_way_policy.py`** — 14 new tests covering the policy lookup, condition gating, fallback to Trail, simplifier dedupe + dominance scoping, trainer seeding/mutation contracts, and the serialization round-trip.

## Verification

- 14/14 new tests pass; all 1180 existing tests still pass.
- Manual smoke check on `boards/victoria_kingdom.txt` (Way of the Butterfly): 14/20 randomly generated strategies now include `way_policy` rules like `Wayfarer -> Way of the Butterfly`, exactly the structural lever that was missing per the issue.

## Test plan

- [x] `pytest tests/test_way_policy.py` — 14 passed
- [x] `pytest` (full suite) — 1180 passed
- [x] Smoke: `GeneticTrainer` on Victoria board now seeds non-Trail Way rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)