### PR TITLE
[codex] Fix topdeck card placement

### DIFF
--- a/dominion/cards/base_set/harbinger.py
+++ b/dominion/cards/base_set/harbinger.py
@@ -19,4 +19,4 @@ class Harbinger(Card):
         )
         if choice and choice in player.discard:
             player.discard.remove(choice)
-            player.deck.insert(0, choice)
+            player.deck.append(choice)

--- a/dominion/cards/dark_ages/graverobber.py
+++ b/dominion/cards/dark_ages/graverobber.py
@@ -38,7 +38,7 @@ class Graverobber(Card):
         if not choice or choice not in candidates:
             choice = candidates[0]
         game_state.trash.remove(choice)
-        player.deck.insert(0, choice)
+        player.deck.append(choice)
 
     def _upgrade(self, game_state, player, action_cards):
         from ..registry import get_card

--- a/dominion/cards/hinterlands/mandarin.py
+++ b/dominion/cards/hinterlands/mandarin.py
@@ -18,7 +18,7 @@ class Mandarin(Card):
 
         choice = min(player.hand, key=self._topdeck_priority)
         player.hand.remove(choice)
-        player.deck.insert(0, choice)
+        player.deck.append(choice)
 
     def on_gain(self, game_state, player):
         super().on_gain(game_state, player)
@@ -26,7 +26,7 @@ class Mandarin(Card):
         treasures = [card for card in player.in_play if card.is_treasure]
         for card in reversed(treasures):
             player.in_play.remove(card)
-            player.deck.insert(0, card)
+            player.deck.append(card)
 
     @staticmethod
     def _topdeck_priority(card):

--- a/dominion/cards/hinterlands/nomad_camp.py
+++ b/dominion/cards/hinterlands/nomad_camp.py
@@ -15,4 +15,4 @@ class NomadCamp(Card):
 
         if self in player.discard:
             player.discard.remove(self)
-            player.deck.insert(0, self)
+            player.deck.append(self)

--- a/dominion/events/menagerie_events.py
+++ b/dominion/events/menagerie_events.py
@@ -415,7 +415,7 @@ class Transport(Event):
             player.exile.remove(card)
             if card in player.invested_exile:
                 player.invested_exile.remove(card)
-            player.deck.insert(0, card)
+            player.deck.append(card)
             return
 
         available = []

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -2391,7 +2391,7 @@ class GameState:
                 playable_actions.remove(chosen)
                 if chosen in player.in_play:
                     player.in_play.remove(chosen)
-                player.deck.insert(0, chosen)
+                player.deck.append(chosen)
 
         # Plunder Pendant: +$1 per differently-named Treasure in play per Pendant.
         # Calculated before any hand-mutating cleanup hooks fire.
@@ -2515,7 +2515,7 @@ class GameState:
             elif getattr(card, "_frog_topdeck", False):
                 # Menagerie Way of the Frog: topdeck on cleanup.
                 card._frog_topdeck = False
-                player.deck.insert(0, card)
+                player.deck.append(card)
             elif card.name == "Merchant Camp":
                 # Allies Merchant Camp: "When you discard this card from
                 # play, you may put it on top of your deck." We always take
@@ -2530,14 +2530,14 @@ class GameState:
                 card.name == "Walled Village"
                 and getattr(player, "walled_villages_played", 0) <= 1
             ):
-                player.deck.insert(0, card)
+                player.deck.append(card)
             elif (
                 card.name == "Border Guard"
                 and getattr(card, "horn_topdeck_pending", False)
             ):
                 # Renaissance Horn: topdeck this Border Guard during cleanup.
                 card.horn_topdeck_pending = False
-                player.deck.insert(0, card)
+                player.deck.append(card)
             elif (
                 card.is_treasure
                 and getattr(player, "panic_active", False)
@@ -2633,7 +2633,7 @@ class GameState:
 
         # Tireless: put set-aside cards on top of deck after drawing
         for card in tireless_set_aside:
-            player.deck.insert(0, card)
+            player.deck.append(card)
 
         # Nocturne — Faithful Hound: set-aside Hounds return to hand at end of turn
         if getattr(player, "hound_set_aside", None):
@@ -3152,7 +3152,7 @@ class GameState:
             self.supply[card.name] = self.supply.get(card.name, 0) + 1
 
         if destination_is_deck:
-            player.deck.insert(0, actual_card)
+            player.deck.append(actual_card)
         else:
             player.discard.append(actual_card)
 

--- a/tests/test_engine_smoke.py
+++ b/tests/test_engine_smoke.py
@@ -128,8 +128,9 @@ def test_watchtower_topdecks_gained_card():
     # Simulate buying Estate
     gs.supply["Estate"] -= 1
     gained = gs.gain_card(p, choice)
-    # Because AI always chooses 'topdeck' for Watchtower, the gained card should be in deck top, not discard
-    assert p.deck and p.deck[-1].name == "Estate" or p.deck[0].name == "Estate"
+    # Because AI always chooses 'topdeck' for Watchtower, the gained card
+    # should be on the drawable top of the deck, not discard.
+    assert p.deck and p.deck[-1].name == "Estate"
     assert gs.supply["Estate"] == pre_estate - 1  # supply decremented once
 
 
@@ -161,6 +162,7 @@ def test_scheme_topdecks_best_action_on_cleanup():
     p.discard = []
     gs.phase = "cleanup"
     gs.handle_cleanup_phase()
-    # Village should be topdecked (end or start depending on insert) rather than discarded
-    assert any(c.name == "Village" for c in p.deck)
+    # Village was topdecked before cleanup's redraw, so it should be drawn
+    # into the next hand rather than discarded.
+    assert any(c.name == "Village" for c in p.hand)
     assert not any(c.name == "Village" for c in p.discard)

--- a/tests/test_menagerie_ways.py
+++ b/tests/test_menagerie_ways.py
@@ -232,8 +232,10 @@ def test_way_of_the_frog_topdecks_on_cleanup():
     state.handle_treasure_phase()
     state.handle_buy_phase()
     state.handle_cleanup_phase()
-    # Village should be at top of deck (deck[0]) after cleanup
-    assert village in p1.deck
+    # Village was topdecked before cleanup's redraw, so it should be drawn
+    # into the next hand rather than discarded.
+    assert village in p1.hand
+    assert village not in p1.discard
 
 
 def test_way_of_the_chameleon_swaps_cards_and_coins():
@@ -594,7 +596,7 @@ def test_way_of_the_seal_topdecks_subsequent_gain():
     state.supply["Silver"] -= 1
     state.gain_card(p1, silver)
     assert len(p1.deck) == deck_before + 1
-    assert p1.deck[0].name == "Silver"
+    assert p1.deck[-1].name == "Silver"
 
 
 def test_way_of_the_seal_does_not_persist_past_turn():

--- a/tests/test_new_cards.py
+++ b/tests/test_new_cards.py
@@ -90,17 +90,19 @@ def test_harbinger_topdecks_from_discard():
     harbinger = get_card("Harbinger")
     silver = get_card("Silver")
     copper = get_card("Copper")
+    estate = get_card("Estate")
     player.hand = [harbinger]
-    player.deck = [copper]
+    player.deck = [estate, copper]
     player.discard = [silver]
 
     player.hand.remove(harbinger)
     player.in_play.append(harbinger)
     harbinger.on_play(state)
 
-    assert silver in player.deck
+    assert player.draw_cards(1) == [silver]
+    assert estate in player.deck
     assert silver not in player.discard
-    assert len(player.hand) == 1  # drew copper
+    assert copper in player.hand  # drew copper before Harbinger's effect
 
 
 def test_harbinger_empty_discard():
@@ -307,15 +309,69 @@ def test_graverobber_gain_from_trash():
     state, player = _setup(ai)
     graverobber = get_card("Graverobber")
     silver = get_card("Silver")
+    estate = get_card("Estate")
     state.trash = [silver]
     player.hand = [graverobber]
+    player.deck = [estate]
 
     player.hand.remove(graverobber)
     player.in_play.append(graverobber)
     graverobber.on_play(state)
 
     assert silver not in state.trash
-    assert silver in player.deck
+    assert player.draw_cards(1) == [silver]
+    assert estate in player.deck
+
+
+# --- Hinterlands topdeck regressions ---
+
+def test_nomad_camp_on_gain_topdecks_above_existing_deck():
+    ai = GainFirstBuyAI()
+    state, player = _setup(ai, [get_card("Nomad Camp")])
+    nomad_camp = get_card("Nomad Camp")
+    estate = get_card("Estate")
+    player.deck = [estate]
+
+    state.gain_card(player, nomad_camp, from_supply=False)
+
+    assert nomad_camp not in player.discard
+    assert player.draw_cards(1) == [nomad_camp]
+    assert estate in player.deck
+
+
+def test_mandarin_play_topdecks_from_hand_above_existing_deck():
+    ai = GainFirstBuyAI()
+    state, player = _setup(ai, [get_card("Mandarin")])
+    mandarin = get_card("Mandarin")
+    estate = get_card("Estate")
+    silver = get_card("Silver")
+    player.hand = [mandarin, estate, silver]
+    player.deck = [get_card("Copper")]
+
+    player.hand.remove(mandarin)
+    player.in_play.append(mandarin)
+    mandarin.on_play(state)
+
+    assert player.draw_cards(1) == [estate]
+    assert silver in player.hand
+
+
+def test_mandarin_on_gain_topdecks_treasures_above_existing_deck():
+    ai = GainFirstBuyAI()
+    state, player = _setup(ai, [get_card("Mandarin")])
+    mandarin = get_card("Mandarin")
+    copper = get_card("Copper")
+    silver = get_card("Silver")
+    estate = get_card("Estate")
+    player.in_play = [copper, silver]
+    player.deck = [estate]
+
+    state.gain_card(player, mandarin, from_supply=False)
+
+    assert copper not in player.in_play
+    assert silver not in player.in_play
+    assert player.draw_cards(2) == [copper, silver]
+    assert estate in player.deck
 
 
 def test_graverobber_upgrade():

--- a/tests/test_plunder_card.py
+++ b/tests/test_plunder_card.py
@@ -66,9 +66,9 @@ def test_plunder_play_topdecks_gold():
 
     plunder.on_play(state)
 
-    assert player.deck[0].name == "Gold"
+    assert player.deck[-1].name == "Gold"
     assert len(player.deck) == 2
-    assert player.deck[1].name == "Estate"
+    assert player.deck[0].name == "Estate"
     assert state.supply["Gold"] == 4
 
 
@@ -131,8 +131,8 @@ def test_insignia_respects_optional_topdecking():
 
     state.supply["Silver"] -= 1
     state.gain_card(player, get_card("Silver"))
-    assert player.deck[0].name == "Silver"
-    assert player.deck[1].name == "Copper"
+    assert player.deck[-1].name == "Silver"
+    assert player.deck[0].name == "Copper"
     assert not any(card.name == "Silver" for card in player.discard)
 
     state.supply["Estate"] -= 1
@@ -141,8 +141,8 @@ def test_insignia_respects_optional_topdecking():
 
     state.supply["Gold"] -= 1
     state.gain_card(player, get_card("Gold"))
-    assert player.deck[0].name == "Gold"
-    assert player.deck[1].name == "Silver"
+    assert player.deck[-1].name == "Gold"
+    assert player.deck[-2].name == "Silver"
     assert ai.decisions == []
     assert ai.seen_cards == ["Silver", "Estate", "Gold"]
 


### PR DESCRIPTION
Fixes #246.

Several card-specific and shared gain-to-deck effects used `deck.insert(0, ...)`, but this engine draws from `deck.pop()`, making index 0 the bottom of the deck. This updates intended topdeck effects to append to the drawable top while leaving the explicit Sibyl bottomdeck behavior unchanged. Regression tests now draw from non-empty decks to verify the topdecked card is drawn first, and stale assertions were updated to use `deck[-1]` for the deck top.

Validation: `pytest -q` passes with 1361 tests.