### PR TITLE
[codex] Fix board trait setup for Supplies strategies

### DIFF
--- a/dominion/boards/loader.py
+++ b/dominion/boards/loader.py
@@ -32,11 +32,11 @@ def _normalise_entry(entry: str) -> str:
 def _parse_trait_value(value: str) -> tuple[str, str]:
     """Return ``(trait_name, card_name)`` for supported Trait line formats."""
 
-    trait_name, separator, card_name = value.partition("-")
-    if separator:
-        return trait_name.strip(), card_name.strip()
-
     match = re.fullmatch(r"(.+?)\s*\((.+)\)", value)
+    if match:
+        return match.group(1).strip(), match.group(2).strip()
+
+    match = re.fullmatch(r"(.+?)\s+-\s+(.+)", value)
     if match:
         return match.group(1).strip(), match.group(2).strip()
 

--- a/dominion/boards/loader.py
+++ b/dominion/boards/loader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+import re
 
 
 @dataclass(slots=True)
@@ -26,6 +27,20 @@ def _normalise_entry(entry: str) -> str:
     if not value:
         raise ValueError("Board entry cannot be empty")
     return value
+
+
+def _parse_trait_value(value: str) -> tuple[str, str]:
+    """Return ``(trait_name, card_name)`` for supported Trait line formats."""
+
+    trait_name, separator, card_name = value.partition("-")
+    if separator:
+        return trait_name.strip(), card_name.strip()
+
+    match = re.fullmatch(r"(.+?)\s*\((.+)\)", value)
+    if match:
+        return match.group(1).strip(), match.group(2).strip()
+
+    return "", ""
 
 
 def _parse_special_line(line: str, config: BoardConfig) -> bool:
@@ -57,10 +72,8 @@ def _parse_special_line(line: str, config: BoardConfig) -> bool:
     elif key == "ally":
         config.allies.append(value)
     elif key == "trait":
-        # Format: "Trait: TraitName - CardName"
-        trait_name, _, card_name = value.partition("-")
-        trait_name = trait_name.strip()
-        card_name = card_name.strip()
+        # Formats: "Trait: TraitName - CardName" or "Trait: TraitName (CardName)".
+        trait_name, card_name = _parse_trait_value(value)
         if trait_name and card_name:
             config.traits[card_name] = trait_name
     else:
@@ -99,4 +112,3 @@ def load_board(path: Path | str) -> BoardConfig:
         raise ValueError(f"Board file {board_path} does not list any kingdom cards")
 
     return config
-

--- a/dominion/cards/menagerie/supplies.py
+++ b/dominion/cards/menagerie/supplies.py
@@ -3,6 +3,9 @@
 from ..base_card import Card, CardCost, CardStats, CardType
 
 
+HORSE_PILE_COUNT = 30
+
+
 class Supplies(Card):
     """$1. When you gain this, gain a Horse, putting it on top of your deck."""
 
@@ -13,6 +16,9 @@ class Supplies(Card):
             stats=CardStats(coins=1),
             types=[CardType.TREASURE],
         )
+
+    def get_additional_non_supply_piles(self) -> dict[str, int]:
+        return {"Horse": HORSE_PILE_COUNT}
 
     def on_gain(self, game_state, player):
         super().on_gain(game_state, player)

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -260,6 +260,7 @@ class GameState:
         prophecy: object = None,
         riverboat_set_aside: Card = None,
         landmarks: list = None,
+        draw_initial_hands: bool = True,
     ):
         """Set up the game with given AIs and kingdom cards."""
         # Reset per-game state on the reused ``GameState`` so artifacts from
@@ -336,7 +337,11 @@ class GameState:
 
         # Initialize players
         for player in self.players:
-            player.initialize(use_shelters, heirlooms=heirlooms)
+            player.initialize(
+                use_shelters,
+                heirlooms=heirlooms,
+                draw_initial_hand=draw_initial_hands,
+            )
 
         # Nocturne: setup Boons-related infrastructure when needed.
         needs_boons = any(

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -209,7 +209,13 @@ class PlayerState:
     # be played at the start of the next turn.
     farmhands_set_aside: list[Card] = field(default_factory=list)
 
-    def initialize(self, use_shelters: bool = False, heirlooms: list[str] = None):
+    def initialize(
+        self,
+        use_shelters: bool = False,
+        heirlooms: list[str] = None,
+        *,
+        draw_initial_hand: bool = True,
+    ):
         """Set up starting deck and draw initial hand.
 
         If ``use_shelters`` is ``True``, start with Necropolis, Hovel and
@@ -217,6 +223,8 @@ class PlayerState:
 
         ``heirlooms`` is a list of Heirloom card names (Nocturne). For each
         heirloom, one starting Copper is replaced with the matching Heirloom.
+        ``draw_initial_hand`` allows game setup code to apply start-of-game
+        effects to the shuffled deck before the opening hand is drawn.
         """
 
         # Create starting deck
@@ -388,7 +396,8 @@ class PlayerState:
         self.farmhands_set_aside = []
 
         # Draw initial hand of 5 cards
-        self.draw_cards(5)
+        if draw_initial_hand:
+            self.draw_cards(5)
 
     def draw_cards(self, count: int) -> list[Card]:
         """Draw specified number of cards from deck, shuffling if needed."""

--- a/dominion/simulation/strategy_battle.py
+++ b/dominion/simulation/strategy_battle.py
@@ -481,6 +481,7 @@ class StrategyBattle:
             ways,
             allies,
         )
+        delay_initial_draw = bool(self.board_config and self.board_config.traits)
         game_state.initialize_game(
             [ai1, ai2],
             kingdom_cards,
@@ -489,9 +490,13 @@ class StrategyBattle:
             projects=project_objs,
             ways=way_objs,
             allies=ally_objs,
+            draw_initial_hands=not delay_initial_draw,
         )
 
         self._apply_board_traits(game_state)
+        if delay_initial_draw:
+            for player in game_state.players:
+                player.draw_cards(5)
 
         # Run game
         while not game_state.is_game_over():

--- a/dominion/simulation/strategy_battle.py
+++ b/dominion/simulation/strategy_battle.py
@@ -18,6 +18,7 @@ from dominion.reporting.html_report import generate_html_report
 from dominion.simulation.game_logger import GameLogger
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
 from dominion.strategy.strategy_loader import StrategyLoader
+from dominion.traits import apply_trait
 from dominion.ways.registry import WAY_TYPES, get_way
 
 logger = getLogger(__name__)
@@ -202,6 +203,15 @@ class StrategyBattle:
         allies = [get_ally(name) for name in ally_names or []]
 
         return kingdom_cards, events, projects, ways, allies
+
+    def _apply_board_traits(self, game_state: GameState) -> None:
+        """Apply Plunder traits declared by the loaded board config."""
+
+        if not self.board_config:
+            return
+
+        for card_name, trait in self.board_config.traits.items():
+            apply_trait(game_state, trait, card_name)
 
     @staticmethod
     def _empty_decision_firings(strategy_name: str) -> dict[str, Any]:
@@ -481,11 +491,7 @@ class StrategyBattle:
             allies=ally_objs,
         )
 
-        # Apply traits from board config
-        if self.board_config:
-            for card_name, trait in self.board_config.traits.items():
-                if trait.lower() == "tireless":
-                    game_state.tireless_piles.add(card_name)
+        self._apply_board_traits(game_state)
 
         # Run game
         while not game_state.is_game_over():

--- a/tests/test_board_loader.py
+++ b/tests/test_board_loader.py
@@ -115,6 +115,30 @@ def test_strategy_battle_applies_board_traits():
     assert state.pile_traits["Supplies"] == "Inspiring"
 
 
+def test_strategy_battle_applies_inherited_trait_before_initial_hands(monkeypatch, tmp_path):
+    board = BoardConfig(["Supplies"], traits={"Supplies": "Inherited"})
+    battle = StrategyBattle(
+        board_config=board,
+        log_folder=str(tmp_path),
+        log_frequency=0,
+    )
+    hands: list[list[str]] = []
+
+    monkeypatch.setattr("dominion.game.player_state.random.shuffle", lambda deck: None)
+    monkeypatch.setattr(GameState, "is_game_over", lambda self: True)
+
+    def capture_end_game(winner, scores, supply_state, players):
+        hands.extend([[card.name for card in player.hand] for player in players])
+        return None
+
+    battle.logger.end_game = capture_end_game
+
+    battle.run_game(DummyAI(), DummyAI(), board.kingdom_cards)
+
+    assert hands
+    assert all("Supplies" in hand for hand in hands)
+
+
 def test_strategy_battle_splits_implicit_event_references():
     strategy = EnhancedStrategy()
     strategy.gain_priority = [

--- a/tests/test_board_loader.py
+++ b/tests/test_board_loader.py
@@ -66,6 +66,20 @@ def test_load_board_parses_trait_parenthetical_format(tmp_path):
     assert board.traits == {"Armory": "Shy"}
 
 
+def test_load_board_parses_parenthetical_trait_with_hyphenated_card(tmp_path):
+    path = write_board(
+        tmp_path,
+        """
+        Ill-Gotten Gains
+        Trait: Shy (Ill-Gotten Gains)
+        """,
+    )
+
+    board = load_board(path)
+
+    assert board.traits == {"Ill-Gotten Gains": "Shy"}
+
+
 def test_strategy_battle_prepares_landscapes(tmp_path):
     path = write_board(
         tmp_path,

--- a/tests/test_board_loader.py
+++ b/tests/test_board_loader.py
@@ -3,8 +3,11 @@ from pathlib import Path
 import pytest
 
 from dominion.boards.loader import BoardConfig, load_board
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
 from dominion.simulation.strategy_battle import StrategyBattle
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+from tests.utils import DummyAI
 
 
 def write_board(tmp_path: Path, contents: str) -> Path:
@@ -35,6 +38,34 @@ def test_load_board_parses_kingdom_and_landscapes(tmp_path):
     assert board.events == ["Gamble"]
 
 
+def test_load_board_parses_trait_dash_format(tmp_path):
+    path = write_board(
+        tmp_path,
+        """
+        Supplies
+        Trait: Inspiring - Supplies
+        """,
+    )
+
+    board = load_board(path)
+
+    assert board.traits == {"Supplies": "Inspiring"}
+
+
+def test_load_board_parses_trait_parenthetical_format(tmp_path):
+    path = write_board(
+        tmp_path,
+        """
+        Armory
+        Trait: Shy (Armory)
+        """,
+    )
+
+    board = load_board(path)
+
+    assert board.traits == {"Armory": "Shy"}
+
+
 def test_strategy_battle_prepares_landscapes(tmp_path):
     path = write_board(
         tmp_path,
@@ -56,6 +87,18 @@ def test_strategy_battle_prepares_landscapes(tmp_path):
     assert [project.name for project in projects] == board.projects
     assert [way.name for way in ways] == board.ways
     assert allies == []
+
+
+def test_strategy_battle_applies_board_traits():
+    board = BoardConfig(["Supplies"], traits={"Supplies": "Inspiring"})
+    battle = StrategyBattle(board_config=board)
+    state = GameState(players=[])
+    state.initialize_game([DummyAI(), DummyAI()], [get_card("Supplies")])
+
+    battle._apply_board_traits(state)
+
+    assert state.trait_piles["Inspiring"] == "Supplies"
+    assert state.pile_traits["Supplies"] == "Inspiring"
 
 
 def test_strategy_battle_splits_implicit_event_references():

--- a/tests/test_menagerie_cards.py
+++ b/tests/test_menagerie_cards.py
@@ -34,6 +34,26 @@ def test_supplies_gain_horse_on_top_of_deck():
     assert any(c.name == "Horse" for c in p1.deck)
 
 
+def test_supplies_registers_horse_non_supply_pile():
+    state = GameState(players=[])
+    state.initialize_game([DummyAI(), DummyAI()], [get_card("Supplies")])
+
+    assert state.supply["Horse"] == 30
+    assert "Horse" in state.non_supply_pile_names
+
+
+def test_supplies_gains_horse_when_in_kingdom():
+    state = GameState(players=[])
+    state.initialize_game([DummyAI(), DummyAI()], [get_card("Supplies")])
+    p1 = state.players[0]
+
+    state.supply["Supplies"] -= 1
+    state.gain_card(p1, get_card("Supplies"))
+
+    assert state.supply["Horse"] == 29
+    assert any(c.name == "Horse" for c in p1.deck)
+
+
 def test_camel_train_exiles_non_victory():
     state, p1, _ = _two_player_state()
     p1.actions = 1


### PR DESCRIPTION
## Summary

Fix board-configured Plunder traits so strategy battles apply the parsed trait through the shared trait registry instead of only handling Tireless. Register the Horse non-supply pile when Supplies is in the kingdom, allowing Supplies gains to topdeck Horses as intended. Also accept both dash and parenthetical board trait syntax, and add regression coverage for trait parsing, trait application, and Supplies/Horse setup.

## Validation

- `pytest -q tests/test_board_loader.py tests/test_menagerie_cards.py::test_supplies_registers_horse_non_supply_pile tests/test_menagerie_cards.py::test_supplies_gains_horse_when_in_kingdom tests/test_menagerie_cards.py::test_supplies_gain_horse_on_top_of_deck tests/test_plunder_traits.py`
- `pytest -q tests/test_strategy_battle_deterministic.py tests/test_strategy_battle_decision_firings.py tests/test_compare_all_strategies.py tests/test_landscape_sanity.py`
- `pytest -q tests/test_menagerie_cards.py tests/test_menagerie_events.py tests/test_menagerie_ways.py tests/test_board_loader.py`