### PR TITLE
[codex] Fix Lookout trash priority

### DIFF
--- a/dominion/cards/seaside/lookout.py
+++ b/dominion/cards/seaside/lookout.py
@@ -4,6 +4,8 @@ from ..base_card import Card, CardCost, CardStats, CardType
 
 
 class Lookout(Card):
+    _STARTER_JUNK_NAMES = {"Copper", "Estate", "Hovel", "Overgrown Estate"}
+
     def __init__(self):
         super().__init__(
             name="Lookout",
@@ -42,12 +44,48 @@ class Lookout(Card):
     def _trash_priority(card):
         if card.name == "Curse":
             return (0, card.cost.coins, card.name)
-        if card.is_victory and not card.is_action:
+        if card.is_ruins:
             return (1, card.cost.coins, card.name)
-        if card.name == "Copper":
-            return (2, card.cost.coins, card.name)
-        return (3, card.cost.coins, card.name)
+        if card.name in Lookout._STARTER_JUNK_NAMES:
+            return (2, Lookout._card_strength(card))
+        return (3, Lookout._card_strength(card))
 
     @staticmethod
     def _discard_priority(card):
-        return (card.is_action, card.is_treasure, card.cost.coins, card.name)
+        return Lookout._card_strength(card)
+
+    @staticmethod
+    def _card_strength(card):
+        """Rank cards from weakest to strongest for Lookout's default choices."""
+        if card.name == "Curse":
+            return (0, card.cost.coins, card.name)
+        if card.is_ruins:
+            return (
+                1,
+                card.stats.cards,
+                card.stats.actions,
+                card.stats.coins,
+                card.stats.buys,
+                card.cost.coins,
+                card.name,
+            )
+        if card.name in Lookout._STARTER_JUNK_NAMES:
+            return (
+                2,
+                card.stats.coins,
+                card.stats.vp,
+                card.cost.coins,
+                card.name,
+            )
+        return (
+            3,
+            card.cost.coins,
+            card.cost.potions,
+            card.cost.debt,
+            card.stats.vp,
+            card.stats.coins,
+            card.stats.cards,
+            card.stats.actions,
+            card.stats.buys,
+            card.name,
+        )

--- a/tests/test_lookout_card.py
+++ b/tests/test_lookout_card.py
@@ -1,0 +1,67 @@
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+
+from tests.utils import DummyAI
+
+
+def _make_state():
+    player = PlayerState(DummyAI())
+    state = GameState(players=[player])
+    state.log_callback = lambda message: None
+    player.hand = []
+    player.deck = []
+    player.discard = []
+    player.in_play = []
+    return state, player
+
+
+def _play_lookout(state, player):
+    lookout = get_card("Lookout")
+    player.hand = [lookout]
+    player.hand.remove(lookout)
+    player.in_play.append(lookout)
+    lookout.on_play(state)
+
+
+def test_lookout_trashes_copper_before_province():
+    state, player = _make_state()
+    province = get_card("Province")
+    copper = get_card("Copper")
+    silver = get_card("Silver")
+    # Top of deck is the end of the list; Lookout reveals Province, Copper, Silver.
+    player.deck = [silver, copper, province]
+
+    _play_lookout(state, player)
+
+    assert state.trash == [copper]
+    assert province not in state.trash
+    assert player.discard == [silver]
+    assert player.deck[-1] is province
+
+
+def test_lookout_trashes_curse_before_estate_and_gold():
+    state, player = _make_state()
+    curse = get_card("Curse")
+    estate = get_card("Estate")
+    gold = get_card("Gold")
+    player.deck = [gold, estate, curse]
+
+    _play_lookout(state, player)
+
+    assert state.trash == [curse]
+    assert estate not in state.trash
+    assert gold not in state.trash
+
+
+def test_lookout_topdecks_best_remaining_card():
+    state, player = _make_state()
+    curse = get_card("Curse")
+    estate = get_card("Estate")
+    gold = get_card("Gold")
+    player.deck = [gold, estate, curse]
+
+    _play_lookout(state, player)
+
+    assert player.discard == [estate]
+    assert player.deck == [gold]


### PR DESCRIPTION
## Summary

Lookout's default judgment now trashes Curse/Ruins/starter junk before valuable cards and discards the weakest remaining card so the strongest card is topdecked.

## Why

The prior priority ranked all Victory cards ahead of Copper for trashing, so Lookout could trash Province before Copper.

## Validation

- `pytest -q tests/test_lookout_card.py tests/test_seaside_cards.py`
- Full combined suite was also run from the source workspace: `1474 passed`.