### PR TITLE
Canonicalize parametric Way names in evolved way_policy

### DIFF
--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import re
 from copy import deepcopy
 from typing import Callable, Optional, Tuple
 
@@ -13,6 +14,23 @@ from dominion.strategy.strategies.base_strategy import BaseStrategy
 
 log = logging.getLogger(__name__)
 coloredlogs.install(level="INFO", logger=log)
+
+
+_WAY_PARAM_RE = re.compile(r"\s*\(.+\)$")
+
+
+def _canonical_way_name(way: str) -> str:
+    """Strip a parametric ``(...)`` suffix from a Way name.
+
+    The board loader stores ``Way of the Mouse: Native Village`` as
+    ``"Way of the Mouse (Native Village)"`` so the way registry's regex can
+    resolve the set-aside card. But the constructed ``WayOfTheMouse``
+    instance's ``.name`` is just ``"Way of the Mouse"`` — without the
+    parametric suffix. ``WayRule.way_name`` is matched against the runtime
+    ``Way.name`` in :meth:`EnhancedStrategy._choose_from_way_policy`, so we
+    canonicalise here to keep the two sides aligned.
+    """
+    return _WAY_PARAM_RE.sub("", way)
 
 
 def _distribute_games(total_budget: int, n_opponents: int) -> list[int]:
@@ -95,9 +113,13 @@ class GeneticTrainer:
         # Cache way names available on the board (for way_policy mutations).
         # Only populated when the board declares any Ways; otherwise way_policy
         # mutators are no-ops since there's nothing to bind a rule to.
+        # Parametric variants like "Way of the Mouse (Native Village)" are
+        # stripped to their base name ("Way of the Mouse") so WayRule.way_name
+        # matches the runtime ``Way.name`` (the ways/registry constructs the
+        # mouse instance with the unparameterised name).
         self._kingdom_ways: list[str] = []
         if board_config is not None and board_config.ways:
-            self._kingdom_ways = list(board_config.ways)
+            self._kingdom_ways = [_canonical_way_name(w) for w in board_config.ways]
 
     # Probability that ``_random_condition_with_compound`` wraps a normally
     # sampled inner condition in ``and_(card_in_play(X), inner)``. Tunable.

--- a/tests/test_way_policy.py
+++ b/tests/test_way_policy.py
@@ -224,6 +224,31 @@ class TestGeneticTrainerWayPolicy:
             assert rule.way_name == "Way of the Butterfly"
             assert rule.card_name in trainer._kingdom_action_cards
 
+    def test_parametric_mouse_way_is_canonicalized(self):
+        """Boards declared as ``Way of the Mouse (Native Village)`` round-trip
+        through ``WayRule.way_name`` as the unparameterised ``Way of the Mouse``
+        — so the rule actually matches the runtime ``Way.name`` and isn't
+        silently unreachable."""
+        from dominion.ways.registry import get_way
+
+        board = BoardConfig(
+            kingdom_cards=["Flag Bearer", "Village"],
+            ways=["Way of the Mouse (Native Village)"],
+        )
+        trainer = GeneticTrainer(
+            kingdom_cards=board.kingdom_cards,
+            population_size=1,
+            generations=1,
+            board_config=board,
+        )
+        assert trainer._kingdom_ways == ["Way of the Mouse"]
+
+        # The runtime Way object also has the unparameterised name, so the
+        # equality check in ``EnhancedStrategy._choose_from_way_policy``
+        # succeeds.
+        runtime_way = get_way("Way of the Mouse (Native Village)")
+        assert runtime_way.name == trainer._kingdom_ways[0]
+
 
 # ---------------------------------------------------------------------------
 # Round-trip serialization


### PR DESCRIPTION
## Summary
- The board loader stores parametric Ways like `Way of the Mouse: Native Village` as `"Way of the Mouse (Native Village)"` in `board_config.ways` so the registry's regex can resolve the set-aside card. But the constructed `WayOfTheMouse` instance's `.name` is just `"Way of the Mouse"`.
- `GeneticTrainer.__init__` was copying the parametric form straight into `_kingdom_ways`, and `_random_way_rule` then stuffed it into `WayRule.way_name`. The equality check in `EnhancedStrategy._choose_from_way_policy` (`way.name == rule.way_name`) never matched, so any evolved Mouse rule was silently unreachable on Mouse boards (e.g. `boards/astrolabe_treasury.txt`).
- Strip the parametric `(...)` suffix when populating `_kingdom_ways` via a small `_canonical_way_name` helper. Add a regression test that asserts the canonical name matches the runtime `Way.name` from `dominion.ways.registry.get_way`.

This fixes the Codex P1 review comment from #237 (which was closed as a duplicate of the merged #236 — the bug exists in both implementations).

## Test Plan
- [x] `pytest tests/test_way_policy.py` — 15/15 pass (new regression test included)
- [x] `pytest` (full suite) — 1204/1204 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)