### PR TITLE
Gate Peddler cost discount to Buy phase only

### DIFF
--- a/dominion/cards/prosperity/peddler.py
+++ b/dominion/cards/prosperity/peddler.py
@@ -11,5 +11,8 @@ class Peddler(Card):
         )
 
     def cost_modifier(self, game_state, player) -> int:
+        # Discount only applies "during your Buy phase" per card text.
+        if getattr(game_state, "phase", None) != "buy":
+            return 0
         actions_in_play = sum(1 for c in player.in_play if c.is_action)
         return -2 * actions_in_play

--- a/tests/test_nocturne_cards.py
+++ b/tests/test_nocturne_cards.py
@@ -676,6 +676,8 @@ def test_changeling_uses_effective_cost_at_gain_peddler_reduced_below_three():
     player.cost_reduction = 3
     # Two Action cards in play to trigger Peddler's cost_modifier.
     player.in_play = [get_card("Village"), get_card("Smithy")]
+    # Peddler's discount only applies during the Buy phase.
+    state.phase = "buy"
 
     # Sanity: confirm get_card_cost agrees the effective cost is < 3.
     peddler_template = get_card("Peddler")

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -974,3 +974,27 @@ def test_watchtower_reaction_only_fires_when_in_hand():
 
     assert all(c.name != "Estate" for c in state.trash)
     assert any(c.name == "Estate" for c in player.discard + player.deck)
+
+
+def test_peddler_discount_only_applies_in_buy_phase():
+    """Peddler's "$2 less per Action card you have in play" reduction is
+    a Buy-phase-only effect per the printed text. Outside the Buy phase
+    (e.g. when something gains a Peddler during the Action phase, or
+    when another card asks for Peddler's cost), the printed cost of
+    $8 must apply unchanged."""
+
+    player = PlayerState(DummyAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Peddler"), get_card("Village")])
+
+    # Two Action cards in play would reduce Peddler by $4 if the
+    # discount applied unconditionally.
+    player.in_play = [get_card("Village"), get_card("Village")]
+
+    peddler = get_card("Peddler")
+
+    state.phase = "action"
+    assert state.get_card_cost(player, peddler) == 8
+
+    state.phase = "buy"
+    assert state.get_card_cost(player, peddler) == 4


### PR DESCRIPTION
## Summary
- Peddler's "-$2 per Action in play" reduction now only applies when \`game_state.phase == \"buy\"\`, matching the card's printed "during your Buy phase" wording.
- Previously the discount applied unconditionally, so a Peddler gained via Workshop/Remodel-style effects in the Action phase, or queried by any cost-aware card outside the Buy phase, would incorrectly cost less than $8.
- Cost was already clamped to $0 by \`GameState.get_card_cost\`, so this was never a "negative cost" bug — only a phase-gating bug.

## Test plan
- [x] New \`test_peddler_discount_only_applies_in_buy_phase\` in \`tests/test_prosperity_cards.py\` — confirms full $8 cost in the Action phase and discounted cost in the Buy phase.
- [x] Updated \`test_changeling_uses_effective_cost_at_gain_peddler_reduced_below_three\` to set \`state.phase = "buy"\` (the scenario it models is a buy with Bridge+actions in play).
- [x] Full suite: \`pytest tests/\` — 1248 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)