### PR TITLE
Handle implicit landscapes in strategy battles

### DIFF
--- a/compare_all_strategies.py
+++ b/compare_all_strategies.py
@@ -5,8 +5,35 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from dominion.boards.loader import BoardConfig, load_board
-from dominion.simulation.strategy_battle import BASIC_CARDS, StrategyBattle
+from dominion.simulation.strategy_battle import (
+    StrategyBattle,
+    StrategyBoardReferences,
+    canonical_way_name,
+)
 from dominion.reporting.html_report import generate_leaderboard_html
+
+
+def _missing_board_components(
+    refs: StrategyBoardReferences,
+    board_config: BoardConfig,
+    board_cards: set[str],
+) -> list[str]:
+    missing_cards = set(refs.kingdom_cards) - board_cards
+    missing_events = set(refs.events) - set(board_config.events)
+    missing_projects = set(refs.projects) - set(board_config.projects)
+    missing_ways = {canonical_way_name(w) for w in refs.ways} - {
+        canonical_way_name(w) for w in board_config.ways
+    }
+    missing_allies = set(refs.allies) - set(board_config.allies)
+
+    missing = [
+        f"cards: {', '.join(sorted(missing_cards))}" if missing_cards else "",
+        f"events: {', '.join(sorted(missing_events))}" if missing_events else "",
+        f"projects: {', '.join(sorted(missing_projects))}" if missing_projects else "",
+        f"ways: {', '.join(sorted(missing_ways))}" if missing_ways else "",
+        f"allies: {', '.join(sorted(missing_allies))}" if missing_allies else "",
+    ]
+    return [entry for entry in missing if entry]
 
 
 def run_full_battle(
@@ -38,14 +65,16 @@ def run_full_battle(
         strat = battle.strategy_loader.get_strategy(name)
         if not strat:
             continue
-        cards = battle._extract_cards_from_strategy(strat)
-        kingdom_cards = sorted(c for c in cards if c not in BASIC_CARDS)
+        refs = battle._split_board_references(battle._extract_cards_from_strategy(strat))
+        kingdom_cards = refs.kingdom_cards
         desc = getattr(strat, "description", "")
 
         if board_cards is not None:
-            # Only include strategies whose cards are all on the board
-            if not set(kingdom_cards).issubset(board_cards):
-                print(f"  Excluding {name}: uses cards not on board ({', '.join(sorted(set(kingdom_cards) - board_cards))})")
+            # Only include strategies whose referenced components are all on
+            # the explicit board.
+            missing = _missing_board_components(refs, board_config, board_cards)
+            if missing:
+                print(f"  Excluding {name}: uses components not on board ({'; '.join(missing)})")
                 continue
 
         compatible_names.append(name)
@@ -61,12 +90,14 @@ def run_full_battle(
     total_pairings = len(list(combinations(strategy_names, 2)))
     print(f"Running {total_pairings} pairings ({len(strategy_names)} strategies, {num_games} games each)...")
 
+    skipped_pairings = 0
     for i, (strat1, strat2) in enumerate(combinations(strategy_names, 2), 1):
         if i % 10 == 0 or i == total_pairings:
             print(f"  Pairing {i}/{total_pairings}: {strat1} vs {strat2}")
         try:
             results = battle.run_battle(strat1, strat2, num_games)
         except Exception as exc:
+            skipped_pairings += 1
             print(f"  Skipping {strat1} vs {strat2}: {exc}")
             continue
 
@@ -84,6 +115,9 @@ def run_full_battle(
             stats["win_rate"] = stats["wins"] / stats["games"] * 100
         else:
             stats["win_rate"] = 0.0
+
+    if skipped_pairings:
+        print(f"Skipped {skipped_pairings} of {total_pairings} pairings due to setup or runtime errors.")
 
     return aggregated
 

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -1,6 +1,5 @@
 import logging
 import random
-import re
 from copy import deepcopy
 from typing import Callable, Optional, Tuple
 
@@ -8,29 +7,12 @@ import coloredlogs
 
 from dominion.boards.loader import BoardConfig
 from dominion.simulation.game_logger import GameLogger
-from dominion.simulation.strategy_battle import StrategyBattle
+from dominion.simulation.strategy_battle import StrategyBattle, canonical_way_name
 from dominion.strategy.enhanced_strategy import PriorityRule, WayRule
 from dominion.strategy.strategies.base_strategy import BaseStrategy
 
 log = logging.getLogger(__name__)
 coloredlogs.install(level="INFO", logger=log)
-
-
-_WAY_PARAM_RE = re.compile(r"\s*\(.+\)$")
-
-
-def _canonical_way_name(way: str) -> str:
-    """Strip a parametric ``(...)`` suffix from a Way name.
-
-    The board loader stores ``Way of the Mouse: Native Village`` as
-    ``"Way of the Mouse (Native Village)"`` so the way registry's regex can
-    resolve the set-aside card. But the constructed ``WayOfTheMouse``
-    instance's ``.name`` is just ``"Way of the Mouse"`` — without the
-    parametric suffix. ``WayRule.way_name`` is matched against the runtime
-    ``Way.name`` in :meth:`EnhancedStrategy._choose_from_way_policy`, so we
-    canonicalise here to keep the two sides aligned.
-    """
-    return _WAY_PARAM_RE.sub("", way)
 
 
 def _distribute_games(total_budget: int, n_opponents: int) -> list[int]:
@@ -125,7 +107,7 @@ class GeneticTrainer:
         # mouse instance with the unparameterised name).
         self._kingdom_ways: list[str] = []
         if board_config is not None and board_config.ways:
-            self._kingdom_ways = [_canonical_way_name(w) for w in board_config.ways]
+            self._kingdom_ways = [canonical_way_name(w) for w in board_config.ways]
 
     # Probability that ``_random_condition_with_compound`` wraps a normally
     # sampled inner condition in ``and_(card_in_play(X), inner)``. Tunable.
@@ -411,16 +393,37 @@ class GeneticTrainer:
             breakdown: list[tuple] = []
             for i, opponent in enumerate(panel):
                 games_per_opp = games_for_opp[i]
-                kingdom_card_names = self.battle_system._determine_kingdom_cards(strategy, opponent)
+                board_references = self.battle_system._determine_board_references(strategy, opponent)
+                kingdom_card_names = board_references.kingdom_cards
+                landscape_kwargs = {
+                    key: value
+                    for key, value in {
+                        "events": board_references.events,
+                        "projects": board_references.projects,
+                        "ways": board_references.ways,
+                        "allies": board_references.allies,
+                    }.items()
+                    if value
+                }
                 wins = 0
                 margin_total = 0.0
                 for game_num in range(games_per_opp):
                     ai1 = GeneticAI(strategy)
                     ai2 = GeneticAI(opponent)
                     if game_num % 2 == 0:
-                        winner, scores, _l, _t = self.battle_system.run_game(ai1, ai2, kingdom_card_names)
+                        winner, scores, _l, _t = self.battle_system.run_game(
+                            ai1,
+                            ai2,
+                            kingdom_card_names,
+                            **landscape_kwargs,
+                        )
                     else:
-                        winner, scores, _l, _t = self.battle_system.run_game(ai2, ai1, kingdom_card_names)
+                        winner, scores, _l, _t = self.battle_system.run_game(
+                            ai2,
+                            ai1,
+                            kingdom_card_names,
+                            **landscape_kwargs,
+                        )
                     if winner == ai1:
                         wins += 1
                     # ``scores`` is keyed by ai.name; if the mock omits scores

--- a/dominion/simulation/strategy_battle.py
+++ b/dominion/simulation/strategy_battle.py
@@ -1,25 +1,28 @@
 import argparse
 import logging
 import re
+from dataclasses import dataclass
 from datetime import datetime
 from logging import getLogger
 from pathlib import Path
 from typing import Any, Optional
 
 from dominion.ai.genetic_ai import GeneticAI
-from dominion.allies.registry import get_ally
+from dominion.allies.registry import ALLY_TYPES, get_ally
 from dominion.boards.loader import BoardConfig, load_board
-from dominion.cards.registry import get_card
-from dominion.events.registry import get_event
+from dominion.cards.registry import CARD_ALIASES, CARD_TYPES, get_card
+from dominion.events.registry import EVENT_TYPES, get_event
 from dominion.game.game_state import GameState
-from dominion.projects.registry import get_project
+from dominion.projects.registry import PROJECT_TYPES, get_project
 from dominion.reporting.html_report import generate_html_report
 from dominion.simulation.game_logger import GameLogger
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
 from dominion.strategy.strategy_loader import StrategyLoader
-from dominion.ways.registry import get_way
+from dominion.ways.registry import WAY_TYPES, get_way
 
 logger = getLogger(__name__)
+
+_WAY_PARAM_RE = re.compile(r"\s*\(.+\)$")
 
 DEFAULT_KINGDOM_CARDS = [
     "Village",
@@ -50,6 +53,21 @@ BASIC_CARDS = {
     "Necropolis",
     "Overgrown Estate",
 }
+
+
+@dataclass(frozen=True)
+class StrategyBoardReferences:
+    kingdom_cards: list[str]
+    events: list[str]
+    projects: list[str]
+    ways: list[str]
+    allies: list[str]
+
+
+def canonical_way_name(way: str) -> str:
+    """Return the runtime Way.name for a board or strategy Way reference."""
+    return _WAY_PARAM_RE.sub("", way)
+
 
 # Set up module-level logger
 logger = logging.getLogger(__name__)
@@ -82,8 +100,8 @@ class StrategyBattle:
         self.verbose = verbose
 
     def _extract_cards_from_strategy(self, strat: EnhancedStrategy) -> set[str]:
-        """Return all card names referenced by a strategy's priority lists."""
-        cards: set[str] = set()
+        """Return all names referenced by a strategy's priority lists."""
+        references: set[str] = set()
         for priority_list in [
             strat.gain_priority,
             strat.action_priority,
@@ -92,32 +110,96 @@ class StrategyBattle:
         ]:
             for rule in priority_list:
                 if isinstance(rule, PriorityRule):
-                    cards.add(rule.card_name)
-        return cards
+                    references.add(rule.card_name)
+
+        for rule in getattr(strat, "way_policy", []) or []:
+            card_name = getattr(rule, "card_name", None)
+            way_name = getattr(rule, "way_name", None)
+            if card_name:
+                references.add(card_name)
+            if way_name:
+                references.add(way_name)
+
+        return references
+
+    @staticmethod
+    def _is_card_reference(name: str) -> bool:
+        return CARD_ALIASES.get(name, name) in CARD_TYPES
+
+    @staticmethod
+    def _is_way_reference(name: str) -> bool:
+        if name in WAY_TYPES:
+            return True
+
+        match = re.match(r"^(Way of the Mouse)\s*\((.+)\)$", name)
+        return bool(match and match.group(1) in WAY_TYPES)
+
+    def _split_board_references(self, names: set[str]) -> StrategyBoardReferences:
+        """Split strategy references into cards and supported landscapes."""
+
+        kingdom_cards: list[str] = []
+        events: list[str] = []
+        projects: list[str] = []
+        ways: list[str] = []
+        allies: list[str] = []
+
+        for name in sorted(names):
+            if name in BASIC_CARDS:
+                continue
+
+            if self._is_card_reference(name):
+                kingdom_cards.append(name)
+            elif name in EVENT_TYPES:
+                events.append(name)
+            elif name in PROJECT_TYPES:
+                projects.append(name)
+            elif self._is_way_reference(name):
+                ways.append(name)
+            elif name in ALLY_TYPES:
+                allies.append(name)
+            else:
+                # Preserve the old failure mode for typos and unsupported
+                # references: board preparation will raise Unknown card.
+                kingdom_cards.append(name)
+
+        return StrategyBoardReferences(kingdom_cards, events, projects, ways, allies)
+
+    def _determine_board_references(
+        self, strat1: EnhancedStrategy, strat2: EnhancedStrategy
+    ) -> StrategyBoardReferences:
+        """Compute cards and landscapes from both strategies if not explicitly set."""
+        if self.kingdom_cards is not None:
+            return StrategyBoardReferences(self.kingdom_cards, [], [], [], [])
+
+        all_names = self._extract_cards_from_strategy(strat1) | self._extract_cards_from_strategy(strat2)
+        return self._split_board_references(all_names)
 
     def _determine_kingdom_cards(self, strat1: EnhancedStrategy, strat2: EnhancedStrategy) -> list[str]:
         """Compute kingdom cards from both strategies if not explicitly set."""
-        if self.kingdom_cards is not None:
-            return self.kingdom_cards
+        return self._determine_board_references(strat1, strat2).kingdom_cards
 
-        all_cards = self._extract_cards_from_strategy(strat1) | self._extract_cards_from_strategy(strat2)
-        return sorted(c for c in all_cards if c not in BASIC_CARDS)
-
-    def _prepare_board_components(self, kingdom_card_names: list[str]):
+    def _prepare_board_components(
+        self,
+        kingdom_card_names: list[str],
+        event_names: Optional[list[str]] = None,
+        project_names: Optional[list[str]] = None,
+        way_names: Optional[list[str]] = None,
+        ally_names: Optional[list[str]] = None,
+    ):
         """Instantiate cards and landscape components for a game."""
 
         kingdom_cards = [get_card(name) for name in kingdom_card_names]
 
-        events = []
-        projects = []
-        ways = []
-        allies = []
-
         if self.board_config:
-            events = [get_event(name) for name in self.board_config.events]
-            projects = [get_project(name) for name in self.board_config.projects]
-            ways = [get_way(name) for name in self.board_config.ways]
-            allies = [get_ally(name) for name in self.board_config.allies]
+            event_names = self.board_config.events
+            project_names = self.board_config.projects
+            way_names = self.board_config.ways
+            ally_names = self.board_config.allies
+
+        events = [get_event(name) for name in event_names or []]
+        projects = [get_project(name) for name in project_names or []]
+        ways = [get_way(name) for name in way_names or []]
+        allies = [get_ally(name) for name in ally_names or []]
 
         return kingdom_cards, events, projects, ways, allies
 
@@ -241,9 +323,26 @@ class StrategyBattle:
             logger.info("Strategy 1: %s", strategy1_name)
             logger.info("Strategy 2: %s\n", strategy2_name)
 
-        kingdom_card_names = self._determine_kingdom_cards(strategy1, strategy2)
+        board_references = self._determine_board_references(strategy1, strategy2)
+        kingdom_card_names = board_references.kingdom_cards
         if self.verbose:
             logger.info("Using kingdom cards: %s", ", ".join(kingdom_card_names))
+            if not self.board_config:
+                logger.info(
+                    "Using landscapes: %s",
+                    ", ".join(
+                        filter(
+                            None,
+                            [
+                                f"Ways={len(board_references.ways)}" if board_references.ways else "",
+                                f"Projects={len(board_references.projects)}" if board_references.projects else "",
+                                f"Events={len(board_references.events)}" if board_references.events else "",
+                                f"Allies={len(board_references.allies)}" if board_references.allies else "",
+                            ],
+                        ),
+                    )
+                    or "(no landscapes)",
+                )
 
         if self.board_config and self.verbose:
             logger.info(
@@ -284,6 +383,10 @@ class StrategyBattle:
                     ai2,
                     kingdom_card_names,
                     decision_stats_by_ai=decision_stats_by_ai,
+                    events=board_references.events,
+                    projects=board_references.projects,
+                    ways=board_references.ways,
+                    allies=board_references.allies,
                 )
             else:
                 winner, scores, log_path, turns = self.run_game(
@@ -291,6 +394,10 @@ class StrategyBattle:
                     ai1,
                     kingdom_card_names,
                     decision_stats_by_ai=decision_stats_by_ai,
+                    events=board_references.events,
+                    projects=board_references.projects,
+                    ways=board_references.ways,
+                    allies=board_references.allies,
                 )
 
             # Record results
@@ -339,6 +446,10 @@ class StrategyBattle:
         kingdom_card_names: list[str],
         *,
         decision_stats_by_ai: Optional[dict[GeneticAI, dict[str, Any]]] = None,
+        events: Optional[list[str]] = None,
+        projects: Optional[list[str]] = None,
+        ways: Optional[list[str]] = None,
+        allies: Optional[list[str]] = None,
     ) -> tuple[GeneticAI, dict[str, int], Optional[str], int]:
         """Run a single game between two AIs. TODO: This shouldn't be within this class."""
         if decision_stats_by_ai:
@@ -353,15 +464,21 @@ class StrategyBattle:
         game_state.set_logger(self.logger)
 
         # Initialize game
-        kingdom_cards, events, projects, ways, allies = self._prepare_board_components(kingdom_card_names)
+        kingdom_cards, event_objs, project_objs, way_objs, ally_objs = self._prepare_board_components(
+            kingdom_card_names,
+            events,
+            projects,
+            ways,
+            allies,
+        )
         game_state.initialize_game(
             [ai1, ai2],
             kingdom_cards,
             use_shelters=self.use_shelters,
-            events=events,
-            projects=projects,
-            ways=ways,
-            allies=allies,
+            events=event_objs,
+            projects=project_objs,
+            ways=way_objs,
+            allies=ally_objs,
         )
 
         # Apply traits from board config

--- a/tests/test_board_loader.py
+++ b/tests/test_board_loader.py
@@ -4,6 +4,7 @@ import pytest
 
 from dominion.boards.loader import BoardConfig, load_board
 from dominion.simulation.strategy_battle import StrategyBattle
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
 
 
 def write_board(tmp_path: Path, contents: str) -> Path:
@@ -54,6 +55,31 @@ def test_strategy_battle_prepares_landscapes(tmp_path):
     assert events == []
     assert [project.name for project in projects] == board.projects
     assert [way.name for way in ways] == board.ways
+    assert allies == []
+
+
+def test_strategy_battle_splits_implicit_event_references():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [
+        PriorityRule("Village"),
+        PriorityRule("Looting"),
+        PriorityRule("Silver"),
+    ]
+
+    battle = StrategyBattle()
+    refs = battle._determine_board_references(strategy, EnhancedStrategy())
+    kingdom, events, projects, ways, allies = battle._prepare_board_components(
+        refs.kingdom_cards,
+        refs.events,
+        refs.projects,
+        refs.ways,
+        refs.allies,
+    )
+
+    assert [card.name for card in kingdom] == ["Village"]
+    assert [event.name for event in events] == ["Looting"]
+    assert projects == []
+    assert ways == []
     assert allies == []
 
 

--- a/tests/test_compare_all_strategies.py
+++ b/tests/test_compare_all_strategies.py
@@ -1,0 +1,19 @@
+from compare_all_strategies import _missing_board_components
+from dominion.boards.loader import BoardConfig
+from dominion.simulation.strategy_battle import StrategyBoardReferences
+
+
+def test_board_compatibility_canonicalizes_parametric_way_names():
+    board = BoardConfig(
+        kingdom_cards=["Flag Bearer", "Village"],
+        ways=["Way of the Mouse (Native Village)"],
+    )
+    refs = StrategyBoardReferences(
+        kingdom_cards=["Flag Bearer"],
+        events=[],
+        projects=[],
+        ways=["Way of the Mouse"],
+        allies=[],
+    )
+
+    assert _missing_board_components(refs, board, set(board.kingdom_cards)) == []


### PR DESCRIPTION
Fixes #247.

StrategyBattle now splits references pulled from strategy priorities into kingdom cards and supported landscape components, so Event references such as Looting are supplied to GameState instead of crashing through get_card. Genetic trainer evaluations and all-strategies leaderboard compatibility checks use the same split, with skipped pairing totals surfaced when runtime errors remain.

Validation: pytest -q; python -m dominion.simulation.strategy_battle "Custom Board Strategy" "Big Money" --games 1; python compare_all_strategies.py --games 1.