### PR TITLE
[codex] fix landmark board setup

### DIFF
--- a/compare_all_strategies.py
+++ b/compare_all_strategies.py
@@ -24,6 +24,7 @@ def _missing_board_components(
     missing_ways = {canonical_way_name(w) for w in refs.ways} - {
         canonical_way_name(w) for w in board_config.ways
     }
+    missing_landmarks = set(refs.landmarks) - set(board_config.landmarks)
     missing_allies = set(refs.allies) - set(board_config.allies)
 
     missing = [
@@ -31,6 +32,7 @@ def _missing_board_components(
         f"events: {', '.join(sorted(missing_events))}" if missing_events else "",
         f"projects: {', '.join(sorted(missing_projects))}" if missing_projects else "",
         f"ways: {', '.join(sorted(missing_ways))}" if missing_ways else "",
+        f"landmarks: {', '.join(sorted(missing_landmarks))}" if missing_landmarks else "",
         f"allies: {', '.join(sorted(missing_allies))}" if missing_allies else "",
     ]
     return [entry for entry in missing if entry]

--- a/compare_all_strategies.py
+++ b/compare_all_strategies.py
@@ -8,6 +8,7 @@ from dominion.boards.loader import BoardConfig, load_board
 from dominion.simulation.strategy_battle import (
     StrategyBattle,
     StrategyBoardReferences,
+    canonical_landmark_name,
     canonical_way_name,
 )
 from dominion.reporting.html_report import generate_leaderboard_html
@@ -24,7 +25,11 @@ def _missing_board_components(
     missing_ways = {canonical_way_name(w) for w in refs.ways} - {
         canonical_way_name(w) for w in board_config.ways
     }
-    missing_landmarks = set(refs.landmarks) - set(board_config.landmarks)
+    missing_landmarks = {
+        canonical_landmark_name(l) for l in refs.landmarks
+    } - {
+        canonical_landmark_name(l) for l in board_config.landmarks
+    }
     missing_allies = set(refs.allies) - set(board_config.allies)
 
     missing = [

--- a/dominion/boards/loader.py
+++ b/dominion/boards/loader.py
@@ -43,6 +43,20 @@ def _parse_trait_value(value: str) -> tuple[str, str]:
     return "", ""
 
 
+def _parse_landmark_value(value: str) -> str:
+    """Return a normalized Landmark entry.
+
+    Obelisk has a setup-time chosen pile. Board files can express that as
+    ``Landmark: Obelisk (Temple)`` or ``Landmark: Obelisk - Temple``; the
+    registry understands the parenthetical form.
+    """
+
+    landmark_name, chosen_pile = _parse_trait_value(value)
+    if landmark_name and chosen_pile and landmark_name == "Obelisk":
+        return f"{landmark_name} ({chosen_pile})"
+    return value
+
+
 def _parse_special_line(line: str, config: BoardConfig) -> bool:
     """Attempt to parse a special prefix line like ``Way: Foo``.
 
@@ -68,7 +82,7 @@ def _parse_special_line(line: str, config: BoardConfig) -> bool:
         # parametric-Way regex resolves the target.
         config.ways.append(f"{prefix.strip()} ({value})")
     elif key == "landmark":
-        config.landmarks.append(value)
+        config.landmarks.append(_parse_landmark_value(value))
     elif key == "ally":
         config.allies.append(value)
     elif key == "trait":

--- a/dominion/landmarks/landmarks.py
+++ b/dominion/landmarks/landmarks.py
@@ -328,14 +328,33 @@ class Museum(Landmark):
 class Obelisk(Landmark):
     """Setup: choose an Action Supply pile. End: +2 VP per copy you have from that pile."""
 
-    def __init__(self):
+    def __init__(self, chosen_pile: str = ""):
         super().__init__(
             name="Obelisk",
             description="+2 VP per copy of the chosen Action pile.",
         )
+        self.chosen_pile = chosen_pile
 
     def setup(self, game_state) -> None:
         from dominion.cards.registry import get_card
+
+        if self.chosen_pile:
+            try:
+                card = get_card(self.chosen_pile)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Obelisk chosen pile is not a known card: {self.chosen_pile}"
+                ) from exc
+            if (
+                self.chosen_pile not in game_state.supply
+                or not card.is_action
+                or card.is_victory
+            ):
+                raise ValueError(
+                    "Obelisk chosen pile must be a non-Victory Action Supply pile: "
+                    f"{self.chosen_pile}"
+                )
+            return
 
         # Pick the first Action pile in supply alphabetically (deterministic).
         candidates = []

--- a/dominion/landmarks/landmarks.py
+++ b/dominion/landmarks/landmarks.py
@@ -345,6 +345,7 @@ class Obelisk(Landmark):
                 raise ValueError(
                     f"Obelisk chosen pile is not a known card: {self.chosen_pile}"
                 ) from exc
+            self.chosen_pile = card.name
             if (
                 self.chosen_pile not in game_state.supply
                 or not card.is_action

--- a/dominion/landmarks/registry.py
+++ b/dominion/landmarks/registry.py
@@ -1,5 +1,6 @@
 """Registry of Empires Landmarks."""
 
+import re
 from typing import Type
 
 from .base_landmark import Landmark
@@ -51,8 +52,18 @@ LANDMARK_TYPES: dict[str, Type[Landmark]] = {
     "Wolf Den": WolfDen,
 }
 
+_PARAMETRIC_LANDMARK_RE = re.compile(r"^(?P<name>.+?)\s*\((?P<target>.+)\)$")
+
 
 def get_landmark(name: str) -> Landmark:
+    match = _PARAMETRIC_LANDMARK_RE.fullmatch(name)
+    if match:
+        landmark_name = match.group("name").strip()
+        target = match.group("target").strip()
+        if landmark_name != "Obelisk":
+            raise ValueError(f"Landmark does not support a chosen pile: {name}")
+        return Obelisk(chosen_pile=target)
+
     try:
         cls = LANDMARK_TYPES[name]
     except KeyError as exc:

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -401,6 +401,7 @@ class GeneticTrainer:
                         "events": board_references.events,
                         "projects": board_references.projects,
                         "ways": board_references.ways,
+                        "landmarks": board_references.landmarks,
                         "allies": board_references.allies,
                     }.items()
                     if value

--- a/dominion/simulation/strategy_battle.py
+++ b/dominion/simulation/strategy_battle.py
@@ -13,6 +13,7 @@ from dominion.boards.loader import BoardConfig, load_board
 from dominion.cards.registry import CARD_ALIASES, CARD_TYPES, get_card
 from dominion.events.registry import EVENT_TYPES, get_event
 from dominion.game.game_state import GameState
+from dominion.landmarks.registry import LANDMARK_TYPES, get_landmark
 from dominion.projects.registry import PROJECT_TYPES, get_project
 from dominion.reporting.html_report import generate_html_report
 from dominion.simulation.game_logger import GameLogger
@@ -62,6 +63,7 @@ class StrategyBoardReferences:
     events: list[str]
     projects: list[str]
     ways: list[str]
+    landmarks: list[str]
     allies: list[str]
 
 
@@ -135,6 +137,14 @@ class StrategyBattle:
         match = re.match(r"^(Way of the Mouse)\s*\((.+)\)$", name)
         return bool(match and match.group(1) in WAY_TYPES)
 
+    @staticmethod
+    def _is_landmark_reference(name: str) -> bool:
+        if name in LANDMARK_TYPES:
+            return True
+
+        match = re.match(r"^(.+?)\s*\(.+\)$", name)
+        return bool(match and match.group(1) in LANDMARK_TYPES)
+
     def _split_board_references(self, names: set[str]) -> StrategyBoardReferences:
         """Split strategy references into cards and supported landscapes."""
 
@@ -142,6 +152,7 @@ class StrategyBattle:
         events: list[str] = []
         projects: list[str] = []
         ways: list[str] = []
+        landmarks: list[str] = []
         allies: list[str] = []
 
         for name in sorted(names):
@@ -156,6 +167,8 @@ class StrategyBattle:
                 projects.append(name)
             elif self._is_way_reference(name):
                 ways.append(name)
+            elif self._is_landmark_reference(name):
+                landmarks.append(name)
             elif name in ALLY_TYPES:
                 allies.append(name)
             else:
@@ -163,14 +176,23 @@ class StrategyBattle:
                 # references: board preparation will raise Unknown card.
                 kingdom_cards.append(name)
 
-        return StrategyBoardReferences(kingdom_cards, events, projects, ways, allies)
+        return StrategyBoardReferences(kingdom_cards, events, projects, ways, landmarks, allies)
 
     def _determine_board_references(
         self, strat1: EnhancedStrategy, strat2: EnhancedStrategy
     ) -> StrategyBoardReferences:
         """Compute cards and landscapes from both strategies if not explicitly set."""
         if self.kingdom_cards is not None:
-            return StrategyBoardReferences(self.kingdom_cards, [], [], [], [])
+            if self.board_config:
+                return StrategyBoardReferences(
+                    self.kingdom_cards,
+                    list(self.board_config.events),
+                    list(self.board_config.projects),
+                    list(self.board_config.ways),
+                    list(self.board_config.landmarks),
+                    list(self.board_config.allies),
+                )
+            return StrategyBoardReferences(self.kingdom_cards, [], [], [], [], [])
 
         all_names = self._extract_cards_from_strategy(strat1) | self._extract_cards_from_strategy(strat2)
         return self._split_board_references(all_names)
@@ -185,6 +207,7 @@ class StrategyBattle:
         event_names: Optional[list[str]] = None,
         project_names: Optional[list[str]] = None,
         way_names: Optional[list[str]] = None,
+        landmark_names: Optional[list[str]] = None,
         ally_names: Optional[list[str]] = None,
     ):
         """Instantiate cards and landscape components for a game."""
@@ -195,14 +218,16 @@ class StrategyBattle:
             event_names = self.board_config.events
             project_names = self.board_config.projects
             way_names = self.board_config.ways
+            landmark_names = self.board_config.landmarks
             ally_names = self.board_config.allies
 
         events = [get_event(name) for name in event_names or []]
         projects = [get_project(name) for name in project_names or []]
         ways = [get_way(name) for name in way_names or []]
+        landmarks = [get_landmark(name) for name in landmark_names or []]
         allies = [get_ally(name) for name in ally_names or []]
 
-        return kingdom_cards, events, projects, ways, allies
+        return kingdom_cards, events, projects, ways, landmarks, allies
 
     def _apply_board_traits(self, game_state: GameState) -> None:
         """Apply Plunder traits declared by the loaded board config."""
@@ -396,6 +421,7 @@ class StrategyBattle:
                     events=board_references.events,
                     projects=board_references.projects,
                     ways=board_references.ways,
+                    landmarks=board_references.landmarks,
                     allies=board_references.allies,
                 )
             else:
@@ -407,6 +433,7 @@ class StrategyBattle:
                     events=board_references.events,
                     projects=board_references.projects,
                     ways=board_references.ways,
+                    landmarks=board_references.landmarks,
                     allies=board_references.allies,
                 )
 
@@ -459,6 +486,7 @@ class StrategyBattle:
         events: Optional[list[str]] = None,
         projects: Optional[list[str]] = None,
         ways: Optional[list[str]] = None,
+        landmarks: Optional[list[str]] = None,
         allies: Optional[list[str]] = None,
     ) -> tuple[GeneticAI, dict[str, int], Optional[str], int]:
         """Run a single game between two AIs. TODO: This shouldn't be within this class."""
@@ -474,11 +502,12 @@ class StrategyBattle:
         game_state.set_logger(self.logger)
 
         # Initialize game
-        kingdom_cards, event_objs, project_objs, way_objs, ally_objs = self._prepare_board_components(
+        kingdom_cards, event_objs, project_objs, way_objs, landmark_objs, ally_objs = self._prepare_board_components(
             kingdom_card_names,
             events,
             projects,
             ways,
+            landmarks,
             allies,
         )
         game_state.initialize_game(
@@ -488,6 +517,7 @@ class StrategyBattle:
             events=event_objs,
             projects=project_objs,
             ways=way_objs,
+            landmarks=landmark_objs,
             allies=ally_objs,
             traits=self.board_config.traits if self.board_config else None,
         )

--- a/dominion/simulation/strategy_battle.py
+++ b/dominion/simulation/strategy_battle.py
@@ -148,7 +148,7 @@ class StrategyBattle:
             return True
 
         match = re.match(r"^(.+?)\s*\(.+\)$", name)
-        return bool(match and match.group(1) in LANDMARK_TYPES)
+        return bool(match and match.group(1) == "Obelisk")
 
     def _split_board_references(self, names: set[str]) -> StrategyBoardReferences:
         """Split strategy references into cards and supported landscapes."""

--- a/dominion/simulation/strategy_battle.py
+++ b/dominion/simulation/strategy_battle.py
@@ -72,6 +72,11 @@ def canonical_way_name(way: str) -> str:
     return _WAY_PARAM_RE.sub("", way)
 
 
+def canonical_landmark_name(landmark: str) -> str:
+    """Return the runtime Landmark.name for a board or strategy reference."""
+    return _WAY_PARAM_RE.sub("", landmark)
+
+
 # Set up module-level logger
 logger = logging.getLogger(__name__)
 

--- a/tests/test_board_loader.py
+++ b/tests/test_board_loader.py
@@ -67,6 +67,21 @@ def test_load_board_parses_trait_parenthetical_format(tmp_path):
     assert board.traits == {"Armory": "Shy"}
 
 
+def test_load_board_parses_obelisk_chosen_pile(tmp_path):
+    path = write_board(
+        tmp_path,
+        """
+        Temple
+        Ironmonger
+        Landmark: Obelisk - Temple
+        """,
+    )
+
+    board = load_board(path)
+
+    assert board.landmarks == ["Obelisk (Temple)"]
+
+
 def test_load_board_parses_parenthetical_trait_with_hyphenated_card(tmp_path):
     path = write_board(
         tmp_path,
@@ -89,19 +104,42 @@ def test_strategy_battle_prepares_landscapes(tmp_path):
         Ironmonger
         Way: Way of the Butterfly
         Project: Innovation
+        Landmark: Obelisk (Ironmonger)
         """,
     )
 
     board = load_board(path)
     battle = StrategyBattle(board_config=board)
 
-    kingdom, events, projects, ways, allies = battle._prepare_board_components(board.kingdom_cards)
+    kingdom, events, projects, ways, landmarks, allies = battle._prepare_board_components(board.kingdom_cards)
 
     assert [card.name for card in kingdom] == board.kingdom_cards
     assert events == []
     assert [project.name for project in projects] == board.projects
     assert [way.name for way in ways] == board.ways
+    assert [landmark.name for landmark in landmarks] == ["Obelisk"]
+    assert landmarks[0].chosen_pile == "Ironmonger"
     assert allies == []
+
+
+def test_strategy_battle_passes_board_landmarks_to_game(monkeypatch):
+    board = BoardConfig(["Village"], landmarks=["Obelisk (Village)"])
+    battle = StrategyBattle(board_config=board, log_frequency=0)
+    captured_landmarks = []
+
+    original_initialize = GameState.initialize_game
+
+    def capture_initialize(self, *args, **kwargs):
+        captured_landmarks.extend(kwargs.get("landmarks") or [])
+        return original_initialize(self, *args, **kwargs)
+
+    monkeypatch.setattr(GameState, "initialize_game", capture_initialize)
+    monkeypatch.setattr(GameState, "is_game_over", lambda self: True)
+
+    battle.run_game(DummyAI(), DummyAI(), board.kingdom_cards)
+
+    assert [landmark.name for landmark in captured_landmarks] == ["Obelisk"]
+    assert captured_landmarks[0].chosen_pile == "Village"
 
 
 def test_strategy_battle_applies_board_traits():
@@ -165,11 +203,12 @@ def test_strategy_battle_splits_implicit_event_references():
 
     battle = StrategyBattle()
     refs = battle._determine_board_references(strategy, EnhancedStrategy())
-    kingdom, events, projects, ways, allies = battle._prepare_board_components(
+    kingdom, events, projects, ways, landmarks, allies = battle._prepare_board_components(
         refs.kingdom_cards,
         refs.events,
         refs.projects,
         refs.ways,
+        refs.landmarks,
         refs.allies,
     )
 
@@ -177,6 +216,7 @@ def test_strategy_battle_splits_implicit_event_references():
     assert [event.name for event in events] == ["Looting"]
     assert projects == []
     assert ways == []
+    assert landmarks == []
     assert allies == []
 
 

--- a/tests/test_compare_all_strategies.py
+++ b/tests/test_compare_all_strategies.py
@@ -13,6 +13,7 @@ def test_board_compatibility_canonicalizes_parametric_way_names():
         events=[],
         projects=[],
         ways=["Way of the Mouse"],
+        landmarks=[],
         allies=[],
     )
 

--- a/tests/test_compare_all_strategies.py
+++ b/tests/test_compare_all_strategies.py
@@ -1,6 +1,6 @@
 from compare_all_strategies import _missing_board_components
 from dominion.boards.loader import BoardConfig
-from dominion.simulation.strategy_battle import StrategyBoardReferences
+from dominion.simulation.strategy_battle import StrategyBattle, StrategyBoardReferences
 
 
 def test_board_compatibility_canonicalizes_parametric_way_names():
@@ -35,3 +35,12 @@ def test_board_compatibility_canonicalizes_parametric_obelisk_name():
     )
 
     assert _missing_board_components(refs, board, set(board.kingdom_cards)) == []
+
+
+def test_only_obelisk_is_treated_as_parametric_landmark_reference():
+    battle = StrategyBattle()
+
+    refs = battle._split_board_references({"Bandit Fort (Village)"})
+
+    assert refs.landmarks == []
+    assert refs.kingdom_cards == ["Bandit Fort (Village)"]

--- a/tests/test_compare_all_strategies.py
+++ b/tests/test_compare_all_strategies.py
@@ -18,3 +18,20 @@ def test_board_compatibility_canonicalizes_parametric_way_names():
     )
 
     assert _missing_board_components(refs, board, set(board.kingdom_cards)) == []
+
+
+def test_board_compatibility_canonicalizes_parametric_obelisk_name():
+    board = BoardConfig(
+        kingdom_cards=["Temple", "Village"],
+        landmarks=["Obelisk (Temple)"],
+    )
+    refs = StrategyBoardReferences(
+        kingdom_cards=["Temple"],
+        events=[],
+        projects=[],
+        ways=[],
+        landmarks=["Obelisk"],
+        allies=[],
+    )
+
+    assert _missing_board_components(refs, board, set(board.kingdom_cards)) == []

--- a/tests/test_empires_landmarks.py
+++ b/tests/test_empires_landmarks.py
@@ -218,6 +218,21 @@ def test_obelisk_can_use_configured_chosen_pile():
     assert landmark.vp_for(state, player) == 4
 
 
+def test_obelisk_canonicalizes_configured_chosen_pile_alias():
+    landmark = get_landmark("Obelisk (Council room)")
+    state = GameState(players=[], supply={})
+    state.initialize_game(
+        [DummyAI(), DummyAI()],
+        [get_card("Council Room"), get_card("Village")],
+        landmarks=[landmark],
+    )
+    player = state.players[0]
+
+    assert landmark.chosen_pile == "Council Room"
+    player.deck = [get_card("Council Room") for _ in range(2)]
+    assert landmark.vp_for(state, player) == 4
+
+
 def test_orchard_four_vp_per_action_with_three_copies():
     landmark = Orchard()
     state = _make_game([landmark])

--- a/tests/test_empires_landmarks.py
+++ b/tests/test_empires_landmarks.py
@@ -29,6 +29,7 @@ from dominion.landmarks import (
     Wall,
     WolfDen,
     all_landmarks,
+    get_landmark,
 )
 
 from tests.utils import DummyAI
@@ -205,6 +206,16 @@ def test_obelisk_chosen_pile_grants_two_vp_per_copy():
     assert chosen
     player.deck = [get_card(chosen) for _ in range(3)]
     assert landmark.vp_for(state, player) == 6
+
+
+def test_obelisk_can_use_configured_chosen_pile():
+    landmark = get_landmark("Obelisk (Smithy)")
+    state = _make_game([landmark])
+    player = state.players[0]
+
+    assert landmark.chosen_pile == "Smithy"
+    player.deck = [get_card("Smithy") for _ in range(2)]
+    assert landmark.vp_for(state, player) == 4
 
 
 def test_orchard_four_vp_per_action_with_three_copies():


### PR DESCRIPTION
## Summary

Fixes board-driven Landmark handling in the strategy battle path.

- Instantiates and passes board Landmarks into `GameState.initialize_game` from `StrategyBattle`.
- Carries Landmark references through strategy board metadata, trainer evaluation, and compatibility filtering.
- Adds board-file support for Obelisk chosen piles using `Landmark: Obelisk (Temple)` or `Landmark: Obelisk - Temple`.
- Validates configured Obelisk piles at setup so invalid boards fail clearly.

## Root Cause

`BoardConfig` could parse `Landmark:` lines, and `GameState.initialize_game` already supported landmarks, but `StrategyBattle._prepare_board_components` did not instantiate landmarks and `run_game` never passed them through. Obelisk also always chose a deterministic default pile, so board-specific analysis like Temple-with-Obelisk could silently score the wrong pile.

## Validation

- `pytest -q tests/test_board_loader.py tests/test_empires_landmarks.py tests/test_compare_all_strategies.py`
- `python -m compileall -q dominion compare_all_strategies.py`
- `pytest -q` -> 1442 passed