### PR TITLE
[codex] Surface strategy decision firings

### DIFF
--- a/dominion/reporting/html_report.py
+++ b/dominion/reporting/html_report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from html import escape
 import io
 import os
 from pathlib import Path
@@ -19,6 +20,67 @@ def fig_to_base64(fig: plt.Figure) -> str:
     fig.savefig(buf, format="png", bbox_inches="tight")
     buf.seek(0)
     return base64.b64encode(buf.read()).decode("ascii")
+
+
+def _decision_firings_section(results: dict) -> str:
+    decision_firings = results.get("decision_firings") or {}
+    if not decision_firings:
+        return ""
+
+    sections = []
+    for role in ("strategy1", "strategy2"):
+        stats = decision_firings.get(role) or {}
+        strategy_name = escape(str(stats.get("strategy_name", role)))
+        rows = []
+
+        for card_name, ways in sorted((stats.get("choose_way") or {}).items()):
+            for way_name, count in sorted(ways.items()):
+                rows.append(
+                    "<tr>"
+                    "<td>choose_way</td>"
+                    f"<td>{escape(str(card_name))}</td>"
+                    f"<td>{escape(str(way_name))}</td>"
+                    f"<td>{count}</td>"
+                    "</tr>"
+                )
+
+        gain_stats = stats.get("choose_gain_overrides") or {}
+        for selection, count in sorted((gain_stats.get("by_selection") or {}).items()):
+            rows.append(
+                "<tr>"
+                "<td>choose_gain special case</td>"
+                "<td>Top priority bypassed</td>"
+                f"<td>{escape(str(selection))}</td>"
+                f"<td>{count}</td>"
+                "</tr>"
+            )
+
+        if not rows:
+            rows.append(
+                "<tr>"
+                "<td>None</td>"
+                "<td>-</td>"
+                "<td>No non-default Way choices or gain special cases</td>"
+                "<td>0</td>"
+                "</tr>"
+            )
+
+        total_gain_overrides = gain_stats.get("total", 0)
+        sections.append(
+            f"""
+            <h3>{strategy_name}</h3>
+            <p>choose_gain special cases: {total_gain_overrides}</p>
+            <table>
+                <tr><th>Decision</th><th>Card / Baseline</th><th>Selected</th><th>Count</th></tr>
+                {''.join(rows)}
+            </table>
+            """
+        )
+
+    return f"""
+    <h2>Decision Firings</h2>
+    {''.join(sections)}
+    """
 
 
 def generate_html_report(results: dict, output_path: Path, *, verbose: bool = False) -> None:
@@ -110,6 +172,7 @@ def generate_html_report(results: dict, output_path: Path, *, verbose: bool = Fa
             log_items += f'<li>Game {game["game_number"]}: No log available</li>'
 
     title = f"{strat1} vs {strat2}"
+    decision_firings_section = _decision_firings_section(results)
 
     html = f"""
     <html>
@@ -119,6 +182,10 @@ def generate_html_report(results: dict, output_path: Path, *, verbose: bool = Fa
             body {{ font-family: Arial, sans-serif; margin: 40px; }}
             h1 {{ text-align: center; }}
             img {{ max-width: 800px; display: block; margin: 20px auto; }}
+            table {{ margin: 20px auto; border-collapse: collapse; width: 80%; }}
+            th, td {{ border: 1px solid #ccc; padding: 8px 12px; text-align: left; }}
+            th {{ background: #f5f5f5; }}
+            tr:nth-child(even) {{ background: #fafafa; }}
         </style>
     </head>
     <body>
@@ -133,6 +200,7 @@ def generate_html_report(results: dict, output_path: Path, *, verbose: bool = Fa
     <img src="data:image/png;base64,{margin_hist}" />
     <h2>Margin by Game</h2>
     <img src="data:image/png;base64,{margin_scatter}" />
+    {decision_firings_section}
     <h2>Game Logs</h2>
     <ul>{log_items}</ul>
     </body>

--- a/dominion/simulation/strategy_battle.py
+++ b/dominion/simulation/strategy_battle.py
@@ -187,11 +187,13 @@ class StrategyBattle:
             player = getattr(state, "current_player", None)
             top_priority = self._top_gain_priority_choice(ai.strategy, state, player, valid_choices)
             selected = original_choose_buy(state, choices)
-            if selected is not None and (
-                top_priority is None or getattr(selected, "name", None) != getattr(top_priority, "name", None)
+            if (
+                selected is not None
+                and top_priority is not None
+                and getattr(selected, "name", None) != getattr(top_priority, "name", None)
             ):
                 selected_name = getattr(selected, "name", str(selected))
-                top_name = getattr(top_priority, "name", "None") if top_priority is not None else "None"
+                top_name = getattr(top_priority, "name", str(top_priority))
                 stats["choose_gain_overrides"]["total"] += 1
                 self._increment_count(
                     stats["choose_gain_overrides"]["by_selection"],

--- a/dominion/simulation/strategy_battle.py
+++ b/dominion/simulation/strategy_battle.py
@@ -121,6 +121,87 @@ class StrategyBattle:
 
         return kingdom_cards, events, projects, ways, allies
 
+    @staticmethod
+    def _empty_decision_firings(strategy_name: str) -> dict[str, Any]:
+        return {
+            "strategy_name": strategy_name,
+            "choose_way": {},
+            "choose_gain_overrides": {
+                "total": 0,
+                "by_selection": {},
+            },
+        }
+
+    @staticmethod
+    def _increment_nested_count(counts: dict[str, Any], first: str, second: str) -> None:
+        counts.setdefault(first, {})
+        counts[first][second] = counts[first].get(second, 0) + 1
+
+    @staticmethod
+    def _increment_count(counts: dict[str, int], key: str) -> None:
+        counts[key] = counts.get(key, 0) + 1
+
+    @staticmethod
+    def _merge_decision_firings(total: dict[str, Any], game: dict[str, Any]) -> None:
+        for card_name, ways in game["choose_way"].items():
+            for way_name, count in ways.items():
+                total["choose_way"].setdefault(card_name, {})
+                total["choose_way"][card_name][way_name] = (
+                    total["choose_way"][card_name].get(way_name, 0) + count
+                )
+
+        total_gain = total["choose_gain_overrides"]
+        game_gain = game["choose_gain_overrides"]
+        total_gain["total"] += game_gain["total"]
+        for selection, count in game_gain["by_selection"].items():
+            total_gain["by_selection"][selection] = total_gain["by_selection"].get(selection, 0) + count
+
+    @staticmethod
+    def _top_gain_priority_choice(strategy: EnhancedStrategy, state, player, choices) -> Optional[Any]:
+        if not choices:
+            return None
+        choose_from_priority = getattr(strategy, "_choose_from_priority", None)
+        if choose_from_priority is None:
+            return None
+        try:
+            return choose_from_priority(strategy.gain_priority, choices, state, player)
+        except Exception:
+            return None
+
+    def _instrument_ai_decisions(self, ai: GeneticAI, stats: dict[str, Any]) -> None:
+        original_choose_way = ai.choose_way
+        original_choose_buy = ai.choose_buy
+
+        def tracked_choose_way(state, card, ways):
+            way = original_choose_way(state, card, ways)
+            if way is not None:
+                self._increment_nested_count(
+                    stats["choose_way"],
+                    getattr(card, "name", str(card)),
+                    getattr(way, "name", str(way)),
+                )
+            return way
+
+        def tracked_choose_buy(state, choices):
+            valid_choices = [c for c in choices if c is not None]
+            player = getattr(state, "current_player", None)
+            top_priority = self._top_gain_priority_choice(ai.strategy, state, player, valid_choices)
+            selected = original_choose_buy(state, choices)
+            if selected is not None and (
+                top_priority is None or getattr(selected, "name", None) != getattr(top_priority, "name", None)
+            ):
+                selected_name = getattr(selected, "name", str(selected))
+                top_name = getattr(top_priority, "name", "None") if top_priority is not None else "None"
+                stats["choose_gain_overrides"]["total"] += 1
+                self._increment_count(
+                    stats["choose_gain_overrides"]["by_selection"],
+                    f"{selected_name} over {top_name}",
+                )
+            return selected
+
+        ai.choose_way = tracked_choose_way
+        ai.choose_buy = tracked_choose_buy
+
     def run_battle(self, strategy1_name: str, strategy2_name: str, num_games: int = 100) -> dict[str, Any]:
         """Run multiple games between two strategies"""
         # Get strategies from loader
@@ -146,6 +227,10 @@ class StrategyBattle:
             "strategy2_total_score": 0,
             "games_played": num_games,
             "detailed_results": [],
+            "decision_firings": {
+                "strategy1": self._empty_decision_firings(strategy1_name),
+                "strategy2": self._empty_decision_firings(strategy2_name),
+            },
         }
 
         # Run the games
@@ -181,12 +266,30 @@ class StrategyBattle:
             # Create fresh AIs for each game using new strategy instances
             ai1 = GeneticAI(strategy1)
             ai2 = GeneticAI(strategy2)
+            game_decision_firings = {
+                "strategy1": self._empty_decision_firings(strategy1_name),
+                "strategy2": self._empty_decision_firings(strategy2_name),
+            }
+            decision_stats_by_ai = {
+                ai1: game_decision_firings["strategy1"],
+                ai2: game_decision_firings["strategy2"],
+            }
 
             # Alternate who goes first
             if game_num % 2 == 0:
-                winner, scores, log_path, turns = self.run_game(ai1, ai2, kingdom_card_names)
+                winner, scores, log_path, turns = self.run_game(
+                    ai1,
+                    ai2,
+                    kingdom_card_names,
+                    decision_stats_by_ai=decision_stats_by_ai,
+                )
             else:
-                winner, scores, log_path, turns = self.run_game(ai2, ai1, kingdom_card_names)
+                winner, scores, log_path, turns = self.run_game(
+                    ai2,
+                    ai1,
+                    kingdom_card_names,
+                    decision_stats_by_ai=decision_stats_by_ai,
+                )
 
             # Record results
             game_result = {
@@ -197,8 +300,17 @@ class StrategyBattle:
                 "margin": abs(scores[ai1.name] - scores[ai2.name]),
                 "turns": turns,
                 "log_path": log_path,
+                "decision_firings": game_decision_firings,
             }
             results["detailed_results"].append(game_result)
+            self._merge_decision_firings(
+                results["decision_firings"]["strategy1"],
+                game_decision_firings["strategy1"],
+            )
+            self._merge_decision_firings(
+                results["decision_firings"]["strategy2"],
+                game_decision_firings["strategy2"],
+            )
 
             if winner == ai1:
                 results["strategy1_wins"] += 1
@@ -223,8 +335,14 @@ class StrategyBattle:
         ai1: GeneticAI,
         ai2: GeneticAI,
         kingdom_card_names: list[str],
+        *,
+        decision_stats_by_ai: Optional[dict[GeneticAI, dict[str, Any]]] = None,
     ) -> tuple[GeneticAI, dict[str, int], Optional[str], int]:
         """Run a single game between two AIs. TODO: This shouldn't be within this class."""
+        if decision_stats_by_ai:
+            for ai, stats in decision_stats_by_ai.items():
+                self._instrument_ai_decisions(ai, stats)
+
         # Start game logging with actual AI objects for better descriptions
         self.logger.start_game([ai1, ai2])
 
@@ -361,6 +479,8 @@ def log_results(results: dict[str, Any]):
     logger.info("  Wins: %d (%.1f%%)", results['strategy2_wins'], results['strategy2_win_rate'])
     logger.info("  Average Score: %.1f", results['strategy2_avg_score'])
 
+    log_decision_firings(results)
+
     logger.info("\nDetailed game results:")
     for game in results["detailed_results"]:
         logger.info("\nGame %d:", game['game_number'])
@@ -376,6 +496,35 @@ def log_results(results: dict[str, Any]):
         logger.info("  Turns: %d", game['turns'])
         if game.get("log_path"):
             logger.info("  Log: %s", game['log_path'])
+
+
+def log_decision_firings(results: dict[str, Any]) -> None:
+    """Print choose_way and choose_gain instrumentation summaries."""
+    decision_firings = results.get("decision_firings") or {}
+    if not decision_firings:
+        return
+
+    logger.info("\nDecision firings:")
+    for role in ("strategy1", "strategy2"):
+        stats = decision_firings.get(role) or {}
+        logger.info("  %s:", stats.get("strategy_name", role))
+
+        way_rows = [
+            (card_name, way_name, count)
+            for card_name, ways in sorted((stats.get("choose_way") or {}).items())
+            for way_name, count in sorted(ways.items())
+        ]
+        if way_rows:
+            logger.info("    choose_way:")
+            for card_name, way_name, count in way_rows:
+                logger.info("      %s -> %s: %d", card_name, way_name, count)
+        else:
+            logger.info("    choose_way: 0")
+
+        gain_stats = stats.get("choose_gain_overrides") or {}
+        logger.info("    choose_gain special cases: %d", gain_stats.get("total", 0))
+        for selection, count in sorted((gain_stats.get("by_selection") or {}).items()):
+            logger.info("      %s: %d", selection, count)
 
 
 if __name__ == "__main__":

--- a/dominion/strategy/strategies/victoria_engine.py
+++ b/dominion/strategy/strategies/victoria_engine.py
@@ -1,4 +1,4 @@
-from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
 
 
 class VictoriaEngine(EnhancedStrategy):
@@ -128,6 +128,10 @@ class VictoriaEngine(EnhancedStrategy):
             PriorityRule("Stockpile"),
             PriorityRule("Silver"),
             PriorityRule("Copper"),
+        ]
+
+        self.way_policy = [
+            WayRule("Flag Bearer", "Way of the Butterfly"),
         ]
 
 

--- a/tests/test_strategy_battle_decision_firings.py
+++ b/tests/test_strategy_battle_decision_firings.py
@@ -54,6 +54,27 @@ def test_choose_gain_bypassing_priority_and_choose_way_are_counted():
     assert stats["choose_way"] == {"Flag Bearer": {"Way of the Butterfly": 1}}
 
 
+def test_custom_choose_gain_without_priority_baseline_is_not_counted_as_override():
+    class DynamicStrategy(EnhancedStrategy):
+        def choose_gain(self, state, player, choices):
+            return next(card for card in choices if card.name == "Smithy")
+
+    strategy = DynamicStrategy()
+    strategy.gain_priority = []
+    ai = GeneticAI(strategy)
+    battle = StrategyBattle()
+    stats = battle._empty_decision_firings("Dynamic Strategy")
+    state = SimpleNamespace(current_player=SimpleNamespace())
+
+    battle._instrument_ai_decisions(ai, stats)
+
+    selected = ai.choose_buy(state, [_card("Smithy"), _card("Silver"), None])
+
+    assert selected.name == "Smithy"
+    assert stats["choose_gain_overrides"]["total"] == 0
+    assert stats["choose_gain_overrides"]["by_selection"] == {}
+
+
 def test_html_decision_firings_section_renders_zero_rows():
     results = {
         "decision_firings": {

--- a/tests/test_strategy_battle_decision_firings.py
+++ b/tests/test_strategy_battle_decision_firings.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+
+from dominion.ai.genetic_ai import GeneticAI
+from dominion.reporting.html_report import _decision_firings_section
+from dominion.simulation.strategy_battle import StrategyBattle
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+def _card(name):
+    return SimpleNamespace(name=name)
+
+
+def test_choose_gain_matching_top_priority_is_not_counted_as_override():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [PriorityRule("Gold"), PriorityRule("Silver")]
+    ai = GeneticAI(strategy)
+    battle = StrategyBattle()
+    stats = battle._empty_decision_firings("Priority Strategy")
+    state = SimpleNamespace(current_player=SimpleNamespace())
+
+    battle._instrument_ai_decisions(ai, stats)
+
+    selected = ai.choose_buy(state, [_card("Gold"), _card("Silver"), None])
+
+    assert selected.name == "Gold"
+    assert stats["choose_gain_overrides"]["total"] == 0
+    assert stats["choose_gain_overrides"]["by_selection"] == {}
+
+
+def test_choose_gain_bypassing_priority_and_choose_way_are_counted():
+    class OverrideStrategy(EnhancedStrategy):
+        def choose_gain(self, state, player, choices):
+            return next(card for card in choices if card.name == "Smithy")
+
+        def choose_way(self, state, player, card, ways):
+            return next(way for way in ways if way is not None and way.name == "Way of the Butterfly")
+
+    strategy = OverrideStrategy()
+    strategy.gain_priority = [PriorityRule("Gold")]
+    ai = GeneticAI(strategy)
+    battle = StrategyBattle()
+    stats = battle._empty_decision_firings("Override Strategy")
+    state = SimpleNamespace(current_player=SimpleNamespace())
+
+    battle._instrument_ai_decisions(ai, stats)
+
+    selected = ai.choose_buy(state, [_card("Gold"), _card("Smithy"), None])
+    way = ai.choose_way(state, _card("Flag Bearer"), [_card("Way of the Butterfly"), None])
+
+    assert selected.name == "Smithy"
+    assert way.name == "Way of the Butterfly"
+    assert stats["choose_gain_overrides"]["total"] == 1
+    assert stats["choose_gain_overrides"]["by_selection"] == {"Smithy over Gold": 1}
+    assert stats["choose_way"] == {"Flag Bearer": {"Way of the Butterfly": 1}}
+
+
+def test_html_decision_firings_section_renders_zero_rows():
+    results = {
+        "decision_firings": {
+            "strategy1": StrategyBattle._empty_decision_firings("No Overrides"),
+            "strategy2": StrategyBattle._empty_decision_firings("Also Quiet"),
+        }
+    }
+
+    section = _decision_firings_section(results)
+
+    assert "Decision Firings" in section
+    assert "No Overrides" in section
+    assert "No non-default Way choices or gain special cases" in section
+    assert "<td>0</td>" in section


### PR DESCRIPTION
Adds per-game and aggregate decision firing instrumentation for StrategyBattle so reports show which choose_way choices fired and when choose_gain bypassed the top gain_priority choice. The HTML report now renders per-strategy Decision Firings tables, and --print emits the same summary for CLI runs. VictoriaEngine now declares the Flag Bearer -> Way of the Butterfly policy so the Victoria board acceptance case exercises the intended trick. Validated with pytest -q tests/test_strategy_battle_decision_firings.py tests/test_way_policy.py and git diff --check.