### PR TITLE
[codex] Fix topdeck gain placement

### DIFF
--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -3152,7 +3152,7 @@ class GameState:
             self.supply[card.name] = self.supply.get(card.name, 0) + 1
 
         if destination_is_deck:
-            player.deck.insert(0, actual_card)
+            player.deck.append(actual_card)
         else:
             player.discard.append(actual_card)
 

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -27,3 +27,15 @@ def test_player_is_stuck_no_cards_no_supply():
     state = GameState([player])
     state.supply = {"Copper": 0}
     assert state.player_is_stuck(player)
+
+
+def test_gain_card_to_deck_places_card_on_top():
+    player = PlayerState(DummyAI())
+    state = GameState([player])
+    player.deck = [get_card("Estate")]
+
+    state.gain_card(player, get_card("Silver"), to_deck=True)
+
+    assert [card.name for card in player.deck] == ["Estate", "Silver"]
+    drawn = player.draw_cards(1)
+    assert [card.name for card in drawn] == ["Silver"]

--- a/tests/test_menagerie_cards.py
+++ b/tests/test_menagerie_cards.py
@@ -30,7 +30,7 @@ def test_supplies_gain_horse_on_top_of_deck():
     state.supply["Supplies"] = state.supply.get("Supplies", 10)
     state.supply["Supplies"] -= 1
     state.gain_card(p1, supplies)
-    # to_deck=True places at deck[0] per existing trader test convention.
+    # to_deck=True places at deck[-1], which draw_cards pops next.
     assert any(c.name == "Horse" for c in p1.deck)
 
 

--- a/tests/test_menagerie_ways.py
+++ b/tests/test_menagerie_ways.py
@@ -594,7 +594,7 @@ def test_way_of_the_seal_topdecks_subsequent_gain():
     state.supply["Silver"] -= 1
     state.gain_card(p1, silver)
     assert len(p1.deck) == deck_before + 1
-    assert p1.deck[0].name == "Silver"
+    assert p1.deck[-1].name == "Silver"
 
 
 def test_way_of_the_seal_does_not_persist_past_turn():

--- a/tests/test_plunder_card.py
+++ b/tests/test_plunder_card.py
@@ -66,9 +66,9 @@ def test_plunder_play_topdecks_gold():
 
     plunder.on_play(state)
 
-    assert player.deck[0].name == "Gold"
+    assert player.deck[-1].name == "Gold"
     assert len(player.deck) == 2
-    assert player.deck[1].name == "Estate"
+    assert player.deck[0].name == "Estate"
     assert state.supply["Gold"] == 4
 
 
@@ -131,8 +131,8 @@ def test_insignia_respects_optional_topdecking():
 
     state.supply["Silver"] -= 1
     state.gain_card(player, get_card("Silver"))
-    assert player.deck[0].name == "Silver"
-    assert player.deck[1].name == "Copper"
+    assert player.deck[-1].name == "Silver"
+    assert player.deck[0].name == "Copper"
     assert not any(card.name == "Silver" for card in player.discard)
 
     state.supply["Estate"] -= 1
@@ -141,8 +141,8 @@ def test_insignia_respects_optional_topdecking():
 
     state.supply["Gold"] -= 1
     state.gain_card(player, get_card("Gold"))
-    assert player.deck[0].name == "Gold"
-    assert player.deck[1].name == "Silver"
+    assert player.deck[-1].name == "Gold"
+    assert player.deck[-2].name == "Silver"
     assert ai.decisions == []
     assert ai.seen_cards == ["Silver", "Estate", "Gold"]
 

--- a/tests/test_trader.py
+++ b/tests/test_trader.py
@@ -75,7 +75,7 @@ def test_trader_reaction_exchanges_gain_for_silver():
     gained = state.gain_card(player, estate, to_deck=True)
 
     assert gained.name == "Silver"
-    assert player.deck[0].name == "Silver"
+    assert player.deck[-1].name == "Silver"
     assert all(card.name != "Estate" for card in player.deck + player.discard)
     assert state.supply["Estate"] == 8
     assert state.supply["Silver"] == 39


### PR DESCRIPTION
Fixes #245.

The engine draws from the end of `player.deck`, but `gain_card(..., to_deck=True)` inserted gains at index 0, making topdeck gains draw last. This changes `to_deck` gains to append and updates related tests for Trader, Way of the Seal, Plunder, Insignia, and Supplies to expect `deck[-1]` as the top. Validation: `pytest -q` (1359 passed).