### PR TITLE
Fix Prosperity card bugs vs. official rulebook

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -672,6 +672,14 @@ class AI(ABC):
 
         return False
 
+    def choose_coppers_for_counting_house(
+        self, state: GameState, player: PlayerState, coppers: list[Card]
+    ) -> list[Card]:
+        """Choose which Coppers from the discard pile to reveal and take into
+        hand when playing Counting House. Default: take all."""
+
+        return list(coppers)
+
     def should_topdeck_with_way_of_seal(
         self, state: GameState, player: PlayerState, gained_card: Card
     ) -> bool:

--- a/dominion/cards/prosperity/anvil.py
+++ b/dominion/cards/prosperity/anvil.py
@@ -23,14 +23,18 @@ class Anvil(Card):
         Treasure is offered, discard it and gain a card costing up to $4.
         """
 
-        treasures = [card for card in player.hand if card.is_treasure]
+        treasures = [card for card in player.hand if game_state.is_treasure(card)]
         if not treasures:
             return
 
         choice = player.ai.choose_anvil_treasure_to_discard(
             game_state, player, list(treasures)
         )
-        if choice is None or choice not in player.hand or not choice.is_treasure:
+        if (
+            choice is None
+            or choice not in player.hand
+            or not game_state.is_treasure(choice)
+        ):
             return
 
         # Discard the chosen Treasure from hand.

--- a/dominion/cards/prosperity/bank.py
+++ b/dominion/cards/prosperity/bank.py
@@ -14,5 +14,5 @@ class Bank(Card):
 
     def play_effect(self, game_state):
         player = game_state.current_player
-        treasures_in_play = sum(1 for c in player.in_play if c.is_treasure)
+        treasures_in_play = sum(1 for c in player.in_play if game_state.is_treasure(c))
         player.coins += treasures_in_play

--- a/dominion/cards/prosperity/charlatan.py
+++ b/dominion/cards/prosperity/charlatan.py
@@ -4,9 +4,11 @@ from ..base_card import Card, CardCost, CardStats, CardType
 class Charlatan(Card):
     """Action-Attack ($5): +$3. Each other player gains a Curse.
 
-    On the printed card Charlatan also makes Curse cards in the supply
-    "count as Curse-typed Treasures" for cost purposes; this implementation
-    treats Charlatan as a stronger Witch-style attack with +$3.
+    In any kingdom that includes Charlatan, Curses are Treasures (in
+    addition to their other types) and produce $1 when played — for the
+    entire game and in all situations. The Curse-as-Treasure effect is
+    wired in :meth:`GameState.handle_treasure_phase` and keyed off
+    Charlatan's presence in the Supply.
     """
 
     def __init__(self):

--- a/dominion/cards/prosperity/city.py
+++ b/dominion/cards/prosperity/city.py
@@ -16,7 +16,6 @@ class City(Card):
 
         if empty_piles >= 1:
             game_state.draw_cards(player, 1)
-            player.coins += 1
 
         if empty_piles >= 2:
             player.buys += 1

--- a/dominion/cards/prosperity/counting_house.py
+++ b/dominion/cards/prosperity/counting_house.py
@@ -16,6 +16,11 @@ class CountingHouse(Card):
         if not coppers:
             return
         chosen = player.ai.choose_coppers_for_counting_house(game_state, player, coppers)
+        # Normalize a None / non-iterable return to an empty list so an AI
+        # following the common "return None to decline" pattern (used by
+        # other chooser hooks) doesn't raise TypeError here.
+        if chosen is None:
+            chosen = []
         # The AI's pick must come from the offered Coppers; ignore anything
         # else (a buggy or adversarial AI cannot smuggle non-Coppers — e.g.
         # Estates — out of the discard pile this way).

--- a/dominion/cards/prosperity/counting_house.py
+++ b/dominion/cards/prosperity/counting_house.py
@@ -16,7 +16,13 @@ class CountingHouse(Card):
         if not coppers:
             return
         chosen = player.ai.choose_coppers_for_counting_house(game_state, player, coppers)
-        for copper in chosen:
-            if copper in player.discard:
-                player.discard.remove(copper)
-                player.hand.append(copper)
+        # The AI's pick must come from the offered Coppers; ignore anything
+        # else (a buggy or adversarial AI cannot smuggle non-Coppers — e.g.
+        # Estates — out of the discard pile this way).
+        offered = set(map(id, coppers))
+        for card in chosen:
+            if id(card) not in offered:
+                continue
+            if card in player.discard:
+                player.discard.remove(card)
+                player.hand.append(card)

--- a/dominion/cards/prosperity/counting_house.py
+++ b/dominion/cards/prosperity/counting_house.py
@@ -13,6 +13,10 @@ class CountingHouse(Card):
     def play_effect(self, game_state):
         player = game_state.current_player
         coppers = [c for c in player.discard if c.name == "Copper"]
-        for copper in coppers:
-            player.discard.remove(copper)
-            player.hand.append(copper)
+        if not coppers:
+            return
+        chosen = player.ai.choose_coppers_for_counting_house(game_state, player, coppers)
+        for copper in chosen:
+            if copper in player.discard:
+                player.discard.remove(copper)
+                player.hand.append(copper)

--- a/dominion/cards/prosperity/counting_house.py
+++ b/dominion/cards/prosperity/counting_house.py
@@ -16,11 +16,16 @@ class CountingHouse(Card):
         if not coppers:
             return
         chosen = player.ai.choose_coppers_for_counting_house(game_state, player, coppers)
-        # Normalize a None / non-iterable return to an empty list so an AI
-        # following the common "return None to decline" pattern (used by
-        # other chooser hooks) doesn't raise TypeError here.
+        # Normalize a non-iterable / None return to an empty list so a
+        # custom AI that returns None (the common "decline" sentinel) or
+        # any other non-iterable doesn't raise TypeError mid-turn.
         if chosen is None:
             chosen = []
+        else:
+            try:
+                chosen = list(chosen)
+            except TypeError:
+                chosen = []
         # The AI's pick must come from the offered Coppers; ignore anything
         # else (a buggy or adversarial AI cannot smuggle non-Coppers — e.g.
         # Estates — out of the discard pile this way).

--- a/dominion/cards/prosperity/crystal_ball.py
+++ b/dominion/cards/prosperity/crystal_ball.py
@@ -39,7 +39,9 @@ class CrystalBall(Card):
             game_state.discard_card(player, top_card)
             return
 
-        if choice == "play" and (top_card.is_action or top_card.is_treasure):
+        if choice == "play" and (
+            top_card.is_action or game_state.is_treasure(top_card)
+        ):
             player.deck.pop()
             player.in_play.append(top_card)
             top_card.on_play(game_state)

--- a/dominion/cards/prosperity/investment.py
+++ b/dominion/cards/prosperity/investment.py
@@ -23,7 +23,9 @@ class Investment(Card):
             player.in_play.remove(self)
             game_state.trash_card(player, self)
 
-        treasures_in_hand = [card for card in player.hand if card.is_treasure]
+        treasures_in_hand = [
+            card for card in player.hand if game_state.is_treasure(card)
+        ]
         can_trash_treasure = bool(treasures_in_hand)
 
         mode = player.ai.choose_investment_mode(
@@ -40,7 +42,11 @@ class Investment(Card):
         choice = player.ai.choose_treasure_to_trash_for_investment(
             game_state, player, list(treasures_in_hand)
         )
-        if choice is None or choice not in player.hand or not choice.is_treasure:
+        if (
+            choice is None
+            or choice not in player.hand
+            or not game_state.is_treasure(choice)
+        ):
             # Fall back to coin if AI declined despite committing to trash.
             player.coins += 1
             return
@@ -50,6 +56,6 @@ class Investment(Card):
 
         # Reveal hand and count distinct treasure names (after trashing).
         distinct_treasure_names = {
-            card.name for card in player.hand if card.is_treasure
+            card.name for card in player.hand if game_state.is_treasure(card)
         }
         player.vp_tokens += len(distinct_treasure_names)

--- a/dominion/cards/prosperity/loan.py
+++ b/dominion/cards/prosperity/loan.py
@@ -20,7 +20,7 @@ class Loan(Card):
             if not player.deck:
                 break
             card = player.deck.pop()
-            if card.is_treasure:
+            if game_state.is_treasure(card):
                 revealed_treasure = card
                 break
             revealed.append(card)

--- a/dominion/cards/prosperity/magnate.py
+++ b/dominion/cards/prosperity/magnate.py
@@ -14,6 +14,11 @@ class Magnate(Card):
 
     def play_effect(self, game_state):
         player = game_state.current_player
-        treasures_revealed = sum(1 for card in player.hand if card.is_treasure)
+        # Use the game's Treasure check so Curses count when Charlatan is in
+        # the kingdom (Prosperity 2E: Curse becomes Curse-Treasure for the
+        # entire game).
+        treasures_revealed = sum(
+            1 for card in player.hand if game_state.is_treasure(card)
+        )
         if treasures_revealed:
             game_state.draw_cards(player, treasures_revealed)

--- a/dominion/cards/prosperity/mint.py
+++ b/dominion/cards/prosperity/mint.py
@@ -14,7 +14,7 @@ class Mint(Card):
         from ..registry import get_card
 
         player = game_state.current_player
-        treasures = [c for c in player.hand if c.is_treasure]
+        treasures = [c for c in player.hand if game_state.is_treasure(c)]
         if not treasures:
             return
 

--- a/dominion/cards/prosperity/mint.py
+++ b/dominion/cards/prosperity/mint.py
@@ -29,7 +29,10 @@ class Mint(Card):
 
     def on_buy(self, game_state):
         player = game_state.current_player
-        treasures = [c for c in list(player.in_play) if c.is_treasure]
+        # Use the game's Treasure check so Curses played as Treasures via
+        # Charlatan are also trashed when Mint is bought (Prosperity 2E
+        # rulebook explicitly calls this out).
+        treasures = [c for c in list(player.in_play) if game_state.is_treasure(c)]
         for treasure in treasures:
             player.in_play.remove(treasure)
             game_state.trash_card(player, treasure)

--- a/dominion/cards/prosperity/rabble.py
+++ b/dominion/cards/prosperity/rabble.py
@@ -22,7 +22,9 @@ class Rabble(Card):
                     break
                 revealed.append(target.deck.pop())
 
-            to_discard = [c for c in list(revealed) if c.is_action or c.is_treasure]
+            to_discard = [
+                c for c in list(revealed) if c.is_action or game_state.is_treasure(c)
+            ]
             for card in to_discard:
                 if card in revealed:
                     revealed.remove(card)

--- a/dominion/cards/prosperity/venture.py
+++ b/dominion/cards/prosperity/venture.py
@@ -17,7 +17,7 @@ class Venture(Card):
             if not player.deck:
                 player.shuffle_discard_into_deck()
             card = player.deck.pop()
-            if card.is_treasure:
+            if game_state.is_treasure(card):
                 player.in_play.append(card)
                 card.on_play(game_state)
                 game_state.fire_ally_play_hooks(player, card)

--- a/dominion/cards/prosperity/war_chest.py
+++ b/dominion/cards/prosperity/war_chest.py
@@ -2,9 +2,7 @@ from ..base_card import Card, CardCost, CardStats, CardType
 
 
 class WarChest(Card):
-    """Treasure ($5): +1 Buy. +$1.
-
-    When you play this, the player to your left names a card. Gain a card
+    """Treasure ($5): The player to your left names a card. Gain a card
     costing up to $5 that wasn't named (this turn).
 
     Multi-shot: every War Chest played in a turn names a different card; the
@@ -15,7 +13,7 @@ class WarChest(Card):
         super().__init__(
             name="War Chest",
             cost=CardCost(coins=5),
-            stats=CardStats(coins=1, buys=1),
+            stats=CardStats(),
             types=[CardType.TREASURE],
         )
 

--- a/dominion/cards/victory.py
+++ b/dominion/cards/victory.py
@@ -47,6 +47,15 @@ class Curse(Card):
     def __init__(self):
         super().__init__(name="Curse", cost=CardCost(coins=0), stats=CardStats(vp=-1), types=[CardType.CURSE])
 
+    def play_effect(self, game_state):
+        # Prosperity 2E: in any kingdom that includes Charlatan, Curses are
+        # Treasures worth $1 when played. Living here means every play path
+        # (treasure phase, Tiara replay, Reckless double-play, Venture,
+        # Crystal Ball, ...) grants the coin via the normal on_play hook —
+        # no special-cases needed at the call sites.
+        if game_state.charlatan_curse_active():
+            game_state.current_player.coins += 1
+
     def starting_supply(self, game_state) -> int:
         n_players = len(game_state.players)
         if n_players <= 1:

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1622,6 +1622,15 @@ class GameState:
                     and not card.is_treasure
                     and card.stats.coins > 0
                 ]
+            # Prosperity 2E: in any kingdom that includes Charlatan, Curses
+            # are Treasures (in addition to their other types) and produce $1
+            # when played. Per the rulebook this is a game-level modifier
+            # ("for the entire game and in all situations"), keyed off the
+            # presence of the Charlatan pile in the Supply, not whether a
+            # Charlatan is currently in play.
+            charlatan_active = "Charlatan" in self.supply
+            if charlatan_active:
+                treasures += [card for card in player.hand if card.name == "Curse"]
             if not treasures:
                 break
 
@@ -1651,11 +1660,20 @@ class GameState:
                 # Corsair trashes AFTER on_play: the treasure is fully played
                 # (so its +$ applies and any "while in play" counters tick),
                 # then Corsair removes it from in-play to the trash.
-                choice.on_play(self)
+                # Prosperity 2E: Curses played as Treasures via Charlatan
+                # produce $1. ``Curse.on_play`` applies no stats, so we add
+                # the coin alongside every play of a Curse — including any
+                # replay paths below (Reckless, Tiara).
+                def play_choice() -> None:
+                    choice.on_play(self)
+                    if choice.name == "Curse" and charlatan_active:
+                        player.coins += 1
+
+                play_choice()
                 # Plunder Reckless trait: Treasures from Reckless pile play twice.
                 if self.pile_traits.get(choice.name) == "Reckless":
                     if choice in player.in_play:
-                        choice.on_play(self)
+                        play_choice()
                 self._maybe_corsair_trash(player, choice)
                 # Menagerie: Kiln — gain a copy of the next card played.
                 self._maybe_kiln_gain(player, choice)
@@ -1695,7 +1713,7 @@ class GameState:
                         self, player, choice
                     ):
                         player.tiara_replay_used = True
-                        choice.on_play(self)
+                        play_choice()
                         if self.prophecy is not None and self.prophecy.is_active:
                             self.prophecy.on_play_treasure(self, player, choice)
                         # Tiara's bonus replay is another play of the

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -634,6 +634,14 @@ class GameState:
         if any(card.name == "Urchin" for card in kingdom_cards):
             self.supply["Mercenary"] = 10
 
+        # Latch the Charlatan game-level rule at setup time. If Charlatan is
+        # part of this game (Supply or Black Market deck), the "Curses are
+        # Treasures worth $1" effect applies for the entire game — even if
+        # the Charlatan pile is later removed by something like Divine Wind
+        # before the first Curse-as-Treasure check could observe it live.
+        if "Charlatan" in self.supply or "Charlatan" in self.black_market_deck:
+            self._charlatan_seen = True
+
     def gain_ruins(self, target) -> "Card | None":
         """Resolve a "gain a Ruins" by handing over the top of the Ruins pile."""
         order = self.pile_order.get("Ruins")

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1557,14 +1557,31 @@ class GameState:
     def charlatan_curse_active(self) -> bool:
         """Whether Charlatan's "Curses are Treasures worth $1" rule is active.
 
-        Per Prosperity 2E, this applies "for the entire game and in all
-        situations" once Charlatan is part of the kingdom — even when the
-        Charlatan pile has been emptied or no Charlatan is in play. Black
-        Market keeps its deck out of the Supply, so we also check that.
+        Per Prosperity 2E this applies "for the entire game and in all
+        situations" once Charlatan is part of the game. The check is a
+        latched lazy scan: as soon as a Charlatan is observed anywhere
+        (Supply, Black Market deck, any player zone, or the trash) the
+        flag is set to True and stays True for the remainder of the
+        game. This matters because Black Market removes purchased cards
+        from its deck permanently, so a supply/deck-only check would
+        deactivate the rule mid-game.
         """
+        if getattr(self, "_charlatan_seen", False):
+            return True
         if "Charlatan" in self.supply:
+            self._charlatan_seen = True
             return True
         if "Charlatan" in self.black_market_deck:
+            self._charlatan_seen = True
+            return True
+        for p in self.players:
+            for zone_name in ("hand", "deck", "discard", "in_play", "duration"):
+                zone = getattr(p, zone_name, ())
+                if any(getattr(c, "name", None) == "Charlatan" for c in zone):
+                    self._charlatan_seen = True
+                    return True
+        if any(c.name == "Charlatan" for c in self.trash):
+            self._charlatan_seen = True
             return True
         return False
 

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -427,6 +427,11 @@ class GameState:
 
     def setup_supply(self, kingdom_cards: list[Card]):
         """Set up the initial supply piles."""
+        # Reset latches that depend on supply contents. Pairing the reset
+        # with the set (at the bottom of this method) means callers using
+        # ``setup_supply`` directly — e.g. tests rebuilding a kingdom on the
+        # same ``GameState`` — don't leak the prior setup's Charlatan flag.
+        self._charlatan_seen = False
         # Add basic cards with proper counts
         copper_card = get_card("Copper")
         silver_card = get_card("Silver")

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -253,6 +253,10 @@ class GameState:
         landmarks: list = None,
     ):
         """Set up the game with given AIs and kingdom cards."""
+        # Reset latched per-game flags so a reused ``GameState`` doesn't
+        # carry state from a previous game (e.g. a prior Charlatan game
+        # leaving Curse-as-Treasure active in a Charlatan-free game).
+        self._charlatan_seen = False
         # Create PlayerState objects for each AI
         self.players = [PlayerState(ai) for ai in ais]
         # Provide a back-reference so PlayerState methods (notably

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -253,10 +253,13 @@ class GameState:
         landmarks: list = None,
     ):
         """Set up the game with given AIs and kingdom cards."""
-        # Reset latched per-game flags so a reused ``GameState`` doesn't
-        # carry state from a previous game (e.g. a prior Charlatan game
-        # leaving Curse-as-Treasure active in a Charlatan-free game).
+        # Reset per-game state on the reused ``GameState`` so artifacts from
+        # a prior game can't leak into this one. In particular, a stale
+        # trashed Charlatan would otherwise let the live-zone scan in
+        # ``charlatan_curse_active`` re-activate Curse-as-Treasure in a
+        # Charlatan-free kingdom.
         self._charlatan_seen = False
+        self.trash = []
         # Create PlayerState objects for each AI
         self.players = [PlayerState(ai) for ai in ais]
         # Provide a back-reference so PlayerState methods (notably

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1578,13 +1578,18 @@ class GameState:
         """Whether Charlatan's "Curses are Treasures worth $1" rule is active.
 
         Per Prosperity 2E this applies "for the entire game and in all
-        situations" once Charlatan is part of the game. The check is a
-        latched lazy scan: as soon as a Charlatan is observed anywhere
-        (Supply, Black Market deck, any player zone, or the trash) the
-        flag is set to True and stays True for the remainder of the
-        game. This matters because Black Market removes purchased cards
-        from its deck permanently, so a supply/deck-only check would
-        deactivate the rule mid-game.
+        situations" once Charlatan is part of the game. The authoritative
+        source is a setup-time latch (``_charlatan_seen``) set in
+        ``setup_supply`` when Charlatan is in the Supply or the Black
+        Market deck. Once latched, the flag stays True for the remainder
+        of the game even if the Charlatan pile is later removed (e.g. by
+        Divine Wind) or bought out of the Black Market deck.
+
+        Live ``supply`` / ``black_market_deck`` checks act only as a
+        defensive backstop for code paths that may have skipped setup;
+        they never consult player zones or the trash, so stale state from
+        a prior game on a reused ``GameState`` cannot reactivate the
+        rule.
         """
         if getattr(self, "_charlatan_seen", False):
             return True
@@ -1592,15 +1597,6 @@ class GameState:
             self._charlatan_seen = True
             return True
         if "Charlatan" in self.black_market_deck:
-            self._charlatan_seen = True
-            return True
-        for p in self.players:
-            for zone_name in ("hand", "deck", "discard", "in_play", "duration"):
-                zone = getattr(p, zone_name, ())
-                if any(getattr(c, "name", None) == "Charlatan" for c in zone):
-                    self._charlatan_seen = True
-                    return True
-        if any(c.name == "Charlatan" for c in self.trash):
             self._charlatan_seen = True
             return True
         return False

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1658,22 +1658,17 @@ class GameState:
         )
 
         while True:
-            treasures = [card for card in player.hand if card.is_treasure]
+            # ``is_treasure`` respects game-level type modifiers — notably
+            # Charlatan, which makes Curses Treasures for the whole game.
+            treasures = [card for card in player.hand if self.is_treasure(card)]
             if capitalism:
                 treasures += [
                     card
                     for card in player.hand
                     if card.is_action
-                    and not card.is_treasure
+                    and not self.is_treasure(card)
                     and card.stats.coins > 0
                 ]
-            # Prosperity 2E: in any kingdom that includes Charlatan, Curses
-            # are Treasures (in addition to their other types) and produce $1
-            # when played. See ``charlatan_curse_active`` for the activation
-            # rule (game-level, not while-in-play).
-            charlatan_active = self.charlatan_curse_active()
-            if charlatan_active:
-                treasures += [card for card in player.hand if card.name == "Curse"]
             if not treasures:
                 break
 
@@ -1702,21 +1697,15 @@ class GameState:
             else:
                 # Corsair trashes AFTER on_play: the treasure is fully played
                 # (so its +$ applies and any "while in play" counters tick),
-                # then Corsair removes it from in-play to the trash.
-                # Prosperity 2E: Curses played as Treasures via Charlatan
-                # produce $1. ``Curse.on_play`` applies no stats, so we add
-                # the coin alongside every play of a Curse — including any
-                # replay paths below (Reckless, Tiara).
-                def play_choice() -> None:
-                    choice.on_play(self)
-                    if choice.name == "Curse" and charlatan_active:
-                        player.coins += 1
-
-                play_choice()
+                # then Corsair removes it from in-play to the trash. The
+                # Charlatan +$1 for a Curse-as-Treasure is applied inside
+                # ``Curse.play_effect``, so it fires automatically here and
+                # on any replay (Reckless, Tiara) below.
+                choice.on_play(self)
                 # Plunder Reckless trait: Treasures from Reckless pile play twice.
                 if self.pile_traits.get(choice.name) == "Reckless":
                     if choice in player.in_play:
-                        play_choice()
+                        choice.on_play(self)
                 self._maybe_corsair_trash(player, choice)
                 # Menagerie: Kiln — gain a copy of the next card played.
                 self._maybe_kiln_gain(player, choice)
@@ -1756,7 +1745,7 @@ class GameState:
                         self, player, choice
                     ):
                         player.tiara_replay_used = True
-                        play_choice()
+                        choice.on_play(self)
                         if self.prophecy is not None and self.prophecy.is_active:
                             self.prophecy.on_play_treasure(self, player, choice)
                         # Tiara's bonus replay is another play of the

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1554,6 +1554,34 @@ class GameState:
         player.actions_this_turn += 1
         choice.on_play(self)
 
+    def charlatan_curse_active(self) -> bool:
+        """Whether Charlatan's "Curses are Treasures worth $1" rule is active.
+
+        Per Prosperity 2E, this applies "for the entire game and in all
+        situations" once Charlatan is part of the kingdom — even when the
+        Charlatan pile has been emptied or no Charlatan is in play. Black
+        Market keeps its deck out of the Supply, so we also check that.
+        """
+        if "Charlatan" in self.supply:
+            return True
+        if "Charlatan" in self.black_market_deck:
+            return True
+        return False
+
+    def is_treasure(self, card: Card) -> bool:
+        """Treasure check that respects game-level type modifiers.
+
+        While ``card.is_treasure`` is a static type query, the live game
+        may add the Treasure type to a card (notably Charlatan does so for
+        Curse). Use this method whenever a card's effect needs to ask
+        "is this a Treasure right now?".
+        """
+        if card.is_treasure:
+            return True
+        if card.name == "Curse" and self.charlatan_curse_active():
+            return True
+        return False
+
     def _handle_start_of_buy_phase_effects(self) -> None:
         """Apply state effects that trigger at the start of the buy phase."""
 
@@ -1624,11 +1652,9 @@ class GameState:
                 ]
             # Prosperity 2E: in any kingdom that includes Charlatan, Curses
             # are Treasures (in addition to their other types) and produce $1
-            # when played. Per the rulebook this is a game-level modifier
-            # ("for the entire game and in all situations"), keyed off the
-            # presence of the Charlatan pile in the Supply, not whether a
-            # Charlatan is currently in play.
-            charlatan_active = "Charlatan" in self.supply
+            # when played. See ``charlatan_curse_active`` for the activation
+            # rule (game-level, not while-in-play).
+            charlatan_active = self.charlatan_curse_active()
             if charlatan_active:
                 treasures += [card for card in player.hand if card.name == "Curse"]
             if not treasures:

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -1202,3 +1202,97 @@ def test_charlatan_curse_coin_applies_on_tiara_replay():
 
     # Curse played once as a Treasure (+$1), then replayed via Tiara (+$1)
     assert player.coins == 2
+
+
+def test_charlatan_makes_magnate_count_curses_in_hand():
+    """Magnate counts Curses as Treasures when Charlatan is in the kingdom."""
+    player = PlayerState(DummyAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Charlatan"), get_card("Magnate")])
+
+    magnate = get_card("Magnate")
+    # Hand revealed during Magnate: 1 Copper, 1 Silver, 2 Curses, 1 Estate.
+    # With Charlatan in kingdom: 4 "Treasures" → draw 4 cards.
+    player.hand = [
+        magnate,
+        get_card("Copper"),
+        get_card("Silver"),
+        get_card("Curse"),
+        get_card("Curse"),
+        get_card("Estate"),
+    ]
+    player.deck = [get_card("Gold"), get_card("Gold"), get_card("Gold"), get_card("Gold")]
+    hand_before = len(player.hand) - 1  # we'll move Magnate to in_play
+
+    play_action(state, player, "Magnate")
+
+    drew = len(player.hand) - hand_before
+    assert drew == 4
+
+
+def test_magnate_does_not_count_curses_without_charlatan():
+    """Without Charlatan in the kingdom, Curses are not Treasures for Magnate."""
+    player = PlayerState(DummyAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Magnate")])
+    state.supply.pop("Charlatan", None)
+
+    magnate = get_card("Magnate")
+    player.hand = [magnate, get_card("Copper"), get_card("Curse"), get_card("Curse")]
+    player.deck = [get_card("Gold"), get_card("Gold")]
+    hand_before = len(player.hand) - 1
+
+    play_action(state, player, "Magnate")
+
+    # Only the Copper counts — 1 card drawn.
+    assert len(player.hand) - hand_before == 1
+
+
+class BuyMintAI(DummyAI):
+    def choose_buy(self, state, choices):
+        for c in choices:
+            if c and c.name == "Mint":
+                return c
+        return None
+
+
+def test_mint_on_buy_trashes_charlataned_curses_in_play():
+    """Mint's on-buy trash-all-treasures-in-play must include Curses played
+    as Treasures via Charlatan."""
+    player = PlayerState(BuyMintAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Charlatan"), get_card("Mint")])
+
+    # A Curse already played as a Treasure sits in play.
+    player.in_play = [get_card("Curse"), get_card("Silver")]
+    player.coins = 5
+    player.buys = 1
+
+    state.handle_buy_phase()
+
+    # Both the Silver and the Curse-as-Treasure are trashed.
+    assert any(c.name == "Curse" for c in state.trash)
+    assert any(c.name == "Silver" for c in state.trash)
+    assert all(c.name not in {"Curse", "Silver"} for c in player.in_play)
+
+
+def test_charlatan_active_when_only_in_black_market_deck():
+    """Even if Charlatan is only in the Black Market deck (and not in the
+    Supply), Curse-as-Treasure must still be active."""
+    player = PlayerState(PlayAllTreasuresAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Village")])
+    # Simulate a Black Market deck containing Charlatan, with the kingdom
+    # not otherwise including it.
+    state.supply.pop("Charlatan", None)
+    state.black_market_deck = ["Charlatan"]
+
+    player.in_play = []
+    player.hand = [get_card("Curse")]
+    player.coins = 0
+    player.buys = 1
+
+    state.handle_treasure_phase()
+
+    assert player.coins == 1
+    assert any(c.name == "Curse" for c in player.in_play)

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -1478,6 +1478,33 @@ def test_charlatan_stale_trash_does_not_reactivate_rule():
     assert state.charlatan_curse_active() is False
 
 
+class DeclineCountingHouseAI(DummyAI):
+    """AI that returns None from the Counting House hook — the common
+    'decline' pattern used by other chooser hooks."""
+
+    def choose_coppers_for_counting_house(self, state, player, coppers):
+        return None
+
+
+def test_counting_house_handles_none_from_ai():
+    """A None return from the AI hook must be normalized to "no Coppers
+    moved" rather than raising TypeError mid-turn."""
+    player = PlayerState(DeclineCountingHouseAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Counting House")])
+
+    ch = get_card("Counting House")
+    player.hand = [ch]
+    player.discard = [get_card("Copper"), get_card("Copper")]
+
+    # Should not raise.
+    play_action(state, player, "Counting House")
+
+    # Coppers stay in discard; nothing moved to hand.
+    assert sum(1 for c in player.discard if c.name == "Copper") == 2
+    assert all(c.name != "Copper" for c in player.hand)
+
+
 class SmuggleEstateForCountingHouseAI(DummyAI):
     """A misbehaving AI that tries to return an Estate from discard."""
 

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -1296,3 +1296,48 @@ def test_charlatan_active_when_only_in_black_market_deck():
 
     assert player.coins == 1
     assert any(c.name == "Curse" for c in player.in_play)
+
+
+def test_charlatan_activation_persists_after_black_market_purchase():
+    """Black Market removes purchased cards from its deck permanently. Once
+    Charlatan has been observed in the game, the Curse-as-Treasure rule must
+    stay active even after the Charlatan leaves the Black Market deck."""
+    player = PlayerState(PlayAllTreasuresAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Village")])
+    state.supply.pop("Charlatan", None)
+    state.black_market_deck = ["Charlatan"]
+
+    # Activate the cache via a no-op call while Charlatan is in the BM deck.
+    assert state.charlatan_curse_active() is True
+
+    # Simulate a Black Market purchase: card leaves the deck and enters the
+    # buyer's discard. After this, the BM deck no longer contains Charlatan.
+    state.black_market_deck.remove("Charlatan")
+    player.discard.append(get_card("Charlatan"))
+
+    # The rule must still be active.
+    assert state.charlatan_curse_active() is True
+
+    player.in_play = []
+    player.hand = [get_card("Curse")]
+    player.coins = 0
+    player.buys = 1
+    state.handle_treasure_phase()
+    assert player.coins == 1
+
+
+def test_charlatan_active_when_seen_only_in_player_zone():
+    """A Charlatan present only in a player's deck/discard (e.g. after being
+    bought from Black Market with no other source) still activates the rule
+    on first call, before any caching."""
+    player = PlayerState(PlayAllTreasuresAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Village")])
+    state.supply.pop("Charlatan", None)
+    state.black_market_deck = []
+
+    # Charlatan exists only in a player's discard.
+    player.discard = [get_card("Charlatan")]
+
+    assert state.charlatan_curse_active() is True

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -1341,3 +1341,129 @@ def test_charlatan_active_when_seen_only_in_player_zone():
     player.discard = [get_card("Charlatan")]
 
     assert state.charlatan_curse_active() is True
+
+
+# ---------------------------------------------------------------------------
+# Charlatan-Curse-as-Treasure interactions across the Prosperity set
+# ---------------------------------------------------------------------------
+
+
+class RevealCurseForMintAI(DummyAI):
+    """Mint reveal: pick the Curse if available, else first treasure."""
+
+    def choose_treasure(self, state, choices):
+        for c in choices:
+            if c is not None and c.name == "Curse":
+                return c
+        for c in choices:
+            if c is not None:
+                return c
+        return None
+
+
+def test_mint_play_can_reveal_curse_as_treasure():
+    """With Charlatan in the kingdom, Mint's play effect should let the
+    player reveal a Curse-as-Treasure to gain a copy."""
+    player = PlayerState(RevealCurseForMintAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Charlatan"), get_card("Mint")])
+
+    mint = get_card("Mint")
+    player.hand = [mint, get_card("Curse")]
+
+    play_action(state, player, "Mint")
+
+    # A copy of Curse was gained from the supply.
+    assert any(c.name == "Curse" for c in player.discard)
+
+
+def test_bank_counts_charlataned_curses_in_play():
+    """Bank pays $1 per Treasure in play. A Curse played as a Treasure via
+    Charlatan must contribute."""
+    player = PlayerState(DummyAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Charlatan"), get_card("Bank")])
+
+    bank = get_card("Bank")
+    # 1 Copper + 1 Curse + Bank itself = 3 "treasures" in play.
+    player.in_play = [get_card("Copper"), get_card("Curse")]
+    player.coins = 0
+
+    player.in_play.append(bank)
+    bank.on_play(state)
+
+    assert player.coins == 3
+
+
+def test_venture_can_find_and_play_curse_as_treasure():
+    """Venture reveals deck until a Treasure is revealed and plays it. With
+    Charlatan in the game, a Curse counts and produces its own $1 via the
+    Curse-as-Treasure rule, on top of Venture's own $1."""
+    player = PlayerState(DummyAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Charlatan"), get_card("Venture")])
+
+    venture = get_card("Venture")
+    # Deck top will be popped first — a Curse is the first Treasure.
+    player.deck = [get_card("Estate"), get_card("Curse")]
+    player.hand = [venture]
+    player.coins = 0
+
+    play_action(state, player, "Venture")
+
+    # Venture's own +$1 + Curse-as-Treasure +$1 = +$2.
+    assert player.coins == 2
+    assert any(c.name == "Curse" for c in player.in_play)
+
+
+def test_loan_recognizes_curse_as_treasure():
+    """Loan reveals until a Treasure is found. With Charlatan in the game,
+    a Curse satisfies that search."""
+
+    class DiscardLoanFindAI(DummyAI):
+        def choose_card_to_trash(self, state, choices):
+            return None
+
+    player = PlayerState(DiscardLoanFindAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Charlatan"), get_card("Loan")])
+
+    loan = get_card("Loan")
+    player.deck = [get_card("Curse"), get_card("Estate")]  # Estate revealed first, then Curse
+    player.hand = [loan]
+
+    play_action(state, player, "Loan")
+
+    # The Curse is the first "treasure" revealed (under Charlatan); it
+    # ends up discarded (player chose not to trash).
+    assert any(c.name == "Curse" for c in player.discard)
+
+
+class InvestmentTrashCurseAI(DummyAI):
+    def choose_investment_mode(self, state, player, can_trash):
+        return "trash" if can_trash else "coin"
+
+    def choose_treasure_to_trash_for_investment(self, state, player, choices):
+        for c in choices:
+            if c.name == "Curse":
+                return c
+        return choices[0] if choices else None
+
+
+def test_investment_can_trash_curse_as_treasure():
+    """Investment's "trash a Treasure" must accept a Curse when Charlatan is
+    in the game."""
+    player = PlayerState(InvestmentTrashCurseAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Charlatan"), get_card("Investment")])
+
+    investment = get_card("Investment")
+    player.in_play = [investment]
+    player.hand = [get_card("Curse"), get_card("Copper")]
+
+    investment.play_effect(state)
+
+    # Investment self-trashes + Curse trashed
+    trashed_names = [c.name for c in state.trash]
+    assert "Investment" in trashed_names
+    assert "Curse" in trashed_names

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -1486,6 +1486,46 @@ class DeclineCountingHouseAI(DummyAI):
         return None
 
 
+class ReturnIntForCountingHouseAI(DummyAI):
+    """AI that misbehaves with a non-iterable return type."""
+
+    def choose_coppers_for_counting_house(self, state, player, coppers):
+        return 42
+
+
+def test_counting_house_handles_non_iterable_from_ai():
+    """A non-iterable return (e.g. an int from a buggy AI) must be
+    normalized rather than raising TypeError at iteration."""
+    player = PlayerState(ReturnIntForCountingHouseAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Counting House")])
+
+    ch = get_card("Counting House")
+    player.hand = [ch]
+    player.discard = [get_card("Copper")]
+
+    # Should not raise.
+    play_action(state, player, "Counting House")
+
+    assert sum(1 for c in player.discard if c.name == "Copper") == 1
+    assert all(c.name != "Copper" for c in player.hand)
+
+
+def test_charlatan_latch_clears_on_setup_supply_reuse():
+    """If a caller invokes ``setup_supply`` directly on a reused GameState
+    (a common test pattern), a prior Charlatan setup must not leak its
+    latch into a later Charlatan-free setup."""
+    player = PlayerState(PlayAllTreasuresAI())
+    state = GameState([player])
+
+    state.setup_supply([get_card("Charlatan")])
+    assert state.charlatan_curse_active() is True
+
+    # Rebuild the kingdom on the same GameState without Charlatan.
+    state.setup_supply([get_card("Village")])
+    assert state.charlatan_curse_active() is False
+
+
 def test_counting_house_handles_none_from_ai():
     """A None return from the AI hook must be normalized to "no Coppers
     moved" rather than raising TypeError mid-turn."""

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -1450,6 +1450,36 @@ class InvestmentTrashCurseAI(DummyAI):
         return choices[0] if choices else None
 
 
+def test_charlatan_latches_at_setup_survives_pile_removal():
+    """Charlatan's game-level rule is latched at setup so that subsequent
+    kingdom-pile mutations (e.g. Divine Wind deleting the Charlatan pile)
+    cannot deactivate it before the first Curse-as-Treasure check."""
+    player = PlayerState(PlayAllTreasuresAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Charlatan")])
+
+    # Simulate a Prophecy like Divine Wind: the Charlatan pile is removed
+    # outright. No Charlatan exists anywhere observable in the live state.
+    del state.supply["Charlatan"]
+    for p in state.players:
+        for zone_name in ("hand", "deck", "discard", "in_play", "duration"):
+            zone = getattr(p, zone_name, None)
+            if zone is not None:
+                zone[:] = [c for c in zone if c.name != "Charlatan"]
+    state.trash = [c for c in state.trash if c.name != "Charlatan"]
+    state.black_market_deck = [n for n in state.black_market_deck if n != "Charlatan"]
+
+    # Live scan would now fail; the setup-time latch must keep the rule on.
+    assert state.charlatan_curse_active() is True
+
+    player.in_play = []
+    player.hand = [get_card("Curse")]
+    player.coins = 0
+    player.buys = 1
+    state.handle_treasure_phase()
+    assert player.coins == 1
+
+
 def test_investment_can_trash_curse_as_treasure():
     """Investment's "trash a Treasure" must accept a Curse when Charlatan is
     in the game."""

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -1462,6 +1462,22 @@ def test_charlatan_latch_resets_between_games_on_same_state():
     assert state.charlatan_curse_active() is False
 
 
+def test_charlatan_stale_trash_does_not_reactivate_rule():
+    """A trashed Charlatan from a prior game must not reactivate the rule
+    via the live-zone scan when the same GameState is re-initialized for
+    a Charlatan-free game."""
+    state = GameState([PlayerState(DummyAI())])
+    state.initialize_game([DummyAI()], [get_card("Charlatan")])
+    # Simulate a prior game leaving a trashed Charlatan in self.trash.
+    state.trash.append(get_card("Charlatan"))
+
+    # Re-initialize with a kingdom that does not include Charlatan.
+    state.initialize_game([DummyAI()], [get_card("Village")])
+
+    assert state.trash == []
+    assert state.charlatan_curse_active() is False
+
+
 class SmuggleEstateForCountingHouseAI(DummyAI):
     """A misbehaving AI that tries to return an Estate from discard."""
 

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -1327,20 +1327,26 @@ def test_charlatan_activation_persists_after_black_market_purchase():
     assert player.coins == 1
 
 
-def test_charlatan_active_when_seen_only_in_player_zone():
-    """A Charlatan present only in a player's deck/discard (e.g. after being
-    bought from Black Market with no other source) still activates the rule
-    on first call, before any caching."""
+def test_charlatan_stale_trash_does_not_reactivate_on_setup_supply_reuse():
+    """If ``setup_supply`` is reused on the same GameState to swap from a
+    Charlatan kingdom to a Charlatan-free kingdom, a Charlatan left in
+    ``self.trash`` from the prior game must not reactivate the rule. The
+    setup-time latch is the source of truth — live state is only consulted
+    via ``supply`` and ``black_market_deck``, not player zones or trash."""
     player = PlayerState(PlayAllTreasuresAI())
     state = GameState([player])
-    state.setup_supply([get_card("Village")])
-    state.supply.pop("Charlatan", None)
-    state.black_market_deck = []
 
-    # Charlatan exists only in a player's discard.
-    player.discard = [get_card("Charlatan")]
-
+    state.setup_supply([get_card("Charlatan")])
+    # Simulate a trashed Charlatan from the prior "game".
+    state.trash.append(get_card("Charlatan"))
     assert state.charlatan_curse_active() is True
+
+    # Rebuild kingdom without Charlatan on the same GameState. Trash is
+    # not reset by ``setup_supply``, so the test deliberately leaves the
+    # stale Charlatan there.
+    state.setup_supply([get_card("Village")])
+
+    assert state.charlatan_curse_active() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -817,7 +817,8 @@ class NameSilverAI(DummyAI):
         return supply_choices[0] if supply_choices else None
 
 
-def test_war_chest_grants_coin_and_buy():
+def test_war_chest_has_no_base_coin_or_buy():
+    """War Chest grants neither +Coins nor +Buys; it only enables a gain."""
     owner = PlayerState(WarChestAI())
     opp = PlayerState(NameSilverAI())
     state = GameState([owner, opp])
@@ -825,11 +826,12 @@ def test_war_chest_grants_coin_and_buy():
 
     wc = get_card("War Chest")
     owner.in_play.append(wc)
+    initial_coins = owner.coins
     initial_buys = owner.buys
     wc.on_play(state)
 
-    assert owner.coins == 1
-    assert owner.buys == initial_buys + 1
+    assert owner.coins == initial_coins
+    assert owner.buys == initial_buys
 
 
 def test_war_chest_gains_unnamed_card():
@@ -998,3 +1000,205 @@ def test_peddler_discount_only_applies_in_buy_phase():
 
     state.phase = "buy"
     assert state.get_card_cost(player, peddler) == 4
+
+
+# ---------------------------------------------------------------------------
+# City ($5 Action)
+# ---------------------------------------------------------------------------
+
+
+def test_city_no_empty_piles_just_card_and_actions():
+    player = PlayerState(DummyAI())
+    state = GameState([player])
+    state.setup_supply([get_card("City")])
+
+    city = get_card("City")
+    player.hand = [city]
+    player.deck = [get_card("Copper"), get_card("Silver"), get_card("Gold")]
+
+    coins_before = player.coins
+    buys_before = player.buys
+    play_action(state, player, "City")
+
+    # Base: +1 Card, +2 Actions, no extra coins/buys
+    assert player.coins == coins_before
+    assert player.buys == buys_before
+
+
+def test_city_one_empty_pile_grants_extra_card_only():
+    """At 1+ empty piles: +1 Card extra. No extra coins, no extra buys."""
+    player = PlayerState(DummyAI())
+    other = PlayerState(DummyAI())
+    state = GameState([player, other])
+    state.setup_supply([get_card("City"), get_card("Estate")])
+
+    # Empty out one pile
+    state.supply["Estate"] = 0
+
+    city = get_card("City")
+    player.hand = [city]
+    player.deck = [get_card("Copper"), get_card("Silver"), get_card("Gold"), get_card("Copper")]
+    hand_before = len(player.hand) - 1  # -1 because we'll play City out of hand
+
+    coins_before = player.coins
+    buys_before = player.buys
+    play_action(state, player, "City")
+
+    # +1 Card (base) + +1 Card (1+ empty) = 2 cards drawn into hand
+    assert len(player.hand) == hand_before + 2
+    # No extra coins or buys at 1 empty pile
+    assert player.coins == coins_before
+    assert player.buys == buys_before
+
+
+def test_city_two_empty_piles_grants_buy_and_coin_no_extra_card():
+    """At 2+ empty piles: +1 Card extra (from 1+ branch), +1 Buy and +$1.
+    Crucially, the +$1 fires only once (not twice)."""
+    player = PlayerState(DummyAI())
+    other = PlayerState(DummyAI())
+    state = GameState([player, other])
+    state.setup_supply([get_card("City"), get_card("Estate"), get_card("Duchy")])
+
+    state.supply["Estate"] = 0
+    state.supply["Duchy"] = 0
+
+    city = get_card("City")
+    player.hand = [city]
+    player.deck = [get_card("Copper"), get_card("Silver"), get_card("Gold"), get_card("Copper")]
+    hand_before = len(player.hand) - 1
+
+    coins_before = player.coins
+    buys_before = player.buys
+    play_action(state, player, "City")
+
+    # +1 Card (base) + +1 Card (1+ empty) — no additional card at 2+
+    assert len(player.hand) == hand_before + 2
+    # +$1 once (not +$2), +1 Buy
+    assert player.coins == coins_before + 1
+    assert player.buys == buys_before + 1
+
+
+# ---------------------------------------------------------------------------
+# Counting House ($5 Action)
+# ---------------------------------------------------------------------------
+
+
+class TakeFewCoppersAI(DummyAI):
+    """Take only the first Copper, to verify the choice is honoured."""
+
+    def choose_coppers_for_counting_house(self, state, player, coppers):
+        return coppers[:1]
+
+
+def test_counting_house_default_takes_all_coppers():
+    player = PlayerState(DummyAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Counting House")])
+
+    ch = get_card("Counting House")
+    player.hand = [ch]
+    player.discard = [get_card("Copper"), get_card("Copper"), get_card("Estate"), get_card("Copper")]
+
+    play_action(state, player, "Counting House")
+
+    assert sum(1 for c in player.hand if c.name == "Copper") == 3
+    assert all(c.name != "Copper" for c in player.discard)
+    # Estate stays in discard
+    assert any(c.name == "Estate" for c in player.discard)
+
+
+def test_counting_house_respects_ai_choice():
+    """AI may choose to take only some Coppers (or none)."""
+    player = PlayerState(TakeFewCoppersAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Counting House")])
+
+    ch = get_card("Counting House")
+    player.hand = [ch]
+    player.discard = [get_card("Copper"), get_card("Copper"), get_card("Copper")]
+
+    play_action(state, player, "Counting House")
+
+    assert sum(1 for c in player.hand if c.name == "Copper") == 1
+    assert sum(1 for c in player.discard if c.name == "Copper") == 2
+
+
+# ---------------------------------------------------------------------------
+# Charlatan ($5 Action-Attack) — Curse-as-Treasure effect
+# ---------------------------------------------------------------------------
+
+
+class PlayAllTreasuresAI(DummyAI):
+    def choose_treasure(self, state, choices):
+        for c in choices:
+            if c is not None:
+                return c
+        return None
+
+
+def test_charlatan_makes_curses_produce_one_coin():
+    """In a kingdom that includes Charlatan, Curses played in the Buy phase
+    produce $1 — even with no Charlatan currently in play."""
+    player = PlayerState(PlayAllTreasuresAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Charlatan"), get_card("Curse")])
+
+    # Deliberately no Charlatan in play. Per the rulebook the Curse-as-
+    # Treasure effect applies for the entire game once Charlatan is in the
+    # kingdom.
+    player.in_play = []
+    player.hand = [get_card("Curse"), get_card("Curse")]
+    player.coins = 0
+    player.buys = 1
+
+    state.handle_treasure_phase()
+
+    # Two Curses played as Treasures = +$2
+    assert player.coins == 2
+    assert sum(1 for c in player.in_play if c.name == "Curse") == 2
+    assert all(c.name != "Curse" for c in player.hand)
+
+
+def test_curses_are_not_treasures_without_charlatan_in_supply():
+    """Without Charlatan in the kingdom, Curses are not Treasures and stay in
+    hand during the Treasure phase."""
+    player = PlayerState(PlayAllTreasuresAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Village")])
+    # Curses live in the basic supply; explicitly remove Charlatan so the
+    # game-level modifier is inactive.
+    state.supply.pop("Charlatan", None)
+
+    player.in_play = []
+    player.hand = [get_card("Curse"), get_card("Curse")]
+    player.coins = 0
+    player.buys = 1
+
+    state.handle_treasure_phase()
+
+    assert player.coins == 0
+    assert sum(1 for c in player.hand if c.name == "Curse") == 2
+
+
+class TiaraReplayCurseAI(PlayAllTreasuresAI):
+    def should_replay_treasure_with_tiara(self, state, player, treasure):
+        return treasure.name == "Curse"
+
+
+def test_charlatan_curse_coin_applies_on_tiara_replay():
+    """Tiara's once-per-turn replay of a Curse-as-Treasure must also grant
+    the +$1 from Charlatan's effect — the coin attaches to the play, not just
+    the first one."""
+    player = PlayerState(TiaraReplayCurseAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Charlatan"), get_card("Tiara"), get_card("Curse")])
+
+    player.in_play = [get_card("Tiara")]
+    player.hand = [get_card("Curse")]
+    player.coins = 0
+    player.buys = 1
+
+    state.handle_treasure_phase()
+
+    # Curse played once as a Treasure (+$1), then replayed via Tiara (+$1)
+    assert player.coins == 2

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -1450,6 +1450,44 @@ class InvestmentTrashCurseAI(DummyAI):
         return choices[0] if choices else None
 
 
+def test_charlatan_latch_resets_between_games_on_same_state():
+    """A reused GameState must not carry _charlatan_seen across games — a
+    later Charlatan-free game should not treat Curses as Treasures."""
+    state = GameState([PlayerState(DummyAI())])
+    state.initialize_game([DummyAI()], [get_card("Charlatan")])
+    assert state.charlatan_curse_active() is True
+
+    # Re-initialize the same GameState with a Charlatan-free kingdom.
+    state.initialize_game([DummyAI()], [get_card("Village")])
+    assert state.charlatan_curse_active() is False
+
+
+class SmuggleEstateForCountingHouseAI(DummyAI):
+    """A misbehaving AI that tries to return an Estate from discard."""
+
+    def choose_coppers_for_counting_house(self, state, player, coppers):
+        # Try to smuggle the Estate (already in discard) past Counting House.
+        return [c for c in player.discard if c.name == "Estate"]
+
+
+def test_counting_house_rejects_non_copper_ai_picks():
+    """Counting House must validate AI picks against the offered Coppers
+    list; non-Copper cards from discard cannot be smuggled into hand."""
+    player = PlayerState(SmuggleEstateForCountingHouseAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Counting House")])
+
+    ch = get_card("Counting House")
+    player.hand = [ch]
+    player.discard = [get_card("Copper"), get_card("Estate")]
+
+    play_action(state, player, "Counting House")
+
+    # The Estate must remain in discard, not be moved to hand.
+    assert any(c.name == "Estate" for c in player.discard)
+    assert all(c.name != "Estate" for c in player.hand)
+
+
 def test_charlatan_latches_at_setup_survives_pile_removal():
     """Charlatan's game-level rule is latched at setup so that subsequent
     kingdom-pile mutations (e.g. Divine Wind deleting the Charlatan pile)


### PR DESCRIPTION
## Summary

Audited all 35 Prosperity card implementations against the Prosperity 2nd Edition rulebook (Rio Grande Games, 2022) and fixed four behavioural bugs.

- **City** — At 1+ empty piles the +\$1 was firing erroneously; at 2+ empty piles +\$1 was firing twice (giving +\$2). Per rulebook: 1+ empty → +1 Card only; 2+ empty → +1 Buy and +\$1 (in addition to the +1 Card from the first branch).
- **War Chest** — Removed +\$1 and +1 Buy from base stats. The card produces neither; it only enables a gain up to \$5 (other than a card named with a War Chest this turn). Replaced the test that asserted the buggy behaviour.
- **Counting House** — Routed the "reveal any number of Coppers" choice through a new AI hook (`choose_coppers_for_counting_house`, default: take all) instead of unconditionally taking all.
- **Charlatan** — Implemented the "while Charlatan is in play, Curses are Treasures worth \$1" effect in `handle_treasure_phase`. Previously the docstring acknowledged this was an intentional simplification; per the rulebook (page 4) it's a defining part of the card.

## Out of scope (flagged for follow-up)

- **Collection** is listed in the Prosperity 2E rulebook (page 2) but is missing from the codebase entirely. Worth a separate issue.
- Crystal Ball was previously suspected to be misplaced; the rulebook confirms it IS a Prosperity 2E card, so its current location is correct.

## Test plan
- [x] Existing prosperity tests pass (42 → 49 with new regressions)
- [x] Full suite passes (1254 passed)
- [x] New regression tests cover City pile counts (0/1/2 empty), Counting House AI choice respected, Charlatan Curse-as-Treasure on/off