### PR TITLE
[codex] Fix stale report documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,17 @@ To run every strategy against each other and produce a leaderboard:
 python compare_all_strategies.py --games 5
 ```
 
-The leaderboard will be written to `leaderboard.html` by default.
+The leaderboard will be written to `reports/leaderboard_all.html` by default.
+When using `--board`, the default output is
+`reports/leaderboard_<board-name>.html`.
 
-Example reports can be generated using the generic comparison runner:
+Example strategy comparison reports can be generated with the strategy battle
+module:
 
 ```
-python compare_strategies.py "Chapel Witch" "Big Money" --games 50
+python -m dominion.simulation.strategy_battle "Chapel Witch" "Big Money" --games 50 --output reports/chapel_witch_vs_big_money.html
 ```
 
-Reports are written to the `reports` directory.
-
+If `--output` is omitted, reports are written to the `reports` directory with
+an auto-generated filename.
 

--- a/compare_all_strategies.py
+++ b/compare_all_strategies.py
@@ -105,7 +105,10 @@ def main() -> None:
         "--output",
         type=Path,
         default=None,
-        help="Output HTML file (default: reports/leaderboard.html)",
+        help=(
+            "Output HTML file (default: reports/leaderboard_all.html, "
+            "or reports/leaderboard_<board>.html with --board)"
+        ),
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Updates the README report-generation examples to match the current CLI surface and generated output paths. Replaces the nonexistent `compare_strategies.py` command with `python -m dominion.simulation.strategy_battle` and documents the default leaderboard paths. Also fixes the stale `compare_all_strategies.py --output` help text. Validated with `python compare_all_strategies.py --help` and `python -m dominion.simulation.strategy_battle "Chapel Witch" "Big Money" --games 1 --no-report`. Closes #249.