### PR TITLE
Fix Watchtower infinite loop when deck and discard are empty

### DIFF
--- a/dominion/cards/prosperity/watchtower.py
+++ b/dominion/cards/prosperity/watchtower.py
@@ -11,8 +11,15 @@ class Watchtower(Card):
         )
 
     def play_effect(self, game_state):
-        """Draw until the current player has six cards in hand."""
+        """Draw until the current player has six cards in hand.
+
+        Stops if the deck and discard are both exhausted — otherwise a
+        thinned-out player could loop forever while ``draw_cards`` returns
+        nothing but the hand never reaches six.
+        """
 
         player = game_state.current_player
         while len(player.hand) < 6:
-            game_state.draw_cards(player, 1)
+            drawn = game_state.draw_cards(player, 1)
+            if not drawn:
+                break

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -226,6 +226,35 @@ def test_watchtower_draws_to_six_and_can_trash_gains():
     assert any(card.name == "Estate" for card in state.trash)
 
 
+def test_watchtower_terminates_when_deck_and_discard_empty():
+    """Regression: Watchtower's draw-to-6 loop must break if there are no
+    more cards to draw, otherwise a thinned-out player (deck and discard
+    both empty) infinite-loops during fitness evaluation in the GA.
+    """
+    import threading
+
+    player = PlayerState(DummyAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Watchtower")])
+
+    player.hand = [get_card("Watchtower")]
+    player.deck = []
+    player.discard = []
+
+    finished = threading.Event()
+
+    def run():
+        play_action(state, player, "Watchtower")
+        finished.set()
+
+    t = threading.Thread(target=run, daemon=True)
+    t.start()
+    t.join(timeout=2)
+
+    assert finished.is_set(), "Watchtower did not terminate with empty deck+discard"
+    assert len(player.hand) == 0  # nothing to draw
+
+
 def test_watchtower_can_topdeck_gains():
     gain_ai = DummyAI()
     reaction_ai = WatchtowerTopdeckAI()


### PR DESCRIPTION
## Summary

- `Watchtower.play_effect` looped `while len(player.hand) < 6: draw_cards(1)` with no exit when both deck and discard were exhausted — every other "draw to N" card already guards against this (First Mate, Ronin, Jack of All Trades, Library); Watchtower was the only outlier.
- Surfaced as a wedged simulator during GA fitness evaluation: a thinned-out evolved strategy occasionally enters a turn where Watchtower is played with deck+discard empty and the game never returns. Killed an ~27-hour run at Generation 2 with the process pegged at 98.8% CPU.
- Fix matches the pattern used by every other draw-to-N card in the codebase: break when `draw_cards` returns an empty list.

## Test plan

- [x] Added `test_watchtower_terminates_when_deck_and_discard_empty` — runs Watchtower in a thread with a 2-second join, fails on infinite loop.
- [x] Confirmed test fails on `main` (verified with a 2-line repro before fixing) and passes after the fix.
- [x] `pytest tests/test_prosperity_cards.py` — all 44 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)