### PR TITLE
[codex] Add reusable strategy seeding

### DIFF
--- a/README_runner.md
+++ b/README_runner.md
@@ -42,6 +42,20 @@ python runner.py --config kingdom_config.yaml --population-size 30 --generations
 - `--generations`: Number of generations to run (default: 10)
 - `--mutation-rate`: Mutation rate (default: 0.1)
 - `--games-per-eval`: Number of games to play per strategy evaluation (default: 10)
+- `--seed-strategy`: Inject one existing `module:function` strategy into the initial population
+- `--seed-strategies`: Inject multiple existing strategy factories
+- `--baseline-strategy`: Evaluate against one existing strategy instead of Big Money
+- `--baseline-panel`: Evaluate against multiple existing strategy factories
+- `--reuse-compatible-strategies`: Automatically find existing strategies that reference cards on this board, inject them as seeds, and add them to the baseline panel
+- `--reuse-top-k`: Maximum number of compatible strategies to reuse (default: 3)
+- `--reuse-min-overlap`: Minimum non-base card overlap required for automatic reuse (default: 2)
+
+Example automatic reuse:
+
+```bash
+python runner.py --kingdom-cards Village Smithy Festival Workshop Market \
+  --reuse-compatible-strategies --reuse-top-k 3
+```
 
 ## YAML Configuration Format
 

--- a/dominion/analysis/strategy_library.py
+++ b/dominion/analysis/strategy_library.py
@@ -1,0 +1,194 @@
+"""Discover and rank reusable strategy seeds for a target board.
+
+The genetic trainer can already inject hand-picked seed strategies. This module
+adds a lightweight retrieval layer: inspect existing strategy modules, extract
+the non-base cards their rules reference, and rank them by overlap with a new
+board. A compatible old strategy is only a hypothesis; training still has to
+mutate it and prove it against the fitness panel.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, Sequence
+
+from dominion.strategy.enhanced_strategy import EnhancedStrategy
+
+logger = logging.getLogger(__name__)
+
+
+BASE_SUPPLY_CARDS = frozenset(
+    {
+        "Copper",
+        "Silver",
+        "Gold",
+        "Platinum",
+        "Estate",
+        "Duchy",
+        "Province",
+        "Colony",
+        "Curse",
+    }
+)
+
+RULE_LIST_ATTRS = (
+    "gain_priority",
+    "action_priority",
+    "treasure_priority",
+    "trash_priority",
+    "discard_priority",
+)
+
+
+@dataclass(frozen=True)
+class StrategyLibraryEntry:
+    """A strategy candidate ranked for reuse on a specific target board."""
+
+    name: str
+    spec: str
+    factory: Callable[[], EnhancedStrategy]
+    referenced_cards: frozenset[str]
+    core_cards: frozenset[str]
+    matched_cards: frozenset[str]
+    missing_cards: frozenset[str]
+    score: float
+
+
+def referenced_cards(strategy: EnhancedStrategy) -> frozenset[str]:
+    """Return card names directly referenced by a strategy's priority rules."""
+
+    names: set[str] = set()
+    for attr in RULE_LIST_ATTRS:
+        for rule in getattr(strategy, attr, []) or []:
+            card = getattr(rule, "card_name", None) or getattr(rule, "card", None)
+            if card:
+                names.add(card)
+
+    for rule in getattr(strategy, "way_policy", []) or []:
+        card = getattr(rule, "card_name", None)
+        if card:
+            names.add(card)
+
+    return frozenset(names)
+
+
+def score_strategy_for_board(
+    strategy: EnhancedStrategy,
+    board_cards: Iterable[str],
+) -> tuple[float, frozenset[str], frozenset[str], frozenset[str]]:
+    """Score a strategy against a target board.
+
+    Base supply cards are ignored. The score intentionally rewards concrete
+    overlap more than pure coverage: a 4-card known engine with one missing
+    card should usually rank above a 1-card strategy with perfect coverage.
+    """
+
+    board_set = set(board_cards)
+    refs = referenced_cards(strategy)
+    core = frozenset(refs - BASE_SUPPLY_CARDS)
+    if not core:
+        return 0.0, core, frozenset(), frozenset()
+
+    matched = frozenset(core & board_set)
+    missing = frozenset(core - board_set)
+    coverage = len(matched) / len(core)
+    score = (len(matched) * 10.0) + (coverage * 10.0) - (len(missing) * 2.0)
+    return score, core, matched, missing
+
+
+def default_strategy_locations(root: Path | None = None) -> list[tuple[Path, str]]:
+    """Return the built-in strategy locations and import prefixes."""
+
+    if root is None:
+        root = Path.cwd()
+    return [
+        (root / "generated_strategies", "generated_strategies"),
+        (
+            root / "dominion" / "strategy" / "strategies",
+            "dominion.strategy.strategies",
+        ),
+    ]
+
+
+def _iter_strategy_factories(
+    locations: Sequence[tuple[Path, str]],
+) -> Iterable[tuple[str, Callable[[], EnhancedStrategy]]]:
+    for directory, module_prefix in locations:
+        if not directory.exists():
+            continue
+        for path in sorted(directory.glob("*.py")):
+            if path.stem == "__init__":
+                continue
+            module_name = f"{module_prefix}.{path.stem}"
+            try:
+                module = importlib.import_module(module_name)
+            except Exception as exc:
+                logger.debug("Skipping strategy module %s: %s", module_name, exc)
+                continue
+            for name, obj in inspect.getmembers(module, inspect.isfunction):
+                if not name.startswith("create_"):
+                    continue
+                spec = f"{module_name}:{name}"
+                yield spec, obj
+
+
+def find_compatible_strategies(
+    board_cards: Iterable[str],
+    *,
+    top_k: int = 5,
+    min_overlap: int = 2,
+    locations: Sequence[tuple[Path, str]] | None = None,
+) -> list[StrategyLibraryEntry]:
+    """Find existing strategies that reference cards on ``board_cards``.
+
+    ``min_overlap`` is the minimum number of non-base cards a strategy must
+    share with the target board. Returned entries are ordered from strongest
+    to weakest match.
+    """
+
+    if locations is None:
+        locations = default_strategy_locations()
+
+    entries: list[StrategyLibraryEntry] = []
+    seen_specs: set[str] = set()
+    for spec, factory in _iter_strategy_factories(locations):
+        if spec in seen_specs:
+            continue
+        seen_specs.add(spec)
+        try:
+            strategy = factory()
+        except Exception as exc:
+            logger.debug("Skipping strategy factory %s: %s", spec, exc)
+            continue
+
+        score, core, matched, missing = score_strategy_for_board(strategy, board_cards)
+        if len(matched) < min_overlap:
+            continue
+
+        entries.append(
+            StrategyLibraryEntry(
+                name=getattr(strategy, "name", "") or spec.rsplit(":", 1)[1],
+                spec=spec,
+                factory=factory,
+                referenced_cards=referenced_cards(strategy),
+                core_cards=core,
+                matched_cards=matched,
+                missing_cards=missing,
+                score=score,
+            )
+        )
+
+    entries.sort(
+        key=lambda e: (
+            e.score,
+            len(e.matched_cards),
+            -len(e.missing_cards),
+            e.name,
+        ),
+        reverse=True,
+    )
+    return entries[: max(0, top_k)]

--- a/dominion/runner.py
+++ b/dominion/runner.py
@@ -8,6 +8,7 @@ import coloredlogs
 import yaml
 
 from dominion.boards.loader import BoardConfig, load_board
+from dominion.analysis.strategy_library import find_compatible_strategies
 from dominion.simulation.genetic_trainer import GeneticTrainer
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
 
@@ -130,6 +131,29 @@ def main():
         "(e.g. generated_strategies.torture_campaign_v2:create_torture_campaign_v2)",
     )
     parser.add_argument(
+        "--seed-strategies",
+        nargs="+",
+        help="Additional module:function seed strategies to inject into the initial population.",
+    )
+    parser.add_argument(
+        "--reuse-compatible-strategies",
+        action="store_true",
+        help="Automatically reuse existing strategies whose referenced cards overlap this board. "
+        "Selected strategies are injected as seeds and added to the baseline panel.",
+    )
+    parser.add_argument(
+        "--reuse-top-k",
+        type=int,
+        default=3,
+        help="Maximum compatible strategies to reuse when --reuse-compatible-strategies is set (default: 3).",
+    )
+    parser.add_argument(
+        "--reuse-min-overlap",
+        type=int,
+        default=2,
+        help="Minimum non-base card overlap for automatic strategy reuse (default: 2).",
+    )
+    parser.add_argument(
         "--baseline-strategy",
         help="Python module path to a strategy factory function to evaluate against instead of Big Money "
         "(e.g. generated_strategies.torture_campaign_v2:create_torture_campaign_v2)",
@@ -215,14 +239,47 @@ def main():
         mod = importlib.import_module(module_path)
         return getattr(mod, func_name)()
 
-    # Inject seed strategy if provided
-    if args.seed_strategy:
+    reusable_entries = []
+    if args.reuse_compatible_strategies:
         try:
-            seed = _load_strategy(args.seed_strategy)
+            reusable_entries = find_compatible_strategies(
+                kingdom_cards,
+                top_k=args.reuse_top_k,
+                min_overlap=args.reuse_min_overlap,
+            )
+            if reusable_entries:
+                logger.info(
+                    "Reusable strategy seeds: %s",
+                    ", ".join(
+                        f"{entry.name} ({', '.join(sorted(entry.matched_cards))})"
+                        for entry in reusable_entries
+                    ),
+                )
+            else:
+                logger.info("No reusable strategies met the compatibility threshold")
+        except Exception as exc:
+            logger.error("Failed to discover reusable strategies: %s", exc)
+            sys.exit(1)
+
+    # Inject seed strategies if provided or discovered
+    seed_specs = []
+    if args.seed_strategy:
+        seed_specs.append(args.seed_strategy)
+    if args.seed_strategies:
+        seed_specs.extend(args.seed_strategies)
+    seed_specs.extend(entry.spec for entry in reusable_entries)
+
+    seen_seed_specs: set[str] = set()
+    for spec in seed_specs:
+        if spec in seen_seed_specs:
+            continue
+        seen_seed_specs.add(spec)
+        try:
+            seed = _load_strategy(spec)
             trainer.inject_strategy(seed)
             logger.info("Injected seed strategy: %s", seed.name)
         except Exception as exc:
-            logger.error("Failed to load seed strategy: %s", exc)
+            logger.error("Failed to load seed strategy %s: %s", spec, exc)
             sys.exit(1)
 
     # Set baseline panel (preferred) or single baseline
@@ -244,6 +301,25 @@ def main():
         except Exception as exc:
             logger.error("Failed to load baseline strategy: %s", exc)
             sys.exit(1)
+
+    if reusable_entries:
+        reused_panel_specs = [
+            entry.spec
+            for entry in reusable_entries
+            if entry.spec not in set(args.baseline_panel or [])
+        ]
+        try:
+            reused_panel = [_load_strategy(spec) for spec in reused_panel_specs]
+        except Exception as exc:
+            logger.error("Failed to load reusable baseline strategy: %s", exc)
+            sys.exit(1)
+        if reused_panel:
+            panel.extend(reused_panel)
+            trainer.set_baseline_panel(panel)
+            logger.info(
+                "Added reusable strategies to baseline panel: %s",
+                ", ".join(strategy.name for strategy in reused_panel),
+            )
 
     logger.info("Training parameters:")
     logger.info("  Population size: %d", population_size)

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -74,7 +74,7 @@ class GeneticTrainer:
             raise ValueError("kingdom_cards cannot be empty")
         self.current_generation = 0
         self.logger = GameLogger(log_folder)
-        self._strategy_to_inject = None
+        self._strategies_to_inject: list[BaseStrategy] = []
         self._baseline_strategy = None
         self._baseline_panel: list[BaseStrategy] = []
         # List of per-opponent breakdown tuples. With ``shape_rewards=False``
@@ -773,11 +773,26 @@ class GeneticTrainer:
             log.info("Initializing population...")
             population = [self.create_random_strategy() for _ in range(self.population_size)]
 
-            # Inject strategy if one was provided
-            if self._strategy_to_inject is not None:
-                replace_idx = random.randint(0, len(population) - 1)
-                population[replace_idx] = deepcopy(self._strategy_to_inject)
-                self._strategy_to_inject = None
+            # Inject existing strategies if provided. Each seed gets one exact
+            # copy and, when there is room, one mutated neighbor so evolution
+            # starts near proven ideas without collapsing the whole population
+            # into clones.
+            if self._strategies_to_inject:
+                injected: list[BaseStrategy] = []
+                for strategy in self._strategies_to_inject:
+                    injected.append(deepcopy(strategy))
+                    variant = self._mutate(deepcopy(strategy))
+                    variant = self._normalize(variant)
+                    variant.name = f"seed-variant-{id(variant)}"
+                    injected.append(variant)
+
+                slot_count = min(len(population), len(injected))
+                for slot, strategy in zip(
+                    random.sample(range(len(population)), slot_count),
+                    injected[:slot_count],
+                ):
+                    population[slot] = strategy
+                self._strategies_to_inject = []
 
             best_strategy = None
             # Shaped fitness can be negative, so seed below any possible value
@@ -872,4 +887,8 @@ class GeneticTrainer:
     def inject_strategy(self, strategy: BaseStrategy):
         """Inject an existing strategy into the initial population.
         This should be called before train() is called."""
-        self._strategy_to_inject = strategy
+        self._strategies_to_inject.append(strategy)
+
+    def inject_strategies(self, strategies: list[BaseStrategy]):
+        """Inject multiple existing strategies into the initial population."""
+        self._strategies_to_inject.extend(strategies)

--- a/evolve.py
+++ b/evolve.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import coloredlogs
 
 from dominion.ai.genetic_ai import GeneticAI
+from dominion.analysis.strategy_library import find_compatible_strategies
 from dominion.analysis.seed_genomes import build_seed_genomes, trick_signature
 from dominion.boards.loader import load_board
 from dominion.reporting.html_report import generate_leaderboard_html
@@ -114,6 +115,23 @@ def main():
              "mixed in alongside --seeds as additional starting points.",
     )
     parser.add_argument(
+        "--reuse-compatible-strategies",
+        action="store_true",
+        help="Automatically add existing strategies whose referenced cards overlap this board as seeds.",
+    )
+    parser.add_argument(
+        "--reuse-top-k",
+        type=int,
+        default=3,
+        help="Maximum compatible strategies to reuse when --reuse-compatible-strategies is set (default: 3).",
+    )
+    parser.add_argument(
+        "--reuse-min-overlap",
+        type=int,
+        default=2,
+        help="Minimum non-base card overlap for automatic strategy reuse (default: 2).",
+    )
+    parser.add_argument(
         "--population", type=int, default=25,
         help="Genetic algorithm population size (default: 25)",
     )
@@ -159,6 +177,28 @@ def main():
     for spec in args.seeds:
         name = _short_name(spec)
         seeds[name] = _load_factory(spec)
+
+    if args.reuse_compatible_strategies:
+        reusable_entries = find_compatible_strategies(
+            board_config.kingdom_cards,
+            top_k=args.reuse_top_k,
+            min_overlap=args.reuse_min_overlap,
+        )
+        for entry in reusable_entries:
+            name = f"Reuse {entry.name}"
+            if name in seeds:
+                continue
+            seeds[name] = entry.factory
+        if reusable_entries:
+            logger.info(
+                "Reusable strategy seeds added: %s",
+                ", ".join(
+                    f"{entry.name} ({', '.join(sorted(entry.matched_cards))})"
+                    for entry in reusable_entries
+                ),
+            )
+        else:
+            logger.info("No reusable strategies met the compatibility threshold")
 
     # Inject trick-scanner-derived seeds alongside the user-provided seeds.
     # Each one becomes its own evolution lineage in Phase 2 — the evolver
@@ -238,6 +278,13 @@ def main():
             board_config=board_config,
         )
         trainer.inject_strategy(seed_factory())
+        reusable_factories = [
+            factory
+            for other_name, factory in seeds.items()
+            if other_name != seed_name and other_name.startswith("Reuse ")
+        ]
+        if reusable_factories:
+            trainer.inject_strategies([factory() for factory in reusable_factories])
         if panel_strategies:
             trainer.set_baseline_panel(panel_strategies)
         else:

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -69,6 +69,9 @@ def _make_mock_player(coins=3, actions=1, buys=1, vp=3, all_cards=None):
     player.actions = actions
     player.buys = buys
     player.hand = []
+    player.in_play = []
+    player.actions_gained_this_turn = 0
+    player.cards_gained_this_turn = 0
     player.count_in_deck = lambda card_name: {"Silver": 2, "Gold": 1}.get(card_name, 0)
     cards = all_cards if all_cards is not None else []
     player.all_cards = lambda _cards=cards: list(_cards)
@@ -726,6 +729,39 @@ class TestRandomImmigrants:
         assert differing >= 2, (
             f"Expected at least 2 immigrants with differing top-5; got {differing}"
         )
+
+
+class TestInjectedSeedStrategies:
+    def test_train_injects_multiple_exact_seed_strategies(self, monkeypatch):
+        trainer = GeneticTrainer(
+            ["Village", "Smithy", "Festival"],
+            population_size=4,
+            generations=1,
+            games_per_eval=2,
+            mutation_rate=0.0,
+        )
+        seed_a = _strategy_with_gain("Village", "Province")
+        seed_a.name = "SeedA"
+        seed_b = _strategy_with_gain("Smithy", "Province")
+        seed_b.name = "SeedB"
+        trainer.inject_strategies([seed_a, seed_b])
+
+        evaluated_names = []
+        monkeypatch.setattr(
+            trainer,
+            "evaluate_strategy",
+            lambda strategy: evaluated_names.append(strategy.name) or 50.0,
+        )
+        monkeypatch.setattr(
+            trainer,
+            "create_next_generation",
+            lambda population, fitness_scores, **kwargs: population,
+        )
+
+        trainer.train()
+
+        assert "SeedA" in evaluated_names
+        assert "SeedB" in evaluated_names
 
 
 def _deepcopy_strategy(s: BaseStrategy) -> BaseStrategy:

--- a/tests/test_strategy_library.py
+++ b/tests/test_strategy_library.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+
+from dominion.analysis.strategy_library import (
+    find_compatible_strategies,
+    referenced_cards,
+    score_strategy_for_board,
+)
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+def _strategy(*cards: str) -> EnhancedStrategy:
+    strategy = EnhancedStrategy()
+    strategy.name = "test"
+    strategy.gain_priority = [PriorityRule(card) for card in cards]
+    strategy.action_priority = []
+    strategy.treasure_priority = [
+        PriorityRule("Gold"),
+        PriorityRule("Silver"),
+        PriorityRule("Copper"),
+    ]
+    strategy.trash_priority = []
+    return strategy
+
+
+def test_referenced_cards_ignores_list_boundaries():
+    strategy = _strategy("Village", "Smithy")
+    strategy.action_priority = [PriorityRule("Festival")]
+    strategy.trash_priority = [PriorityRule("Estate")]
+
+    assert referenced_cards(strategy) == frozenset(
+        {"Village", "Smithy", "Festival", "Estate", "Gold", "Silver", "Copper"}
+    )
+
+
+def test_score_strategy_for_board_rewards_non_base_overlap():
+    strategy = _strategy("Province", "Gold", "Village", "Smithy", "Festival", "Laboratory")
+
+    score, core, matched, missing = score_strategy_for_board(
+        strategy,
+        ["Village", "Smithy", "Festival", "Workshop"],
+    )
+
+    assert core == frozenset({"Village", "Smithy", "Festival", "Laboratory"})
+    assert matched == frozenset({"Village", "Smithy", "Festival"})
+    assert missing == frozenset({"Laboratory"})
+    assert score > 0
+
+
+def test_find_compatible_strategies_ranks_existing_modules(tmp_path, monkeypatch):
+    package = tmp_path / "tmp_strats"
+    package.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "engine.py").write_text(
+        """
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class Engine(EnhancedStrategy):
+    def __init__(self):
+        super().__init__()
+        self.name = "Engine"
+        self.gain_priority = [
+            PriorityRule("Village"),
+            PriorityRule("Smithy"),
+            PriorityRule("Festival"),
+            PriorityRule("Workshop"),
+            PriorityRule("Province"),
+        ]
+
+
+def create_engine() -> EnhancedStrategy:
+    return Engine()
+""",
+        encoding="utf-8",
+    )
+    (package / "single.py").write_text(
+        """
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class Single(EnhancedStrategy):
+    def __init__(self):
+        super().__init__()
+        self.name = "Single"
+        self.gain_priority = [PriorityRule("Village"), PriorityRule("Province")]
+
+
+def create_single() -> EnhancedStrategy:
+    return Single()
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    entries = find_compatible_strategies(
+        ["Village", "Smithy", "Festival", "Workshop", "Market"],
+        top_k=5,
+        min_overlap=2,
+        locations=[(Path(package), "tmp_strats")],
+    )
+
+    assert [entry.name for entry in entries] == ["Engine"]
+    assert entries[0].spec == "tmp_strats.engine:create_engine"
+    assert entries[0].matched_cards == frozenset(
+        {"Village", "Smithy", "Festival", "Workshop"}
+    )


### PR DESCRIPTION
Adds a strategy library that scans existing generated and built-in strategies, ranks them by non-base card overlap with a target board, and returns reusable seed candidates. Updates the trainer to inject multiple seed strategies with mutated neighbors, then wires automatic reuse into runner.py and evolve.py via --reuse-compatible-strategies flags. Adds tests for strategy matching and multi-seed injection, plus README documentation for the new workflow.

Validation: pytest -q (1449 passed).