### PR TITLE
Make choose_way evolvable via way_policy (closes #231)

### DIFF
--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -8,7 +8,7 @@ import coloredlogs
 from dominion.boards.loader import BoardConfig
 from dominion.simulation.game_logger import GameLogger
 from dominion.simulation.strategy_battle import StrategyBattle
-from dominion.strategy.enhanced_strategy import PriorityRule
+from dominion.strategy.enhanced_strategy import PriorityRule, WayRule
 from dominion.strategy.strategies.base_strategy import BaseStrategy
 
 log = logging.getLogger(__name__)
@@ -91,6 +91,10 @@ class GeneticTrainer:
                     self._kingdom_treasure_cards.append(card_name)
             except ValueError:
                 pass
+
+        # Available Ways for the current board (e.g. ["Way of the Butterfly"]).
+        # Used to evolve per-card ``way_policy`` rules.
+        self._available_ways: list[str] = list(board_config.ways) if board_config else []
 
     # Probability that ``_random_condition_with_compound`` wraps a normally
     # sampled inner condition in ``and_(card_in_play(X), inner)``. Tunable.
@@ -217,6 +221,20 @@ class GeneticTrainer:
             return PriorityRule.excess_actions(op, amount)
         return None
 
+    def _random_way_rule(self) -> "WayRule | None":
+        """Return a random ``WayRule`` over (kingdom action card, board way),
+        or ``None`` if either set is empty (no Way evolution possible)."""
+        if not self._available_ways or not self._kingdom_action_cards:
+            return None
+        card = random.choice(self._kingdom_action_cards)
+        way = random.choice(self._available_ways)
+        # Most way rules should be unconditional (~70%) so they fire as a
+        # default. The rest carry a learned condition.
+        condition = None
+        if random.random() < 0.3:
+            condition = self._random_condition_with_compound()
+        return WayRule(card_name=card, way_name=way, condition=condition)
+
     def create_random_strategy(self) -> BaseStrategy:
         """Create a random strategy"""
         strategy = BaseStrategy()
@@ -272,6 +290,15 @@ class GeneticTrainer:
             PriorityRule("Estate", PriorityRule.provinces_left(">", 4)),
             PriorityRule("Copper", PriorityRule.has_cards(["Silver", "Gold"], 3)),
         ]
+
+        # Seed way_policy with a couple of random rules when the board has
+        # Ways. The genetic mutator can grow/shrink/edit this list.
+        strategy.way_policy = []
+        if self._available_ways and self._kingdom_action_cards:
+            for _ in range(random.randint(0, 2)):
+                rule = self._random_way_rule()
+                if rule is not None:
+                    strategy.way_policy.append(rule)
 
         return self._normalize(strategy)
 
@@ -407,6 +434,11 @@ class GeneticTrainer:
         if random.random() < 0.5:
             child.treasure_priority = deepcopy(parent2.treasure_priority)
 
+        # Crossover way_policy: take parent2's list half the time. The lists
+        # are typically short, so a coarse swap is fine.
+        if hasattr(parent2, "way_policy") and parent2.way_policy and random.random() < 0.5:
+            child.way_policy = deepcopy(parent2.way_policy)
+
         return child
 
     def _mutate(self, strategy: BaseStrategy) -> BaseStrategy:
@@ -522,6 +554,44 @@ class GeneticTrainer:
                         elif priority.card_name == "Copper":
                             min_treasures = random.randint(2, 4)
                             priority.condition = PriorityRule.has_cards(["Silver", "Gold"], min_treasures)
+
+        # --- Mutate way_policy ---
+        # Only meaningful when the board has Ways and the kingdom has actions
+        # the rules can target.
+        if self._available_ways and self._kingdom_action_cards:
+            if not hasattr(strategy, "way_policy") or strategy.way_policy is None:
+                strategy.way_policy = []
+
+            # Insert a fresh rule.
+            if random.random() < self.mutation_rate:
+                rule = self._random_way_rule()
+                if rule is not None:
+                    pos = random.randint(0, len(strategy.way_policy))
+                    strategy.way_policy.insert(pos, rule)
+
+            # Remove a rule.
+            if random.random() < self.mutation_rate * 0.3 and strategy.way_policy:
+                i = random.randint(0, len(strategy.way_policy) - 1)
+                strategy.way_policy.pop(i)
+
+            # Swap two adjacent rules.
+            if random.random() < self.mutation_rate and len(strategy.way_policy) >= 2:
+                i = random.randint(0, len(strategy.way_policy) - 2)
+                strategy.way_policy[i], strategy.way_policy[i + 1] = (
+                    strategy.way_policy[i + 1],
+                    strategy.way_policy[i],
+                )
+
+            # Tweak conditions on existing rules.
+            for rule in strategy.way_policy:
+                if random.random() < self.mutation_rate:
+                    if rule.condition is None:
+                        rule.condition = self._random_condition_with_compound()
+                    else:
+                        if random.random() < 0.5:
+                            rule.condition = None
+                        else:
+                            rule.condition = self._random_condition_with_compound()
 
         return strategy
 

--- a/dominion/strategy/enhanced_strategy.py
+++ b/dominion/strategy/enhanced_strategy.py
@@ -16,6 +16,21 @@ from dominion.game.player_state import PlayerState
 
 
 @dataclass
+class WayRule:
+    """Per-card Way usage rule.
+
+    When ``card_name`` is played and ``way_name`` is offered as one of the
+    available Ways, the rule fires if ``condition`` evaluates True (or is
+    None). The condition follows the same callable shape as
+    :class:`PriorityRule`: ``(state, player) -> bool``.
+    """
+
+    card_name: str
+    way_name: str
+    condition: Optional[Callable[["GameState", "PlayerState"], bool]] = None
+
+
+@dataclass
 class PriorityRule:
     """Represents a single priority rule.
 
@@ -276,6 +291,9 @@ class EnhancedStrategy:
         self.action_priority: list[PriorityRule] = []
         self.trash_priority: list[PriorityRule] = []
         self.treasure_priority: list[PriorityRule] = []
+        # Evolvable per-card Way usage. Walked first by ``choose_way``; falls
+        # back to the hardcoded Trail→Butterfly default below if no rule fires.
+        self.way_policy: list[WayRule] = []
 
     # ------------------------------------------------------------------
     def _choose_from_priority(
@@ -392,7 +410,17 @@ class EnhancedStrategy:
         return self._choose_from_priority(self.trash_priority, choices, state, player)
 
     def choose_way(self, state, player, card, ways):
-        """Default: butterfly Trail into the highest-priority $5 target."""
+        """Consult ``way_policy`` first; fall back to the Trail→Butterfly default.
+
+        ``way_policy`` lets the genetic evolver discover per-card Way usage
+        beyond the hardcoded Trail trick — e.g. butterflying Flag Bearer
+        into a $5 gain on the Victoria board.
+        """
+        chosen = self._choose_from_way_policy(state, player, card, ways)
+        if chosen is not None:
+            return chosen
+
+        # Fallback: butterfly Trail into the highest-priority $5 target.
         if card.name != "Trail":
             return None
         target = self._best_butterfly_target(state, player, card.cost.coins + 1)
@@ -401,6 +429,30 @@ class EnhancedStrategy:
         for w in ways:
             if w and getattr(w, "name", None) == "Way of the Butterfly":
                 return w
+        return None
+
+    def _choose_from_way_policy(self, state, player, card, ways):
+        """Walk ``way_policy`` and return the first matching Way."""
+        if not self.way_policy:
+            return None
+        for rule in self.way_policy:
+            if rule.card_name != card.name:
+                continue
+            way_obj = next(
+                (w for w in ways if w is not None and getattr(w, "name", None) == rule.way_name),
+                None,
+            )
+            if way_obj is None:
+                continue
+            cond = rule.condition
+            if cond is None:
+                return way_obj
+            if callable(cond):
+                try:
+                    if cond(state, player):
+                        return way_obj
+                except Exception:
+                    continue
         return None
 
     # -- Butterfly helpers -------------------------------------------------

--- a/dominion/strategy/genome_simplification.py
+++ b/dominion/strategy/genome_simplification.py
@@ -32,10 +32,10 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Iterable, Optional
 
-from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
 
 
-def _condition_signature(rule: PriorityRule) -> Optional[str]:
+def _condition_signature(rule) -> Optional[str]:
     """Stable string identity for a rule's condition; None if unconditional."""
     cond = rule.condition
     if cond is None:
@@ -68,6 +68,35 @@ def _simplify_priority_list(rules: Iterable[PriorityRule]) -> list[PriorityRule]
     return output
 
 
+def _simplify_way_policy(rules: Iterable[WayRule]) -> list[WayRule]:
+    """Apply dedupe + unconditional-dominance to a way_policy list.
+
+    The matching key is ``(card_name, way_name)``: a later rule for the same
+    pair is dominated once an unconditional rule for that pair appears, and
+    duplicates with identical condition signatures are dropped.
+    """
+    seen_signatures: set[tuple[str, str, Optional[str]]] = set()
+    pairs_with_unconditional: set[tuple[str, str]] = set()
+    output: list[WayRule] = []
+
+    for rule in rules:
+        pair = (rule.card_name, rule.way_name)
+        if pair in pairs_with_unconditional:
+            continue
+
+        sig = (rule.card_name, rule.way_name, _condition_signature(rule))
+        if sig in seen_signatures:
+            continue
+
+        output.append(rule)
+        seen_signatures.add(sig)
+
+        if rule.condition is None:
+            pairs_with_unconditional.add(pair)
+
+    return output
+
+
 def simplify_strategy(strategy: EnhancedStrategy) -> EnhancedStrategy:
     """Return a deep copy of ``strategy`` with each priority list simplified.
 
@@ -80,4 +109,6 @@ def simplify_strategy(strategy: EnhancedStrategy) -> EnhancedStrategy:
     out.action_priority = _simplify_priority_list(out.action_priority)
     out.treasure_priority = _simplify_priority_list(out.treasure_priority)
     out.trash_priority = _simplify_priority_list(out.trash_priority)
+    if hasattr(out, "way_policy"):
+        out.way_policy = _simplify_way_policy(out.way_policy)
     return out

--- a/dominion/strategy/strategies/base_strategy.py
+++ b/dominion/strategy/strategies/base_strategy.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List
 
-from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
 
 
 @dataclass
@@ -19,3 +19,4 @@ class BaseStrategy(EnhancedStrategy):
         self.action_priority: List[PriorityRule] = []
         self.trash_priority: List[PriorityRule] = []
         self.treasure_priority: List[PriorityRule] = []
+        self.way_policy: List[WayRule] = []

--- a/runner.py
+++ b/runner.py
@@ -9,7 +9,7 @@ import yaml
 
 from dominion.boards.loader import BoardConfig, load_board
 from dominion.simulation.genetic_trainer import GeneticTrainer
-from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
 
 logger = logging.getLogger(__name__)
 coloredlogs.install(level="INFO", logger=logger)
@@ -47,8 +47,30 @@ def save_strategy_as_python(strategy: EnhancedStrategy, path: Path, class_name: 
         lines.append("        ]")
         return lines
 
+    def format_way_policy(rules: list[WayRule]) -> list[str]:
+        lines = ["        self.way_policy = ["]
+        for rule in rules:
+            cond_source = getattr(rule.condition, "_source", None) if rule.condition else None
+            if cond_source:
+                lines.append(
+                    f"            WayRule({rule.card_name!r}, {rule.way_name!r}, {cond_source}),"
+                )
+            else:
+                lines.append(
+                    f"            WayRule({rule.card_name!r}, {rule.way_name!r}),"
+                )
+        lines.append("        ]")
+        return lines
+
+    way_policy = getattr(strategy, "way_policy", None) or []
+    import_line = (
+        "from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule"
+        if way_policy
+        else "from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule"
+    )
+
     lines = [
-        "from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule",
+        import_line,
         "",
         "",
         f"class {class_name}(EnhancedStrategy):",
@@ -74,6 +96,9 @@ def save_strategy_as_python(strategy: EnhancedStrategy, path: Path, class_name: 
         lines.append("")
     if getattr(strategy, "discard_priority", None):
         lines.extend(format_list("discard_priority", strategy.discard_priority))
+        lines.append("")
+    if way_policy:
+        lines.extend(format_way_policy(way_policy))
         lines.append("")
 
     lines.extend(

--- a/tests/test_way_policy.py
+++ b/tests/test_way_policy.py
@@ -1,0 +1,302 @@
+"""Tests for the evolvable ``way_policy`` mechanism.
+
+The Way of the Butterfly trick used to be hardcoded for Trail only. With
+``way_policy``, evolved strategies can declare per-card Way usage so the
+genetic evolver can discover, e.g., butterflying Flag Bearer on the
+Victoria board.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+from dominion.boards.loader import BoardConfig
+from dominion.simulation.genetic_trainer import GeneticTrainer
+from dominion.strategy.enhanced_strategy import (
+    EnhancedStrategy,
+    PriorityRule,
+    WayRule,
+)
+from dominion.strategy.genome_simplification import simplify_strategy
+from dominion.strategy.strategies.base_strategy import BaseStrategy
+
+
+def _mock_state():
+    state = types.SimpleNamespace()
+    state.supply = {}
+    state.turn_number = 1
+    state.empty_piles = 0
+    state.players = []
+    state.ways = []
+    return state
+
+
+def _mock_player():
+    player = types.SimpleNamespace()
+    player.coins = 0
+    player.actions = 1
+    player.buys = 1
+    player.hand = []
+    player.in_play = []
+    player.count_in_deck = lambda _name: 0
+    player.all_cards = lambda: []
+    player.get_victory_points = lambda *_: 0
+    return player
+
+
+class _StubWay:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class _StubCard:
+    def __init__(self, name: str, cost_coins: int = 4):
+        self.name = name
+        self.cost = types.SimpleNamespace(coins=cost_coins, potions=0)
+
+
+class TestChooseWayPolicy:
+    """way_policy fires before the hardcoded Trail fallback."""
+
+    def test_unconditional_rule_returns_matching_way(self):
+        strategy = EnhancedStrategy()
+        strategy.way_policy = [WayRule("Flag Bearer", "Way of the Butterfly")]
+
+        butterfly = _StubWay("Way of the Butterfly")
+        chosen = strategy.choose_way(
+            _mock_state(), _mock_player(), _StubCard("Flag Bearer"), [butterfly, None]
+        )
+        assert chosen is butterfly
+
+    def test_card_name_must_match(self):
+        strategy = EnhancedStrategy()
+        strategy.way_policy = [WayRule("Flag Bearer", "Way of the Butterfly")]
+
+        butterfly = _StubWay("Way of the Butterfly")
+        chosen = strategy.choose_way(
+            _mock_state(), _mock_player(), _StubCard("Smithy"), [butterfly, None]
+        )
+        assert chosen is None
+
+    def test_way_must_be_in_offered_list(self):
+        strategy = EnhancedStrategy()
+        strategy.way_policy = [WayRule("Flag Bearer", "Way of the Mouse")]
+
+        butterfly = _StubWay("Way of the Butterfly")
+        chosen = strategy.choose_way(
+            _mock_state(), _mock_player(), _StubCard("Flag Bearer"), [butterfly, None]
+        )
+        assert chosen is None
+
+    def test_condition_gates_the_rule(self):
+        strategy = EnhancedStrategy()
+        strategy.way_policy = [
+            WayRule(
+                "Flag Bearer",
+                "Way of the Butterfly",
+                PriorityRule.turn_number(">=", 100),  # never fires this early
+            )
+        ]
+        butterfly = _StubWay("Way of the Butterfly")
+        chosen = strategy.choose_way(
+            _mock_state(), _mock_player(), _StubCard("Flag Bearer"), [butterfly, None]
+        )
+        assert chosen is None
+
+    def test_first_matching_rule_wins(self):
+        """Earlier rules in the list should beat later ones for the same card."""
+        strategy = EnhancedStrategy()
+        mouse = _StubWay("Way of the Mouse")
+        butterfly = _StubWay("Way of the Butterfly")
+        strategy.way_policy = [
+            WayRule("Flag Bearer", "Way of the Mouse"),
+            WayRule("Flag Bearer", "Way of the Butterfly"),
+        ]
+
+        chosen = strategy.choose_way(
+            _mock_state(),
+            _mock_player(),
+            _StubCard("Flag Bearer"),
+            [mouse, butterfly, None],
+        )
+        assert chosen is mouse
+
+    def test_falls_back_to_trail_default_when_no_rule_matches(self):
+        """Empty (or non-matching) way_policy still triggers the Trail fallback."""
+        strategy = EnhancedStrategy()
+        strategy.gain_priority = [PriorityRule("Smithy")]
+        # way_policy is empty by default
+
+        state = _mock_state()
+        state.supply = {"Smithy": 5}
+        state.ways = [_StubWay("Way of the Butterfly")]
+
+        # Patch _best_butterfly_target to avoid pulling in the real card registry.
+        strategy._best_butterfly_target = lambda *_: "Smithy"
+
+        butterfly = _StubWay("Way of the Butterfly")
+        chosen = strategy.choose_way(
+            state, _mock_player(), _StubCard("Trail", cost_coins=4), [butterfly, None]
+        )
+        assert chosen is butterfly
+
+
+class TestSimplification:
+    def test_simplify_dedupes_way_rules(self):
+        s = BaseStrategy()
+        s.gain_priority = [PriorityRule("Province")]
+        s.way_policy = [
+            WayRule("Flag Bearer", "Way of the Butterfly"),
+            WayRule("Flag Bearer", "Way of the Butterfly"),  # dropped
+            WayRule("Sailor", "Way of the Butterfly"),
+        ]
+        simplified = simplify_strategy(s)
+        cards = [(r.card_name, r.way_name) for r in simplified.way_policy]
+        assert cards == [
+            ("Flag Bearer", "Way of the Butterfly"),
+            ("Sailor", "Way of the Butterfly"),
+        ]
+
+    def test_unconditional_dominates_later_rules_for_same_pair(self):
+        s = BaseStrategy()
+        s.way_policy = [
+            WayRule("Flag Bearer", "Way of the Butterfly"),  # unconditional
+            WayRule(
+                "Flag Bearer",
+                "Way of the Butterfly",
+                PriorityRule.turn_number("<=", 5),
+            ),  # dropped — unreachable
+            # Different (card, way) pair survives.
+            WayRule("Flag Bearer", "Way of the Mouse"),
+        ]
+        simplified = simplify_strategy(s)
+        sigs = [(r.card_name, r.way_name, r.condition) for r in simplified.way_policy]
+        assert sigs == [
+            ("Flag Bearer", "Way of the Butterfly", None),
+            ("Flag Bearer", "Way of the Mouse", None),
+        ]
+
+
+class TestMutation:
+    """The genetic trainer should mutate way_policy when a board has Ways."""
+
+    def _victoria_trainer(self) -> GeneticTrainer:
+        board = BoardConfig(
+            kingdom_cards=["Flag Bearer", "Sailor", "Treasury", "Charlatan"],
+            ways=["Way of the Butterfly"],
+        )
+        return GeneticTrainer(
+            kingdom_cards=board.kingdom_cards,
+            population_size=2,
+            generations=1,
+            games_per_eval=1,
+            board_config=board,
+        )
+
+    def test_random_way_rule_targets_kingdom_action_and_board_way(self):
+        trainer = self._victoria_trainer()
+        # Force determinism via a long sample loop.
+        for _ in range(20):
+            rule = trainer._random_way_rule()
+            assert rule is not None
+            assert rule.card_name in trainer._kingdom_action_cards
+            assert rule.way_name == "Way of the Butterfly"
+            assert rule.condition is None or callable(rule.condition)
+
+    def test_no_ways_yields_no_random_rule(self):
+        trainer = GeneticTrainer(
+            kingdom_cards=["Village", "Smithy"],
+            population_size=1,
+            generations=1,
+            games_per_eval=1,
+        )
+        assert trainer._random_way_rule() is None
+
+    def test_mutation_grows_way_policy_over_iterations(self):
+        """Repeated mutation should eventually produce a non-empty way_policy."""
+        trainer = self._victoria_trainer()
+        trainer.mutation_rate = 0.9  # crank way up so the test isn't flaky
+
+        strategy = BaseStrategy()
+        strategy.way_policy = []
+        # Seed gain/treasure so _mutate runs cleanly.
+        strategy.gain_priority = [PriorityRule("Province")]
+        strategy.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
+
+        for _ in range(50):
+            trainer._mutate(strategy)
+            if strategy.way_policy:
+                break
+
+        assert strategy.way_policy, "way_policy should grow after many mutations"
+        for rule in strategy.way_policy:
+            assert rule.way_name == "Way of the Butterfly"
+            assert rule.card_name in trainer._kingdom_action_cards
+
+
+class TestSerializationRoundTrip:
+    def test_strategy_with_way_policy_round_trips(self, tmp_path):
+        from runner import save_strategy_as_python
+
+        strategy = BaseStrategy()
+        strategy.name = "VictoriaButterfly"
+        strategy.gain_priority = [PriorityRule("Province")]
+        strategy.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+        strategy.way_policy = [
+            WayRule("Flag Bearer", "Way of the Butterfly"),
+            WayRule(
+                "Sailor",
+                "Way of the Butterfly",
+                PriorityRule.turn_number("<=", 8),
+            ),
+        ]
+
+        out_file = tmp_path / "victoria_butterfly_strategy.py"
+        save_strategy_as_python(strategy, out_file, "VictoriaButterflyStrategy")
+
+        source = out_file.read_text()
+        assert "WayRule" in source, "way_policy should be emitted"
+        assert "Way of the Butterfly" in source
+        assert "<lambda" not in source
+        assert "<function" not in source
+
+        sys.path.insert(0, str(tmp_path))
+        try:
+            mod = importlib.import_module("victoria_butterfly_strategy")
+            generated = mod.VictoriaButterflyStrategy()
+            assert generated.name == "VictoriaButterfly"
+            assert len(generated.way_policy) == 2
+            first, second = generated.way_policy
+            assert first.card_name == "Flag Bearer"
+            assert first.way_name == "Way of the Butterfly"
+            assert first.condition is None
+            assert second.card_name == "Sailor"
+            assert callable(second.condition)
+        finally:
+            sys.path.pop(0)
+            sys.modules.pop("victoria_butterfly_strategy", None)
+
+    def test_strategy_without_way_policy_omits_wayrule_import(self, tmp_path):
+        """No way_policy → keep the generated file lean (no WayRule import)."""
+        from runner import save_strategy_as_python
+
+        strategy = BaseStrategy()
+        strategy.name = "Plain"
+        strategy.gain_priority = [PriorityRule("Province")]
+        strategy.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+        out_file = tmp_path / "plain_strategy.py"
+        save_strategy_as_python(strategy, out_file, "PlainStrategy")
+        source = out_file.read_text()
+
+        assert "WayRule" not in source


### PR DESCRIPTION
## Summary
- Adds `WayRule(card_name, way_name, condition)` and `EnhancedStrategy.way_policy: list[WayRule]`. `choose_way` walks `way_policy` first, then falls back to the existing Trail→Butterfly default — so the genetic evolver can now discover, e.g., butterflying Flag Bearer on the Victoria board, not just Trail.
- Mutation operators (insert / remove / swap / condition-tweak), crossover, genome simplification, and `runner.save_strategy_as_python` all round-trip the new field. `WayRule` is only imported in generated files when `way_policy` is non-empty.
- 13 new tests in `tests/test_way_policy.py` covering policy semantics, simplification, mutation on a Victoria-style board, and serialization round-trip.

## Test Plan
- [x] `pytest tests/test_way_policy.py` — 13/13 pass
- [x] `pytest` (full suite) — 1179/1179 pass
- [ ] Run an evolution against `boards/victoria_kingdom.txt` and confirm a non-Trail Butterfly rule emerges in the evolved strategy (acceptance criterion #1; structural mechanism is in place but convergence is a runtime check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)