### PR TITLE
[codex] Fix Rebuild card behavior

### DIFF
--- a/dominion/cards/dark_ages/rebuild.py
+++ b/dominion/cards/dark_ages/rebuild.py
@@ -11,17 +11,141 @@ class Rebuild(Card):
         )
 
     def play_effect(self, game_state):
+        player = game_state.current_player
+        named = self._named_card(game_state, player)
+
+        revealed = []
+        trashed = None
+        while True:
+            if not player.deck and player.discard:
+                player.shuffle_discard_into_deck()
+            if not player.deck:
+                break
+
+            card = player.deck.pop()
+            revealed.append(card)
+            if card.is_victory and card.name != named:
+                trashed = card
+                break
+
+        for card in revealed:
+            if card is trashed:
+                continue
+            game_state.discard_card(player, card)
+
+        if trashed is None:
+            return
+
+        game_state.trash_card(player, trashed)
+        self._gain_replacement(game_state, player, trashed)
+
+    @staticmethod
+    def _named_card(game_state, player) -> str:
+        chooser = getattr(player.ai, "choose_name_for_rebuild", None)
+        if chooser is not None:
+            choice = chooser(game_state, player)
+            if isinstance(choice, str) and choice:
+                return choice
+
+        # Default: protect Provinces once Rebuild finds them; otherwise turn
+        # the first lower Victory card into the best available upgrade.
+        return "Province"
+
+    def _gain_replacement(self, game_state, player, trashed):
+        options, pile_for_card = self._gain_options(game_state, player, trashed)
+        if not options:
+            return
+
+        choice = self._choose_gain(game_state, player, options)
+        pile_name = pile_for_card.get(id(choice), choice.name)
+        if game_state.supply.get(pile_name, 0) <= 0:
+            return
+
+        game_state.supply[pile_name] -= 1
+        is_ordered_pile = pile_name in game_state.pile_order
+        if is_ordered_pile and game_state.pile_order[pile_name]:
+            game_state.pile_order[pile_name].pop()
+
+        post_decrement_supply = game_state.supply[pile_name]
+        post_decrement_order_len = (
+            len(game_state.pile_order[pile_name]) if is_ordered_pile else 0
+        )
+        gained = game_state.gain_card(player, choice)
+        if (
+            is_ordered_pile
+            and gained is not None
+            and gained is not choice
+            and game_state.supply.get(pile_name, 0) == post_decrement_supply
+            and len(game_state.pile_order.get(pile_name, []))
+            == post_decrement_order_len
+        ):
+            game_state.supply[pile_name] = game_state.supply.get(pile_name, 0) + 1
+            game_state.pile_order.setdefault(pile_name, []).append(choice.name)
+
+    @staticmethod
+    def _gain_options(game_state, player, trashed):
         from ..registry import get_card
 
-        player = game_state.current_player
-        # Simplified: trash an Estate from deck/discard if possible, gain a Duchy
-        for pile in [player.hand, player.deck, player.discard]:
-            estate = next((c for c in pile if c.name == "Estate"), None)
-            if estate:
-                pile.remove(estate)
-                game_state.trash_card(player, estate)
-                if game_state.supply.get("Duchy", 0) > 0:
-                    game_state.supply["Duchy"] -= 1
-                    duchy = get_card("Duchy")
-                    game_state.gain_card(player, duchy)
-                return
+        max_coins = game_state.get_card_cost(player, trashed) + 3
+        max_potions = trashed.cost.potions
+        max_debt = trashed.cost.debt
+        options = []
+        pile_for_card = {}
+        non_supply_blocklist = game_state.non_supply_pile_names | {"Horse"}
+
+        for name, count in game_state.supply.items():
+            if count <= 0 or name in non_supply_blocklist:
+                continue
+            if name in game_state.pile_order:
+                candidate = game_state.top_of_pile(name)
+                if candidate is None:
+                    continue
+            else:
+                try:
+                    candidate = get_card(name)
+                except ValueError:
+                    continue
+                if not candidate.may_be_gained(game_state):
+                    continue
+
+            if not candidate.is_victory:
+                continue
+            if game_state.get_card_cost(player, candidate) > max_coins:
+                continue
+            if candidate.cost.potions > max_potions:
+                continue
+            if candidate.cost.debt > max_debt:
+                continue
+
+            options.append(candidate)
+            pile_for_card[id(candidate)] = name
+
+        return options, pile_for_card
+
+    @staticmethod
+    def _choose_gain(game_state, player, options):
+        chooser = getattr(player.ai, "choose_card_to_gain_for_rebuild", None)
+        choice = chooser(game_state, player, list(options)) if chooser else None
+
+        if choice is None:
+            choice = player.ai.choose_buy(game_state, list(options) + [None])
+
+        if choice in options:
+            return choice
+
+        choice_name = getattr(choice, "name", None)
+        if choice_name is not None:
+            for option in options:
+                if option.name == choice_name:
+                    return option
+
+        return max(
+            options,
+            key=lambda card: (
+                game_state.get_card_cost(player, card),
+                card.cost.potions,
+                card.cost.debt,
+                card.stats.vp,
+                card.name,
+            ),
+        )

--- a/tests/test_rebuild_card.py
+++ b/tests/test_rebuild_card.py
@@ -1,0 +1,99 @@
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from tests.utils import DummyAI
+
+
+class NamedRebuildAI(DummyAI):
+    def __init__(self, named="Province", gain_name=None):
+        super().__init__()
+        self.named = named
+        self.gain_name = gain_name
+
+    def choose_name_for_rebuild(self, state, player):
+        return self.named
+
+    def choose_card_to_gain_for_rebuild(self, state, player, choices):
+        if self.gain_name is None:
+            return None
+        for choice in choices:
+            if choice.name == self.gain_name:
+                return choice
+        return None
+
+
+def make_state(ai=None):
+    player = PlayerState(ai or NamedRebuildAI())
+    state = GameState(players=[player])
+    state.log_callback = lambda *args, **kwargs: None
+    state.supply = {"Estate": 8, "Duchy": 8, "Province": 8, "Colony": 8}
+    return state, player
+
+
+def test_rebuild_does_not_trash_estate_from_hand_or_discard_directly():
+    state, player = make_state(NamedRebuildAI(named="Estate"))
+    rebuild = get_card("Rebuild")
+    estate_in_hand = get_card("Estate")
+    estate_in_discard = get_card("Estate")
+    duchy_on_deck = get_card("Duchy")
+
+    player.hand = [estate_in_hand]
+    player.discard = [estate_in_discard]
+    player.deck = [duchy_on_deck]
+
+    rebuild.play_effect(state)
+
+    assert estate_in_hand in player.hand
+    assert estate_in_discard in player.discard
+    assert duchy_on_deck in state.trash
+    assert estate_in_hand not in state.trash
+    assert estate_in_discard not in state.trash
+
+
+def test_rebuild_reveals_through_deck_and_shuffles_discard_as_needed():
+    state, player = make_state(NamedRebuildAI(named="Province"))
+    rebuild = get_card("Rebuild")
+    copper = get_card("Copper")
+    estate = get_card("Estate")
+
+    player.deck = [copper]
+    player.discard = [estate]
+
+    rebuild.play_effect(state)
+
+    assert copper in player.discard
+    assert estate in state.trash
+    assert any(card.name == "Duchy" for card in player.discard)
+
+
+def test_rebuild_trashes_first_victory_not_matching_named_card():
+    state, player = make_state(NamedRebuildAI(named="Estate"))
+    rebuild = get_card("Rebuild")
+    province_in_deck = get_card("Province")
+    duchy = get_card("Duchy")
+    named_estate = get_card("Estate")
+
+    player.deck = [province_in_deck, duchy, named_estate]
+
+    rebuild.play_effect(state)
+
+    assert named_estate in player.discard
+    assert duchy in state.trash
+    assert province_in_deck in player.deck
+    assert province_in_deck not in state.trash
+
+
+def test_rebuild_gains_highest_eligible_victory_by_default():
+    state, player = make_state(NamedRebuildAI(named="Province"))
+    rebuild = get_card("Rebuild")
+    estate = get_card("Estate")
+
+    player.deck = [estate]
+
+    rebuild.play_effect(state)
+
+    assert estate in state.trash
+    assert state.supply["Duchy"] == 7
+    assert state.supply["Province"] == 8
+    assert any(card.name == "Duchy" for card in player.discard)
+    assert not any(card.name == "Province" for card in player.discard)


### PR DESCRIPTION
## Summary

Rebuild now follows the actual deck-reveal flow instead of scanning hand/deck/discard for an Estate. It names a card, reveals until finding a differently named Victory card, discards the other revealed cards, trashes that Victory, and gains an eligible Victory up to +$3.

## Why

The prior implementation could trash cards from the wrong zones and always converted Estate into Duchy, which made Rebuild strategy results unreliable.

## Validation

- `pytest -q tests/test_rebuild_card.py tests/test_dark_ages_cards.py`
- Full combined suite was also run from the source workspace: `1474 passed`.