### PR TITLE
[codex] add Clerk Collection Colony strategy

### DIFF
--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -2754,8 +2754,9 @@ class GameState:
 
         The game ends if:
         1. Province pile is empty
-        2. Any three supply piles are empty
-        3. Maximum turns (100) reached to prevent infinite games
+        2. Colony pile is empty, when Colonies are in the supply
+        3. Any three supply piles are empty
+        4. Maximum turns (100) reached to prevent infinite games
 
         Returns:
             bool: True if the game is over, False otherwise
@@ -2764,9 +2765,9 @@ class GameState:
         if self.logger:
             self.logger.current_metrics.turn_count = self.turn_number
 
-        normal_end = (
-            self.supply.get("Province", 0) == 0 or self.empty_piles >= 3
-        )
+        province_depleted = self.supply.get("Province", 0) == 0
+        colony_depleted = "Colony" in self.supply and self.supply.get("Colony", 0) == 0
+        normal_end = province_depleted or colony_depleted or self.empty_piles >= 3
 
         # If the current player is mid-turn (has not yet finished cleanup),
         # never short-circuit into the Fleet extra round or game-end logic.
@@ -2823,19 +2824,25 @@ class GameState:
             return True
 
         # 1. Province pile empty
-        if self.supply.get("Province", 0) == 0:
+        if province_depleted:
             self._update_final_metrics()
             self.log_callback("Game over: Provinces depleted")
             return True
 
-        # 2. Three supply piles empty
+        # 2. Colony pile empty, if present
+        if colony_depleted:
+            self._update_final_metrics()
+            self.log_callback("Game over: Colonies depleted")
+            return True
+
+        # 3. Three supply piles empty
         empty_piles = self.empty_piles
         if empty_piles >= 3:
             self._update_final_metrics()
             self.log_callback("Game over: Three piles depleted")
             return True
 
-        # 3. Hard turn limit
+        # 4. Hard turn limit
         if self.turn_number > 100:
             self._update_final_metrics()
             self.log_callback("Game over: Maximum turns reached")

--- a/dominion/strategy/strategies/clerk_collection_colony.py
+++ b/dominion/strategy/strategies/clerk_collection_colony.py
@@ -1,0 +1,81 @@
+from dominion.cards.registry import get_card
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+def _card_count_less_than(card_name: str, limit: int):
+    return lambda _state, player: player.count_in_deck(card_name) < limit
+
+
+def _colonies_left(op: str, amount: int):
+    cmp = PriorityRule._OP_MAP[op]
+    return lambda state, _player: cmp(state.supply.get("Colony", 0), amount)
+
+
+def _peddler_cost_at_most(amount: int):
+    def _condition(state, player):
+        return state.get_card_cost(player, get_card("Peddler")) <= amount
+
+    return _condition
+
+
+class ClerkCollectionColonyStrategy(EnhancedStrategy):
+    """Clerk-backed Collection/Peddler engine for the Watchtower Colony board."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "ClerkCollectionColony"
+        self.description = (
+            "Builds around early Clerk pressure, Collection VP, cheap Peddlers, "
+            "and Platinum into Colonies."
+        )
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule("Colony"),
+            PriorityRule("Province", _colonies_left("<=", 3)),
+            PriorityRule("Duchy", _colonies_left("<=", 2)),
+            PriorityRule("Platinum"),
+            PriorityRule("Peddler", _peddler_cost_at_most(2)),
+            PriorityRule("Clerk", _card_count_less_than("Clerk", 3)),
+            PriorityRule("Collection", _card_count_less_than("Collection", 3)),
+            PriorityRule("City", _card_count_less_than("City", 5)),
+            PriorityRule("Workers' Village", _card_count_less_than("Workers' Village", 5)),
+            PriorityRule("Festival", _card_count_less_than("Festival", 4)),
+            PriorityRule("Peddler"),
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+        ]
+
+        self.action_priority = [
+            PriorityRule("City"),
+            PriorityRule("Workers' Village"),
+            PriorityRule("Festival"),
+            PriorityRule("Peddler"),
+            PriorityRule("Clerk"),
+            PriorityRule("Watchtower"),
+        ]
+
+        self.treasure_priority = [
+            PriorityRule("Collection"),
+            PriorityRule("Platinum"),
+            PriorityRule("Gold"),
+            PriorityRule("Investment"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+        self.trash_priority = [
+            PriorityRule("Curse"),
+            PriorityRule("Estate", _colonies_left(">", 3)),
+            PriorityRule(
+                "Copper",
+                PriorityRule.and_(
+                    PriorityRule.has_cards(["Platinum", "Gold"], 3),
+                    _colonies_left(">", 2),
+                ),
+            ),
+        ]
+
+
+def create_clerk_collection_colony() -> EnhancedStrategy:
+    return ClerkCollectionColonyStrategy()

--- a/tests/test_engine_smoke.py
+++ b/tests/test_engine_smoke.py
@@ -116,6 +116,18 @@ def test_gamestate_end_on_province_depletion():
     assert gs.is_game_over() is True
 
 
+def test_gamestate_end_on_colony_depletion_when_colonies_are_in_supply():
+    gs = make_game(kingdom=["Colony"])
+    gs.supply["Colony"] = 0
+    assert gs.is_game_over() is True
+
+
+def test_gamestate_does_not_end_on_missing_colony_pile():
+    gs = make_game()
+    assert "Colony" not in gs.supply
+    assert gs.is_game_over() is False
+
+
 def test_watchtower_topdecks_gained_card():
     gs = make_game(kingdom=["Watchtower"])
     p = gs.current_player


### PR DESCRIPTION
## Summary
- Add `ClerkCollectionColony`, a strategy for the Watchtower/Clerk/Gardens/Investment/Workers' Village/City/Collection/Festival/Expand/Peddler board with Colony and Platinum.
- End games when the Colony pile is depleted if Colonies are in the supply.
- Add smoke coverage for Colony depletion and for games without Colony piles.

## Validation
- `pytest tests/test_engine_smoke.py tests/test_strategy_loader.py -q`
- `pytest tests/test_victory_card_supply.py tests/test_engine_smoke.py -q`
- Strategy discovery smoke check for the target board
- One same-strategy game smoke check on the target board