### PR TITLE
[codex] Add landscape sanity analysis CLI

### DIFF
--- a/dominion/analysis/landscape_sanity.py
+++ b/dominion/analysis/landscape_sanity.py
@@ -1,0 +1,379 @@
+"""Compare strategy results with and without board landscape pieces.
+
+This module is intended as a quick sanity check for board-specific strategies:
+if a strategy claims support for a board with an Event, Project, or Way, removing
+that piece should usually change the strategy's results. A near-zero delta is a
+signal that the strategy may be ignoring the landscape.
+
+Example:
+
+    python -m dominion.analysis.landscape_sanity \
+        --strategy VictoriaEngine \
+        --board boards/victoria_kingdom.txt \
+        --games 500
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from dominion.ai.genetic_ai import GeneticAI
+from dominion.boards.loader import BoardConfig, load_board
+from dominion.simulation.strategy_battle import StrategyBattle
+
+
+DEFAULT_OPPONENT = "Big Money"
+DEFAULT_SEED = 1729
+DEFAULT_THRESHOLD = 2.0
+
+
+@dataclass(frozen=True, slots=True)
+class LandscapePiece:
+    """A single landscape piece declared by a board file."""
+
+    kind: str
+    name: str
+
+    @property
+    def label(self) -> str:
+        return f"{self.kind}: {self.name}"
+
+
+@dataclass(frozen=True, slots=True)
+class MatchupStats:
+    """Aggregate results for one seeded matchup run."""
+
+    games: int
+    wins: int
+    win_rate: float
+    avg_score: float
+
+
+@dataclass(frozen=True, slots=True)
+class LandscapeSanityResult:
+    """With/without comparison for one landscape piece."""
+
+    piece: LandscapePiece
+    with_piece: MatchupStats
+    without_piece: MatchupStats
+    threshold: float
+
+    @property
+    def win_rate_delta(self) -> float:
+        return self.with_piece.win_rate - self.without_piece.win_rate
+
+    @property
+    def avg_score_delta(self) -> float:
+        return self.with_piece.avg_score - self.without_piece.avg_score
+
+    @property
+    def ignores_landscape(self) -> bool:
+        return abs(self.win_rate_delta) < self.threshold
+
+    @property
+    def status(self) -> str:
+        if self.ignores_landscape:
+            return "ignores landscape"
+        return "uses landscape"
+
+
+def landscape_pieces(board: BoardConfig) -> list[LandscapePiece]:
+    """Return Events, Projects, and Ways declared by ``board``."""
+
+    pieces: list[LandscapePiece] = []
+    pieces.extend(LandscapePiece("Event", name) for name in board.events)
+    pieces.extend(LandscapePiece("Project", name) for name in board.projects)
+    pieces.extend(LandscapePiece("Way", name) for name in board.ways)
+    return pieces
+
+
+def without_landscape_piece(board: BoardConfig, piece: LandscapePiece) -> BoardConfig:
+    """Return a copy of ``board`` with exactly ``piece`` removed."""
+
+    events = list(board.events)
+    projects = list(board.projects)
+    ways = list(board.ways)
+
+    if piece.kind == "Event":
+        events.remove(piece.name)
+    elif piece.kind == "Project":
+        projects.remove(piece.name)
+    elif piece.kind == "Way":
+        ways.remove(piece.name)
+    else:
+        raise ValueError(f"Unsupported landscape kind: {piece.kind}")
+
+    return BoardConfig(
+        kingdom_cards=list(board.kingdom_cards),
+        events=events,
+        projects=projects,
+        ways=ways,
+        landmarks=list(board.landmarks),
+        allies=list(board.allies),
+        traits=dict(board.traits),
+    )
+
+
+def run_seeded_matchup(
+    strategy_name: str,
+    opponent_name: str,
+    board: BoardConfig,
+    games: int,
+    *,
+    seed: int = DEFAULT_SEED,
+    use_shelters: bool = False,
+) -> MatchupStats:
+    """Run ``games`` with deterministic per-game seeds and return target stats."""
+
+    if games <= 0:
+        raise ValueError("games must be positive")
+
+    battle = StrategyBattle(
+        board_config=board,
+        use_shelters=use_shelters,
+        log_frequency=0,
+    )
+
+    if battle.strategy_loader.get_strategy(strategy_name) is None:
+        raise ValueError(f"Could not find strategy: {strategy_name}")
+    if battle.strategy_loader.get_strategy(opponent_name) is None:
+        raise ValueError(f"Could not find opponent strategy: {opponent_name}")
+
+    wins = 0
+    total_score = 0
+    kingdom_cards = list(board.kingdom_cards)
+
+    for game_num in range(games):
+        random.seed(seed + game_num)
+
+        strategy = battle.strategy_loader.get_strategy(strategy_name)
+        opponent = battle.strategy_loader.get_strategy(opponent_name)
+        if strategy is None or opponent is None:
+            raise RuntimeError("Strategy lookup failed after initial validation")
+
+        strategy_ai = GeneticAI(strategy)
+        opponent_ai = GeneticAI(opponent)
+
+        if game_num % 2 == 0:
+            winner, scores, *_ = battle.run_game(strategy_ai, opponent_ai, kingdom_cards)
+        else:
+            winner, scores, *_ = battle.run_game(opponent_ai, strategy_ai, kingdom_cards)
+
+        wins += int(winner == strategy_ai)
+        total_score += scores[strategy_ai.name]
+
+    return MatchupStats(
+        games=games,
+        wins=wins,
+        win_rate=wins / games * 100,
+        avg_score=total_score / games,
+    )
+
+
+def analyze_landscapes(
+    strategy_name: str,
+    board: BoardConfig,
+    *,
+    opponent_name: str = DEFAULT_OPPONENT,
+    games: int = 100,
+    seed: int = DEFAULT_SEED,
+    threshold: float = DEFAULT_THRESHOLD,
+    use_shelters: bool = False,
+) -> list[LandscapeSanityResult]:
+    """Compare full-board results with each landscape piece individually stripped."""
+
+    pieces = landscape_pieces(board)
+    if not pieces:
+        return []
+
+    with_all = run_seeded_matchup(
+        strategy_name,
+        opponent_name,
+        board,
+        games,
+        seed=seed,
+        use_shelters=use_shelters,
+    )
+
+    results: list[LandscapeSanityResult] = []
+    for piece in pieces:
+        stripped_board = without_landscape_piece(board, piece)
+        without_piece = run_seeded_matchup(
+            strategy_name,
+            opponent_name,
+            stripped_board,
+            games,
+            seed=seed,
+            use_shelters=use_shelters,
+        )
+        results.append(
+            LandscapeSanityResult(
+                piece=piece,
+                with_piece=with_all,
+                without_piece=without_piece,
+                threshold=threshold,
+            )
+        )
+
+    return results
+
+
+def _format_pct(value: float, *, signed: bool = False) -> str:
+    if signed:
+        return f"{value:+.1f}%"
+    return f"{value:.1f}%"
+
+
+def _format_num(value: float, *, signed: bool = False) -> str:
+    if signed:
+        return f"{value:+.1f}"
+    return f"{value:.1f}"
+
+
+def render_table(results: Sequence[LandscapeSanityResult]) -> str:
+    """Render results as a fixed-width plain-text table."""
+
+    if not results:
+        return "No Events, Projects, or Ways found on this board."
+
+    rows = [
+        [
+            "Piece",
+            "With WR",
+            "Without WR",
+            "Delta WR",
+            "With Avg",
+            "Without Avg",
+            "Delta Avg",
+            "Status",
+        ]
+    ]
+    for result in results:
+        rows.append(
+            [
+                result.piece.label,
+                _format_pct(result.with_piece.win_rate),
+                _format_pct(result.without_piece.win_rate),
+                _format_pct(result.win_rate_delta, signed=True),
+                _format_num(result.with_piece.avg_score),
+                _format_num(result.without_piece.avg_score),
+                _format_num(result.avg_score_delta, signed=True),
+                result.status,
+            ]
+        )
+
+    widths = [max(len(row[idx]) for row in rows) for idx in range(len(rows[0]))]
+    lines: list[str] = []
+    for row_idx, row in enumerate(rows):
+        lines.append("  ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row)))
+        if row_idx == 0:
+            lines.append("  ".join("-" * width for width in widths))
+    return "\n".join(lines)
+
+
+def render_markdown(results: Sequence[LandscapeSanityResult]) -> str:
+    """Render results as a markdown table."""
+
+    if not results:
+        return "No Events, Projects, or Ways found on this board."
+
+    lines = [
+        "| Piece | With WR | Without WR | Delta WR | With Avg | Without Avg | Delta Avg | Status |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for result in results:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    result.piece.label,
+                    _format_pct(result.with_piece.win_rate),
+                    _format_pct(result.without_piece.win_rate),
+                    _format_pct(result.win_rate_delta, signed=True),
+                    _format_num(result.with_piece.avg_score),
+                    _format_num(result.without_piece.avg_score),
+                    _format_num(result.avg_score_delta, signed=True),
+                    result.status,
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Detect strategies whose results barely change when board landscapes are removed."
+    )
+    parser.add_argument(
+        "--strategy",
+        required=True,
+        help="Strategy identifier accepted by StrategyLoader, e.g. VictoriaEngine.",
+    )
+    parser.add_argument(
+        "--board",
+        required=True,
+        type=Path,
+        help="Board definition file, e.g. boards/victoria_kingdom.txt.",
+    )
+    parser.add_argument(
+        "--opponent",
+        default=DEFAULT_OPPONENT,
+        help=f"Opponent strategy identifier. Default: {DEFAULT_OPPONENT}.",
+    )
+    parser.add_argument("--games", type=int, default=100, help="Games per comparison run.")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_THRESHOLD,
+        help="Win-rate delta threshold, in percentage points, below which a piece is flagged.",
+    )
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Base random seed.")
+    parser.add_argument(
+        "--format",
+        choices=["table", "markdown"],
+        default="table",
+        help="Output format.",
+    )
+    parser.add_argument(
+        "--use-shelters",
+        action="store_true",
+        help="Start games with Shelters instead of Estates.",
+    )
+    parser.add_argument(
+        "--fail-on-ignore",
+        action="store_true",
+        help="Exit with status 1 when any landscape delta is below the threshold.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    board = load_board(args.board)
+    results = analyze_landscapes(
+        args.strategy,
+        board,
+        opponent_name=args.opponent,
+        games=args.games,
+        seed=args.seed,
+        threshold=args.threshold,
+        use_shelters=args.use_shelters,
+    )
+
+    renderer = render_markdown if args.format == "markdown" else render_table
+    print(renderer(results))
+
+    if args.fail_on_ignore and any(result.ignores_landscape for result in results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_landscape_sanity.py
+++ b/tests/test_landscape_sanity.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from dominion.analysis import landscape_sanity
+from dominion.analysis.landscape_sanity import (
+    LandscapePiece,
+    MatchupStats,
+    analyze_landscapes,
+    landscape_pieces,
+    render_markdown,
+    render_table,
+    without_landscape_piece,
+)
+from dominion.boards.loader import BoardConfig, load_board
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VICTORIA_BOARD = REPO_ROOT / "boards" / "victoria_kingdom.txt"
+
+
+def test_landscape_pieces_returns_events_projects_and_ways_in_order():
+    board = BoardConfig(
+        kingdom_cards=["Village"],
+        events=["Windfall"],
+        projects=["Innovation"],
+        ways=["Way of the Butterfly"],
+        landmarks=["Keep"],
+    )
+
+    assert landscape_pieces(board) == [
+        LandscapePiece("Event", "Windfall"),
+        LandscapePiece("Project", "Innovation"),
+        LandscapePiece("Way", "Way of the Butterfly"),
+    ]
+
+
+def test_without_landscape_piece_removes_only_requested_piece():
+    board = BoardConfig(
+        kingdom_cards=["Flag Bearer"],
+        events=["Windfall", "Training"],
+        projects=["Innovation"],
+        ways=["Way of the Butterfly"],
+        allies=["League of Shopkeepers"],
+        traits={"Flag Bearer": "Tireless"},
+    )
+
+    stripped = without_landscape_piece(board, LandscapePiece("Event", "Windfall"))
+
+    assert stripped.events == ["Training"]
+    assert stripped.projects == ["Innovation"]
+    assert stripped.ways == ["Way of the Butterfly"]
+    assert stripped.kingdom_cards == ["Flag Bearer"]
+    assert stripped.allies == ["League of Shopkeepers"]
+    assert stripped.traits == {"Flag Bearer": "Tireless"}
+
+
+def test_analyze_landscapes_flags_near_zero_win_rate_delta(monkeypatch):
+    board = BoardConfig(
+        kingdom_cards=["Stockpile"],
+        events=["Windfall"],
+        ways=["Way of the Butterfly"],
+    )
+    calls: list[BoardConfig] = []
+
+    def fake_run(strategy, opponent, board_config, games, *, seed, use_shelters):
+        calls.append(board_config)
+        if board_config.events and board_config.ways:
+            return MatchupStats(games=games, wins=10, win_rate=100.0, avg_score=50.0)
+        if not board_config.events:
+            return MatchupStats(games=games, wins=10, win_rate=100.0, avg_score=49.0)
+        return MatchupStats(games=games, wins=6, win_rate=60.0, avg_score=34.0)
+
+    monkeypatch.setattr(landscape_sanity, "run_seeded_matchup", fake_run)
+
+    results = analyze_landscapes(
+        "VictoriaEngine",
+        board,
+        opponent_name="Big Money",
+        games=10,
+        threshold=2.0,
+    )
+
+    assert [result.piece.label for result in results] == [
+        "Event: Windfall",
+        "Way: Way of the Butterfly",
+    ]
+    assert results[0].win_rate_delta == 0.0
+    assert results[0].ignores_landscape is True
+    assert results[1].win_rate_delta == 40.0
+    assert results[1].ignores_landscape is False
+    assert len(calls) == 3
+
+
+def test_renderers_include_status_and_score_deltas():
+    result = landscape_sanity.LandscapeSanityResult(
+        piece=LandscapePiece("Event", "Windfall"),
+        with_piece=MatchupStats(games=5, wins=5, win_rate=100.0, avg_score=42.2),
+        without_piece=MatchupStats(games=5, wins=5, win_rate=100.0, avg_score=41.1),
+        threshold=2.0,
+    )
+
+    table = render_table([result])
+    markdown = render_markdown([result])
+
+    assert "Event: Windfall" in table
+    assert "+0.0%" in table
+    assert "+1.1" in table
+    assert "ignores landscape" in table
+    assert "| Event: Windfall |" in markdown
+
+
+def test_main_smoke_runs_victoria_board_with_one_game(capsys):
+    exit_code = landscape_sanity.main(
+        [
+            "--strategy",
+            "VictoriaEngine",
+            "--board",
+            str(VICTORIA_BOARD),
+            "--games",
+            "1",
+            "--seed",
+            "233",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Event: Windfall" in output
+    assert "Way: Way of the Butterfly" in output
+
+
+def test_load_victoria_board_has_expected_landscapes():
+    board = load_board(VICTORIA_BOARD)
+
+    assert landscape_pieces(board) == [
+        LandscapePiece("Event", "Windfall"),
+        LandscapePiece("Way", "Way of the Butterfly"),
+    ]


### PR DESCRIPTION
Adds a landscape sanity analysis CLI for issue #233 that compares a strategy with each Event, Project, and Way enabled versus individually stripped.

The report includes win-rate and average-score deltas, configurable ignore thresholds, table/markdown output, deterministic seeds, and an optional CI failure mode.

Adds focused tests for landscape extraction, stripped-board comparisons, renderers, and a VictoriaEngine smoke run.

Validated with `pytest tests/test_board_loader.py tests/test_trick_scanner.py tests/test_landscape_sanity.py -q`.