### PR TITLE
Seed evolution with edge-case strategies from the trick scanner (closes #232)

### DIFF
--- a/dominion/analysis/seed_genomes.py
+++ b/dominion/analysis/seed_genomes.py
@@ -269,11 +269,15 @@ def _seed_for_command_targets(
         PriorityRule(command_name, PriorityRule.max_in_deck(command_name, 3)),
         PriorityRule(primary, PriorityRule.max_in_deck(primary, 3)),
     ] + _baseline_gain_priority()
-    # Play the target first so Command has something to copy; if no target
-    # is in hand, fall back to playing the Command anyway.
+    # Play the Command FIRST so its pending-replay slot is registered;
+    # then the next non-Command Action played consumes the slot. Reversing
+    # this ordering breaks the trick on every "next non-Command Action"
+    # Command (Daimyo, Flagship): the payload would be played first and
+    # the pending counter set by the Command would have nothing to fire
+    # on for the rest of the turn.
     strat.action_priority = [
-        PriorityRule(primary),
         PriorityRule(command_name),
+        PriorityRule(primary),
     ]
     strat.treasure_priority = _baseline_treasure_priority()
     return strat.name, strat

--- a/dominion/analysis/seed_genomes.py
+++ b/dominion/analysis/seed_genomes.py
@@ -1,0 +1,375 @@
+"""Seed genomes derived from trick-scanner output.
+
+The genetic evolver in :mod:`evolve` is normally seeded with hand-written
+generic engine archetypes (Big Money, Chapel/Witch, Village/Smithy/Lab).
+Those templates carry no knowledge of any individual board's mechanical
+edge cases, so the evolver has to re-derive every trick on every board
+from random mutation. Subtle interactions rarely survive the first
+generations because they don't help until the supporting deck is built.
+
+This module bridges that gap. Given a :class:`BoardConfig`, it runs the
+:mod:`trick scanner <dominion.analysis.trick_scanner>` and emits one
+:class:`EnhancedStrategy` per surfaced interaction, with the trick
+pre-encoded into the strategy's gain priority and / or way policy. Each
+seed also carries a generic engine baseline (Province, Duchy, Gold,
+Silver, Copper) so it is at least playable in isolation. Seeds are
+*starting points*: the evolver is expected to mutate them, and bad
+tricks should be pruned by selection.
+
+Public API: :func:`build_seed_genomes`.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from dominion.analysis.trick_scanner import Interaction, scan
+from dominion.boards.loader import BoardConfig
+from dominion.cards.base_card import Card
+from dominion.cards.registry import get_card
+from dominion.strategy.enhanced_strategy import (
+    EnhancedStrategy,
+    PriorityRule,
+    WayRule,
+)
+
+
+# --- Shared baseline ------------------------------------------------------
+
+
+def _baseline_gain_priority() -> list[PriorityRule]:
+    """Generic Province / Duchy / Estate / Gold / Silver fallback rules.
+
+    Trick-specific rules are prepended in front of these so the trick fires
+    when affordable; the baseline takes over once the trick is exhausted or
+    not affordable on a given turn.
+    """
+
+    return [
+        PriorityRule("Province"),
+        PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
+        PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),
+        PriorityRule("Gold"),
+        PriorityRule("Silver", PriorityRule.provinces_left(">", 2)),
+    ]
+
+
+def _baseline_treasure_priority() -> list[PriorityRule]:
+    return [
+        PriorityRule("Gold"),
+        PriorityRule("Silver"),
+        PriorityRule("Copper"),
+    ]
+
+
+def _try_get_card(name: str) -> Optional[Card]:
+    try:
+        return get_card(name)
+    except (KeyError, ValueError):
+        return None
+
+
+def _kingdom_card_objects(board: BoardConfig) -> list[Card]:
+    cards: list[Card] = []
+    for name in board.kingdom_cards:
+        card = _try_get_card(name)
+        if card is not None:
+            cards.append(card)
+    return cards
+
+
+def _split_card_and_partner(headline: str) -> tuple[str, str]:
+    """Pull ``"<Card> + <Way>"`` out of a trash-hook interaction headline.
+
+    The trick scanner formats trash-hook headlines as
+    ``"<card> + <way>: ..."`` — see
+    :func:`dominion.analysis.trick_scanner.predicate_trash_hook_via_return_to_supply`.
+    Parsing the headline keeps this module decoupled from the scanner's
+    internal field layout: the only contract is the public ``Interaction``
+    dataclass plus this stable headline format.
+    """
+
+    head = headline.split(":", 1)[0]
+    if "+" not in head:
+        return head.strip(), ""
+    card_part, way_part = head.split("+", 1)
+    return card_part.strip(), way_part.strip()
+
+
+# --- Builders, one per Interaction.kind -----------------------------------
+
+
+def _seed_for_trash_hook_unreachable(
+    interaction: Interaction, board: BoardConfig
+) -> Optional[tuple[str, EnhancedStrategy]]:
+    """Seed a strategy that buys ``<card>`` and plays it as the bypassing Way.
+
+    For Flag Bearer + Way of the Butterfly on the Victoria board, this seed
+    pays $4 for Flag Bearer (fires its on_gain → take Flag artifact), then
+    plays Flag Bearer as Way of the Butterfly (returns it to its pile and
+    gains a $5 card without firing on_trash, so the artifact is preserved).
+    """
+
+    card_name, way_name = _split_card_and_partner(interaction.headline)
+    card = _try_get_card(card_name)
+    if card is None or not way_name:
+        return None
+
+    strat = EnhancedStrategy()
+    strat.name = f"Trick Butterfly {card_name}"
+    strat.description = (
+        f"Trick-scanner seed: gain {card_name} for its on_gain effect, "
+        f"then play it as {way_name} so the on_trash hook is bypassed and "
+        f"the +1-cost gain still triggers."
+    )
+
+    target_cost = card.cost.coins + 1
+    upgrade_targets = sorted(
+        {
+            c.name
+            for c in _kingdom_card_objects(board)
+            if c.cost.coins == target_cost and c.cost.potions == card.cost.potions
+        }
+    )
+
+    gain_rules: list[PriorityRule] = [PriorityRule("Province")]
+    # Stock up on the trick card while there's room — three copies is enough
+    # to fire the trick a few times per game without flooding the deck.
+    gain_rules.append(
+        PriorityRule(card_name, PriorityRule.max_in_deck(card_name, 3))
+    )
+    # Encourage gaining the upgrade targets the Way will hand us, so we
+    # actually use them once they're in hand.
+    for target in upgrade_targets:
+        gain_rules.append(PriorityRule(target))
+    gain_rules.extend(_baseline_gain_priority())
+
+    strat.gain_priority = gain_rules
+    strat.action_priority = [PriorityRule(card_name)]
+    strat.treasure_priority = _baseline_treasure_priority()
+    strat.way_policy = [WayRule(card_name=card_name, way_name=way_name)]
+    return strat.name, strat
+
+
+def _seed_for_gain_hook_retriggerable(
+    interaction: Interaction, board: BoardConfig
+) -> Optional[tuple[str, EnhancedStrategy]]:
+    """Seed a strategy that re-buys the on_gain card every chance it gets.
+
+    The trick scanner's headline format here is ``"<card>: on_gain hook
+    re-triggerable via <gainer>, <gainer>, ..."`` — see
+    :func:`predicate_gain_hook_retriggerable`. We don't try to detect
+    artifact loss; we just make the hook card top priority so each fresh
+    gain re-fires the artifact / on_gain effect.
+    """
+
+    head = interaction.headline.split(":", 1)[0].strip()
+    card = _try_get_card(head)
+    if card is None:
+        return None
+
+    strat = EnhancedStrategy()
+    strat.name = f"Trick Re-gain {head}"
+    strat.description = (
+        f"Trick-scanner seed: keep buying {head} so its on_gain hook "
+        f"re-fires (e.g. re-claim its artifact when an opponent holds it)."
+    )
+
+    strat.gain_priority = [
+        PriorityRule("Province"),
+        # Always re-buy the hook card when affordable. We deliberately do
+        # *not* gate on "opponent holds the artifact" — most games lack
+        # that signal, and the evolver can layer that condition on later.
+        PriorityRule(head),
+    ] + _baseline_gain_priority()
+    strat.action_priority = [PriorityRule(head)]
+    strat.treasure_priority = _baseline_treasure_priority()
+    return strat.name, strat
+
+
+def _seed_for_empty_deck_discard_combo(
+    interaction: Interaction, board: BoardConfig
+) -> Optional[tuple[str, EnhancedStrategy]]:
+    """Seed a strategy that thins aggressively and times the empty-deck Event.
+
+    Headline format: ``"<self-exile card> + <event>: ..."``. We bias the
+    strategy toward gaining the self-exile card (so the deck/discard
+    actually empties) and toward buying the Event whenever it appears as a
+    legal purchase. Thinners (Chapel, Donate, Mountebank's curse hand-out)
+    are not assumed present; if the kingdom has Chapel or similar trashing
+    we don't special-case it here — the evolver can add that.
+    """
+
+    card_name, event_name = _split_card_and_partner(interaction.headline)
+    if not card_name or not event_name:
+        return None
+    if _try_get_card(card_name) is None:
+        return None
+
+    strat = EnhancedStrategy()
+    strat.name = f"Trick Empty-deck {event_name}"
+    strat.description = (
+        f"Trick-scanner seed: stack {card_name} (sets itself aside on play, "
+        f"keeping deck and discard empty) and buy {event_name} whenever "
+        f"affordable to cash in the empty-deck payoff."
+    )
+
+    strat.gain_priority = [
+        PriorityRule("Province"),
+        PriorityRule(event_name),
+        # Two copies of the self-exile card is enough to trigger the empty
+        # condition reliably without choking on a discard pile of dead
+        # set-aside cards.
+        PriorityRule(card_name, PriorityRule.max_in_deck(card_name, 2)),
+    ] + _baseline_gain_priority()
+    strat.action_priority = [PriorityRule(card_name)]
+    strat.treasure_priority = _baseline_treasure_priority()
+    return strat.name, strat
+
+
+def _seed_for_command_targets(
+    interaction: Interaction, board: BoardConfig
+) -> Optional[tuple[str, EnhancedStrategy]]:
+    """Seed a strategy that pairs the Command card with its top-payload target.
+
+    Headline format: ``"<command>: highest-payload legal Action targets on
+    this board"``. The interaction's *detail* string contains the ranked
+    target list as ``"... Top legal targets here (by cost + stat payload): A, B, C."``.
+    We grab the first listed target and seed a strategy that gains both
+    the Command and that target, with an action-priority rule that plays
+    the target before the Command (so the Command's replay slot fires it).
+    """
+
+    command_name = interaction.headline.split(":", 1)[0].strip()
+    if _try_get_card(command_name) is None:
+        return None
+
+    detail = interaction.detail
+    targets_marker = "targets here (by cost + stat payload):"
+    if targets_marker not in detail:
+        return None
+    listed = detail.split(targets_marker, 1)[1].rstrip(".").strip()
+    targets = [t.strip() for t in listed.split(",") if t.strip()]
+    if not targets:
+        return None
+    primary = targets[0]
+    if _try_get_card(primary) is None:
+        return None
+
+    strat = EnhancedStrategy()
+    strat.name = f"Trick {command_name} + {primary}"
+    strat.description = (
+        f"Trick-scanner seed: pair {command_name} with the kingdom's "
+        f"highest-payload legal target ({primary}) so each {command_name} "
+        f"play replays / copies a strong terminal."
+    )
+
+    strat.gain_priority = [
+        PriorityRule("Province"),
+        PriorityRule(command_name, PriorityRule.max_in_deck(command_name, 3)),
+        PriorityRule(primary, PriorityRule.max_in_deck(primary, 3)),
+    ] + _baseline_gain_priority()
+    # Play the target first so Command has something to copy; if no target
+    # is in hand, fall back to playing the Command anyway.
+    strat.action_priority = [
+        PriorityRule(primary),
+        PriorityRule(command_name),
+    ]
+    strat.treasure_priority = _baseline_treasure_priority()
+    return strat.name, strat
+
+
+def _seed_for_cost_mod_gateway(
+    interaction: Interaction, board: BoardConfig
+) -> Optional[tuple[str, EnhancedStrategy]]:
+    """Seed a strategy that stacks the cost reducer and rushes Provinces.
+
+    Headline format: ``"<reducer>: each play reduces every card's cost by
+    $1 — opens cheaper gains and chains buys into Provinces"``.
+    """
+
+    reducer = interaction.headline.split(":", 1)[0].strip()
+    if _try_get_card(reducer) is None:
+        return None
+
+    strat = EnhancedStrategy()
+    strat.name = f"Trick Cost-mod {reducer}"
+    strat.description = (
+        f"Trick-scanner seed: stack {reducer} to reduce all card costs by "
+        f"$1 per play, opening cheaper gains and chaining Province buys."
+    )
+
+    strat.gain_priority = [
+        PriorityRule("Province"),
+        PriorityRule(reducer, PriorityRule.max_in_deck(reducer, 4)),
+    ] + _baseline_gain_priority()
+    strat.action_priority = [PriorityRule(reducer)]
+    strat.treasure_priority = _baseline_treasure_priority()
+    return strat.name, strat
+
+
+# Dispatch table: kind -> builder.
+_BUILDERS: dict[
+    str,
+    Callable[[Interaction, BoardConfig], Optional[tuple[str, EnhancedStrategy]]],
+] = {
+    "trash_hook_unreachable": _seed_for_trash_hook_unreachable,
+    "gain_hook_retriggerable": _seed_for_gain_hook_retriggerable,
+    "empty_deck_discard_combo": _seed_for_empty_deck_discard_combo,
+    "command_targets": _seed_for_command_targets,
+    "cost_mod_gateway": _seed_for_cost_mod_gateway,
+}
+
+
+def build_seed_genomes(
+    board: BoardConfig,
+    interactions: Optional[list[Interaction]] = None,
+) -> list[tuple[str, EnhancedStrategy]]:
+    """Build a list of ``(name, EnhancedStrategy)`` seeds for ``board``.
+
+    If ``interactions`` is omitted, the trick scanner is run against
+    ``board`` to discover them. Names within the returned list are unique:
+    if two Interactions would yield the same seed name (e.g. two cards
+    sharing the same Command target), the duplicate is dropped silently —
+    the first wins. Order follows the trick scanner's predicate order, so
+    callers iterating the list see related seeds grouped together.
+    """
+
+    if interactions is None:
+        interactions = scan(board)
+
+    seeds: list[tuple[str, EnhancedStrategy]] = []
+    seen_names: set[str] = set()
+    for interaction in interactions:
+        builder = _BUILDERS.get(interaction.kind)
+        if builder is None:
+            continue
+        result = builder(interaction, board)
+        if result is None:
+            continue
+        name, strategy = result
+        if name in seen_names:
+            continue
+        seen_names.add(name)
+        seeds.append((name, strategy))
+    return seeds
+
+
+def trick_signature(strategy: EnhancedStrategy) -> dict[str, list[str]]:
+    """Summarise which trick-scanner-shaped patterns a strategy still carries.
+
+    Used by the diversity report in ``evolve.py`` to decide whether an
+    evolved descendant *kept* the trick its seed encoded. We deliberately
+    look at structural fingerprints rather than identity: the evolver may
+    rename, reorder, or wrap rules, but if a way_policy entry routes
+    ``<card>`` through a return-to-pile Way, the trash-hook trick is still
+    in play.
+    """
+
+    return {
+        "way_policy": [
+            f"{rule.card_name}->{rule.way_name}" for rule in strategy.way_policy
+        ],
+        "gain_cards": [rule.card for rule in strategy.gain_priority],
+        "action_cards": [rule.card for rule in strategy.action_priority],
+    }

--- a/evolve.py
+++ b/evolve.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import coloredlogs
 
 from dominion.ai.genetic_ai import GeneticAI
+from dominion.analysis.seed_genomes import build_seed_genomes, trick_signature
 from dominion.boards.loader import load_board
 from dominion.reporting.html_report import generate_leaderboard_html
 from dominion.simulation.genetic_trainer import GeneticTrainer
@@ -107,6 +108,12 @@ def main():
         help="module:function specs for seed strategy factories",
     )
     parser.add_argument(
+        "--no-trick-seeds", action="store_true",
+        help="Skip auto-generating seeds from the trick scanner. By default, "
+             "any interactions surfaced by dominion.analysis.trick_scanner are "
+             "mixed in alongside --seeds as additional starting points.",
+    )
+    parser.add_argument(
         "--population", type=int, default=25,
         help="Genetic algorithm population size (default: 25)",
     )
@@ -152,6 +159,25 @@ def main():
     for spec in args.seeds:
         name = _short_name(spec)
         seeds[name] = _load_factory(spec)
+
+    # Inject trick-scanner-derived seeds alongside the user-provided seeds.
+    # Each one becomes its own evolution lineage in Phase 2 — the evolver
+    # is expected to either build on the trick or prune it.
+    trick_seed_strategies: dict[str, EnhancedStrategy] = {}
+    if not args.no_trick_seeds:
+        for name, strategy in build_seed_genomes(board_config):
+            if name in seeds:
+                # Keep the user's version if a name happens to collide.
+                continue
+            seeds[name] = (lambda _s=strategy: deepcopy(_s))
+            trick_seed_strategies[name] = strategy
+        if trick_seed_strategies:
+            logger.info(
+                "Trick-scanner seeds added: %s",
+                ", ".join(trick_seed_strategies.keys()),
+            )
+        else:
+            logger.info("Trick-scanner surfaced no interactions for this board")
 
     if len(seeds) < 2:
         logger.error("Need at least 2 seed strategies for a tournament")
@@ -270,6 +296,57 @@ def main():
             "  #%d %s: %d-%d (%.1f%%)",
             rank, name, stats["wins"], stats["losses"], stats["win_rate"],
         )
+
+    # --- Trick-seed diversity report ---
+    # For each trick-scanner-derived seed, show its final rank, its evolved
+    # descendant's rank, and whether the descendant retained the structural
+    # fingerprint of the trick (way_policy entry, gain rule for the hook
+    # card, etc.). This is the report called out in issue #232's acceptance
+    # criteria: "seeded interactions are tried and either kept (when they
+    # work) or pruned (when they don't)".
+    if trick_seed_strategies:
+        rank_by_name = {name: rank for rank, (name, _) in enumerate(final_ranked, 1)}
+        logger.info("\n" + "=" * 60)
+        logger.info("TRICK-SEED DIVERSITY REPORT")
+        logger.info("=" * 60)
+        for seed_name, seed_strategy in trick_seed_strategies.items():
+            seed_sig = trick_signature(seed_strategy)
+            seed_rank = rank_by_name.get(seed_name)
+            evolved_name = f"Evolved {seed_name}"
+            evolved_rank = rank_by_name.get(evolved_name)
+            evolved_strategy = evolved.get(evolved_name)
+            kept = "n/a"
+            if evolved_strategy is not None:
+                evolved_sig = trick_signature(evolved_strategy)
+                # Trick is "kept" if the evolved strategy still contains
+                # the seed's way_policy entries (most discriminating
+                # fingerprint) or, in the absence of way_policy, still
+                # references the seed's primary gain card.
+                if seed_sig["way_policy"]:
+                    kept = "kept" if all(
+                        entry in evolved_sig["way_policy"]
+                        for entry in seed_sig["way_policy"]
+                    ) else "pruned"
+                else:
+                    primary_gain = next(
+                        (c for c in seed_sig["gain_cards"] if c != "Province"),
+                        None,
+                    )
+                    if primary_gain is None:
+                        kept = "n/a"
+                    else:
+                        kept = (
+                            "kept"
+                            if primary_gain in evolved_sig["gain_cards"]
+                            else "pruned"
+                        )
+            logger.info(
+                "  %s — seed rank: %s, evolved rank: %s, trick: %s",
+                seed_name,
+                f"#{seed_rank}" if seed_rank else "—",
+                f"#{evolved_rank}" if evolved_rank else "—",
+                kept,
+            )
 
     # Generate leaderboard report
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/tests/test_seed_genomes.py
+++ b/tests/test_seed_genomes.py
@@ -143,10 +143,16 @@ def test_command_seed_pairs_command_with_top_payload_target():
     seed = command_seeds[0]
     gain_cards = [r.card for r in seed.gain_priority]
     assert "Band of Misfits" in gain_cards
-    # Top payload among Witch / Village / Smithy is Witch ($3 + curser).
-    # Whatever the scanner ranks first, the seed must include it.
-    target_in_action = [r.card for r in seed.action_priority][0]
-    assert target_in_action in {"Witch", "Smithy", "Village"}
+
+    # Action priority must play the Command FIRST so its pending-replay
+    # slot is registered, then the payload that consumes the slot. The
+    # reverse order silently breaks every "next non-Command Action"
+    # Command (Daimyo, Flagship): the payload would be played first and
+    # the Command's pending counter would have nothing to fire on for the
+    # rest of the turn.
+    action_cards = [r.card for r in seed.action_priority]
+    assert action_cards[0] == "Band of Misfits", action_cards
+    assert action_cards[1] in {"Witch", "Smithy", "Village"}, action_cards
 
 
 def test_cost_mod_seed_stacks_reducer():

--- a/tests/test_seed_genomes.py
+++ b/tests/test_seed_genomes.py
@@ -1,0 +1,204 @@
+"""Tests for ``dominion.analysis.seed_genomes``.
+
+Each Interaction kind has a unit test using a synthetic ``BoardConfig``.
+The acceptance test from issue #232 — running the seed builder on
+``boards/victoria_kingdom.txt`` produces a strategy that uses Way of the
+Butterfly on Flag Bearer — is covered explicitly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dominion.analysis.seed_genomes import (
+    build_seed_genomes,
+    trick_signature,
+)
+from dominion.analysis.trick_scanner import Interaction, scan
+from dominion.boards.loader import BoardConfig, load_board
+from dominion.strategy.enhanced_strategy import (
+    EnhancedStrategy,
+    PriorityRule,
+    WayRule,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VICTORIA_BOARD = REPO_ROOT / "boards" / "victoria_kingdom.txt"
+
+
+def _board(**kwargs) -> BoardConfig:
+    kingdom = kwargs.pop("kingdom_cards")
+    return BoardConfig(kingdom_cards=list(kingdom), **kwargs)
+
+
+# --- Acceptance: issue #232 -------------------------------------------------
+
+
+def test_acceptance_victoria_seeds_include_butterfly_flag_bearer():
+    """Issue #232 acceptance: running the seed builder on victoria_kingdom
+    produces at least one seed that uses Way of the Butterfly on Flag
+    Bearer (i.e. has a ``WayRule(card_name='Flag Bearer',
+    way_name='Way of the Butterfly')``)."""
+
+    board = load_board(VICTORIA_BOARD)
+
+    seeds = build_seed_genomes(board)
+
+    matching: list[tuple[str, EnhancedStrategy]] = []
+    for name, strategy in seeds:
+        for rule in strategy.way_policy:
+            if (
+                rule.card_name == "Flag Bearer"
+                and rule.way_name == "Way of the Butterfly"
+            ):
+                matching.append((name, strategy))
+                break
+    assert matching, (
+        "Expected build_seed_genomes(victoria_kingdom) to include a seed with "
+        "WayRule('Flag Bearer', 'Way of the Butterfly'). Got seeds: "
+        f"{[name for name, _ in seeds]}"
+    )
+
+
+# --- Per-kind unit tests ----------------------------------------------------
+
+
+def test_trash_hook_seed_emits_butterfly_way_policy():
+    board = _board(
+        kingdom_cards=["Flag Bearer", "Village", "Smithy"],
+        ways=["Way of the Butterfly"],
+    )
+
+    seeds = build_seed_genomes(board)
+
+    butterfly_seeds = [
+        (name, s)
+        for name, s in seeds
+        if any(
+            r.card_name == "Flag Bearer" and r.way_name == "Way of the Butterfly"
+            for r in s.way_policy
+        )
+    ]
+    assert butterfly_seeds, [name for name, _ in seeds]
+
+    name, strategy = butterfly_seeds[0]
+    # Sanity: the seed must also gain Flag Bearer (otherwise the way policy
+    # never fires) and have a treasure priority list (so it can pay).
+    gain_cards = [r.card for r in strategy.gain_priority]
+    assert "Flag Bearer" in gain_cards
+    assert any(r.card == "Gold" for r in strategy.treasure_priority)
+    assert any(r.card == "Province" for r in strategy.gain_priority)
+
+
+def test_gain_hook_seed_prioritises_hook_card():
+    """Flag Bearer + Duplicate triggers the gain-hook predicate; the seed
+    should put Flag Bearer high in the gain priority so each gainer
+    re-fires its on_gain hook."""
+
+    board = _board(kingdom_cards=["Flag Bearer", "Duplicate"])
+
+    seeds = build_seed_genomes(board)
+
+    re_gain_seeds = [s for name, s in seeds if name.startswith("Trick Re-gain")]
+    assert re_gain_seeds, [name for name, _ in seeds]
+
+    flag_bearer_seed = next(
+        s for s in re_gain_seeds if "Flag Bearer" in (s.name or "")
+    )
+    gain_cards = [r.card for r in flag_bearer_seed.gain_priority]
+    assert "Flag Bearer" in gain_cards
+    # The hook card should rank ahead of the generic Silver fallback.
+    assert gain_cards.index("Flag Bearer") < gain_cards.index("Silver")
+
+
+def test_empty_deck_event_seed_buys_event_and_self_exile_card():
+    board = _board(
+        kingdom_cards=["Stockpile", "Village"],
+        events=["Windfall"],
+    )
+
+    seeds = build_seed_genomes(board)
+
+    empty_seeds = [s for _, s in seeds if any(r.card == "Windfall" for r in s.gain_priority)]
+    assert empty_seeds, [name for name, _ in seeds]
+
+    seed = empty_seeds[0]
+    gain_cards = [r.card for r in seed.gain_priority]
+    assert "Windfall" in gain_cards
+    assert "Stockpile" in gain_cards
+    # Windfall (the payoff event) should come before the generic Silver.
+    assert gain_cards.index("Windfall") < gain_cards.index("Silver")
+
+
+def test_command_seed_pairs_command_with_top_payload_target():
+    board = _board(
+        kingdom_cards=["Band of Misfits", "Witch", "Village", "Smithy"],
+    )
+
+    seeds = build_seed_genomes(board)
+
+    command_seeds = [s for name, s in seeds if name.startswith("Trick Band of Misfits")]
+    assert command_seeds, [name for name, _ in seeds]
+
+    seed = command_seeds[0]
+    gain_cards = [r.card for r in seed.gain_priority]
+    assert "Band of Misfits" in gain_cards
+    # Top payload among Witch / Village / Smithy is Witch ($3 + curser).
+    # Whatever the scanner ranks first, the seed must include it.
+    target_in_action = [r.card for r in seed.action_priority][0]
+    assert target_in_action in {"Witch", "Smithy", "Village"}
+
+
+def test_cost_mod_seed_stacks_reducer():
+    board = _board(kingdom_cards=["Bridge", "Village", "Smithy"])
+
+    seeds = build_seed_genomes(board)
+
+    cost_mod_seeds = [s for name, s in seeds if name.startswith("Trick Cost-mod")]
+    assert cost_mod_seeds, [name for name, _ in seeds]
+
+    seed = cost_mod_seeds[0]
+    gain_cards = [r.card for r in seed.gain_priority]
+    assert "Bridge" in gain_cards
+
+
+# --- Misc -------------------------------------------------------------------
+
+
+def test_build_seed_genomes_drops_unknown_kinds_silently():
+    """Interactions with kinds the seed builder doesn't know about must be
+    skipped without raising — keeps adding new trick scanner predicates
+    backwards-compatible with this module."""
+
+    board = _board(kingdom_cards=["Village"])
+    fake = Interaction(kind="brand_new_kind_no_builder", headline="x")
+
+    seeds = build_seed_genomes(board, interactions=[fake])
+
+    assert seeds == []
+
+
+def test_build_seed_genomes_dedupes_by_name():
+    """Two Interactions producing the same seed name (e.g. duplicated
+    re-trigger sources for the same hook card) must collapse to one seed."""
+
+    board = _board(kingdom_cards=["Flag Bearer", "Duplicate", "Workshop"])
+
+    interactions = scan(board)
+    seeds = build_seed_genomes(board, interactions=interactions)
+    names = [name for name, _ in seeds]
+
+    assert len(names) == len(set(names))
+
+
+def test_trick_signature_captures_way_policy_and_gain_cards():
+    s = EnhancedStrategy()
+    s.gain_priority = [PriorityRule("Province"), PriorityRule("Flag Bearer")]
+    s.action_priority = [PriorityRule("Flag Bearer")]
+    s.way_policy = [WayRule(card_name="Flag Bearer", way_name="Way of the Butterfly")]
+
+    sig = trick_signature(s)
+
+    assert "Flag Bearer->Way of the Butterfly" in sig["way_policy"]
+    assert "Flag Bearer" in sig["gain_cards"]
+    assert "Flag Bearer" in sig["action_cards"]


### PR DESCRIPTION
## Summary

- Adds `dominion/analysis/seed_genomes.py`: converts each `Interaction` from the trick scanner (#230) into an `EnhancedStrategy` that pre-encodes the trick (way_policy entry, gain rule for the hook card, Command + top-payload target, etc.) on top of a generic engine baseline. One builder per Interaction kind.
- Wires `build_seed_genomes(board)` into `evolve.py` so trick seeds are mixed alongside user-provided `--seeds`; each one gets its own evolution lineage. New `--no-trick-seeds` flag opts out.
- Adds a trick-seed diversity report after Phase 3: for each trick seed, prints the seed's final-tournament rank, its evolved descendant's rank, and whether the descendant retained the structural fingerprint of the trick (way_policy entry / hook-card gain rule).

## Acceptance (issue #232)

- [x] Running `build_seed_genomes(load_board('boards/victoria_kingdom.txt'))` produces a strategy with `WayRule(card_name='Flag Bearer', way_name='Way of the Butterfly')`. Covered by `test_acceptance_victoria_seeds_include_butterfly_flag_bearer`.
- [x] On Victoria, four trick seeds are generated: Butterfly Flag Bearer, Re-gain Flag Bearer, Empty-deck Windfall, Daimyo + Wayfarer.
- [x] Diversity report wires per-seed kept/pruned status into the Phase 3 logs.

## Test plan

- [x] `pytest tests/test_seed_genomes.py` (9 tests, all pass).
- [x] `pytest tests/` (1257 tests pass; the one flake in `tests/test_genetic_trainer.py::TestConditionsEvaluate::test_random_strategy_conditions_evaluate` is pre-existing and depends on test-collection order — verified by stashing this PR and reproducing the same failure).
- [x] Smoke test: a generated Butterfly + Flag Bearer seed plays a complete game on Victoria against Big Money without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)