### PR TITLE
[codex] Fix Count card choices

### DIFF
--- a/dominion/cards/dark_ages/count.py
+++ b/dominion/cards/dark_ages/count.py
@@ -1,9 +1,11 @@
-"""Simplified implementation of the Count card."""
+"""Implementation of the Count card."""
 
 from ..base_card import Card, CardCost, CardStats, CardType
 
 
 class Count(Card):
+    """Choose one of three first effects, then one of three second effects."""
+
     def __init__(self):
         super().__init__(
             name="Count",
@@ -18,49 +20,155 @@ class Count(Card):
         self._resolve_second_choice(game_state, player)
 
     def _resolve_first_choice(self, game_state, player):
-        hand = list(player.hand)
-        if len(hand) >= 2:
-            to_discard = player.ai.choose_cards_to_discard(game_state, player, hand, 2)
-            while len(to_discard) < 2 and hand:
-                candidate = min(hand, key=lambda c: (c.cost.coins, c.name))
-                if candidate not in to_discard:
-                    to_discard.append(candidate)
-                hand.remove(candidate)
-            for card in to_discard[:2]:
-                if card in player.hand:
-                    player.hand.remove(card)
-                    game_state.discard_card(player, card)
-            return
+        choice = self._choose_first_mode(game_state, player)
 
-        if hand:
-            keep = max(hand, key=lambda c: (c.cost.coins, c.stats.cards, c.name))
-            if keep in player.hand:
-                player.hand.remove(keep)
-                player.deck.append(keep)
-            return
-
-        if game_state.supply.get("Copper", 0) > 0:
-            from ..registry import get_card
-
-            copper = get_card("Copper")
-            game_state.supply["Copper"] -= 1
-            game_state.gain_card(player, copper)
+        if choice == "discard":
+            self._discard_two(game_state, player)
+        elif choice == "topdeck":
+            self._topdeck_from_hand(game_state, player)
+        elif choice == "copper":
+            self._gain_from_supply(game_state, player, "Copper")
 
     def _resolve_second_choice(self, game_state, player):
-        hand = list(player.hand)
-        junk_cards = [card for card in hand if card.name in {"Curse", "Estate", "Copper"}]
+        choice = self._choose_second_mode(game_state, player)
 
-        if hand and len(junk_cards) >= len(hand) - 1:
+        if choice == "coins":
+            player.coins += 3
+        elif choice == "trash":
             for card in list(player.hand):
                 player.hand.remove(card)
                 game_state.trash_card(player, card)
+        elif choice == "duchy":
+            self._gain_from_supply(game_state, player, "Duchy")
+
+    def _choose_first_mode(self, game_state, player):
+        options = ["discard", "topdeck"]
+        if game_state.supply.get("Copper", 0) > 0:
+            options.append("copper")
+
+        hook = getattr(player.ai, "choose_count_first_mode", None)
+        if hook is None:
+            hook = getattr(player.ai, "choose_count_first_choice", None)
+        if hook is not None:
+            choice = hook(game_state, player, list(options))
+            if choice in options:
+                return choice
+
+        discardable = [card for card in player.hand if self._is_disposable(card)]
+        if len(discardable) >= 2:
+            return "discard"
+        if player.hand:
+            return "topdeck"
+        if "copper" in options:
+            return "copper"
+        return "discard"
+
+    def _choose_second_mode(self, game_state, player):
+        options = ["coins", "trash"]
+        if game_state.supply.get("Duchy", 0) > 0:
+            options.append("duchy")
+
+        hook = getattr(player.ai, "choose_count_second_mode", None)
+        if hook is None:
+            hook = getattr(player.ai, "choose_count_second_choice", None)
+        if hook is not None:
+            choice = hook(game_state, player, list(options))
+            if choice in options:
+                return choice
+
+        if "duchy" in options and game_state.turn_number >= 10:
+            return "duchy"
+        if player.hand and all(self._is_disposable(card) for card in player.hand):
+            return "trash"
+        return "coins"
+
+    def _discard_two(self, game_state, player):
+        if not player.hand:
             return
 
-        if game_state.supply.get("Duchy", 0) > 0 and game_state.turn_number >= 10:
-            from ..registry import get_card
+        choices = list(player.hand)
+        selected = player.ai.choose_cards_to_discard(
+            game_state, player, choices, 2, reason="count"
+        )
+        selected = self._valid_unique_cards(selected, choices)
 
-            duchy = get_card("Duchy")
-            game_state.supply["Duchy"] -= 1
-            game_state.gain_card(player, duchy)
+        remaining = [card for card in choices if card not in selected]
+        while len(selected) < min(2, len(choices)) and remaining:
+            fallback = min(remaining, key=self._discard_priority)
+            selected.append(fallback)
+            remaining.remove(fallback)
+
+        for card in selected[:2]:
+            if card in player.hand:
+                player.hand.remove(card)
+                game_state.discard_card(player, card)
+
+    def _topdeck_from_hand(self, game_state, player):
+        if not player.hand:
+            return
+
+        choices = list(player.hand)
+        choice = player.ai.choose_card_to_topdeck_from_hand(
+            game_state, player, choices, reason="count"
+        )
+        if choice not in choices:
+            choice = min(choices, key=self._topdeck_priority)
+
+        player.hand.remove(choice)
+        player.deck.append(choice)
+
+    def _gain_from_supply(self, game_state, player, card_name):
+        if game_state.supply.get(card_name, 0) <= 0:
+            return
+
+        from ..registry import get_card
+
+        game_state.supply[card_name] -= 1
+        game_state.gain_card(player, get_card(card_name))
+
+    @staticmethod
+    def _valid_unique_cards(selected, choices):
+        valid = []
+        remaining = list(choices)
+        if selected is None:
+            candidates = []
+        elif isinstance(selected, (list, tuple)):
+            candidates = selected
         else:
-            player.coins += 3
+            candidates = [selected]
+
+        for card in candidates:
+            if card in remaining:
+                valid.append(card)
+                remaining.remove(card)
+        return valid
+
+    @staticmethod
+    def _discard_priority(card):
+        if card.name == "Curse":
+            return (0, 0, card.name)
+        if card.name == "Estate":
+            return (1, 0, card.name)
+        if card.is_victory and not card.is_action and card.cost.coins <= 2:
+            return (1, card.cost.coins, card.name)
+        if card.name == "Copper":
+            return (2, 0, card.name)
+        return (3, card.cost.coins, card.name)
+
+    @staticmethod
+    def _topdeck_priority(card):
+        if card.is_action:
+            return (0, -card.cost.coins, card.name)
+        if card.is_treasure:
+            return (1, -card.cost.coins, card.name)
+        return (2, card.cost.coins, card.name)
+
+    @staticmethod
+    def _is_disposable(card):
+        if card.name in {"Curse", "Copper", "Estate", "Hovel", "Overgrown Estate"}:
+            return True
+        if card.is_ruins:
+            return True
+        if card.is_victory and not card.is_action and card.cost.coins <= 2:
+            return True
+        return False

--- a/tests/test_count_card.py
+++ b/tests/test_count_card.py
@@ -1,0 +1,90 @@
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from tests.utils import DummyAI
+
+
+def _setup(ai=None):
+    player = PlayerState(ai or DummyAI())
+    state = GameState([player])
+    state.setup_supply([get_card("Count")])
+    player.hand = []
+    player.deck = []
+    player.discard = []
+    player.in_play = []
+    player.coins = 0
+    player.actions = 1
+    player.buys = 1
+    return state, player
+
+
+def _play_count(state, player):
+    count = get_card("Count")
+    player.in_play.append(count)
+    count.play_effect(state)
+
+
+class CoinsAI(DummyAI):
+    def choose_count_second_mode(self, state, player, options):
+        return "coins"
+
+
+class DiscardCopperEstateAI(CoinsAI):
+    def choose_count_first_mode(self, state, player, options):
+        return "discard"
+
+    def choose_cards_to_discard(self, state, player, choices, count, *, reason=None):
+        return [card for card in choices if card.name in {"Copper", "Estate"}]
+
+
+class InvalidTopdeckAI(CoinsAI):
+    def choose_card_to_topdeck_from_hand(self, state, player, choices, reason=None):
+        return get_card("Province")
+
+
+def test_count_default_does_not_trash_gold_with_junk():
+    state, player = _setup()
+    player.hand = [get_card("Gold"), get_card("Copper"), get_card("Estate")]
+
+    _play_count(state, player)
+
+    assert [card.name for card in player.hand] == ["Gold"]
+    assert sorted(card.name for card in player.discard) == ["Copper", "Estate"]
+    assert all(card.name != "Gold" for card in state.trash)
+    assert player.coins == 3
+
+
+def test_count_discard_two_path_discards_chosen_cards():
+    state, player = _setup(DiscardCopperEstateAI())
+    player.hand = [get_card("Gold"), get_card("Copper"), get_card("Estate")]
+
+    _play_count(state, player)
+
+    assert [card.name for card in player.hand] == ["Gold"]
+    assert sorted(card.name for card in player.discard) == ["Copper", "Estate"]
+    assert player.coins == 3
+
+
+def test_count_topdeck_path_with_fewer_than_two_disposable_cards_validates_pick():
+    state, player = _setup(InvalidTopdeckAI())
+    player.hand = [get_card("Gold"), get_card("Copper")]
+
+    _play_count(state, player)
+
+    assert [card.name for card in player.deck] == ["Gold"]
+    assert [card.name for card in player.hand] == ["Copper"]
+    assert all(card.name != "Province" for card in player.deck)
+    assert player.coins == 3
+
+
+def test_count_default_gains_duchy_late_game():
+    state, player = _setup()
+    state.turn_number = 10
+    duchies_before = state.supply["Duchy"]
+    player.hand = [get_card("Gold")]
+
+    _play_count(state, player)
+
+    assert [card.name for card in player.deck] == ["Gold"]
+    assert any(card.name == "Duchy" for card in player.discard)
+    assert state.supply["Duchy"] == duchies_before - 1


### PR DESCRIPTION
## Summary

Count now resolves one first-choice mode and one second-choice mode with safer defaults and optional local AI hooks. It discards only when there are enough disposable cards, topdecks or gains Copper when appropriate, and only trashes the whole hand when every remaining card is disposable.

## Why

The old simplified implementation could trash valuable cards just because the hand also contained junk.

## Validation

- `pytest -q tests/test_count_card.py tests/test_dark_ages_cards.py`
- Full combined suite was also run from the source workspace: `1474 passed`.