### PR TITLE
[codex] Fix Taxman optional trash

### DIFF
--- a/dominion/cards/guilds/taxman.py
+++ b/dominion/cards/guilds/taxman.py
@@ -35,7 +35,6 @@ class Taxman(Card):
             card = get_card(name)
             if (
                 card.is_treasure
-                and card.name != trashed_name
                 and card.cost.coins <= trash_choice.cost.coins + 3
             ):
                 gain_candidates.append(card)

--- a/dominion/cards/guilds/taxman.py
+++ b/dominion/cards/guilds/taxman.py
@@ -22,30 +22,32 @@ class Taxman(Card):
 
         trash_choice = player.ai.choose_card_to_trash(game_state, treasures + [None])
         if trash_choice is None or trash_choice not in player.hand:
-            trash_choice = min(treasures, key=lambda c: (c.cost.coins, c.name))
-        if trash_choice not in player.hand:
             return
 
         player.hand.remove(trash_choice)
         game_state.trash_card(player, trash_choice)
+        trashed_name = trash_choice.name
 
         gain_candidates = []
         for name, count in game_state.supply.items():
             if count <= 0:
                 continue
             card = get_card(name)
-            if card.cost.coins <= trash_choice.cost.coins + 3 and card.is_treasure:
+            if (
+                card.is_treasure
+                and card.name != trashed_name
+                and card.cost.coins <= trash_choice.cost.coins + 3
+            ):
                 gain_candidates.append(card)
 
         if gain_candidates:
             choice = player.ai.choose_buy(game_state, gain_candidates + [None])
-            if choice is None:
+            gain_names = {card.name for card in gain_candidates}
+            if choice is None or choice.name not in gain_names:
                 choice = max(gain_candidates, key=lambda c: (c.cost.coins, c.stats.vp, c.name))
             if game_state.supply.get(choice.name, 0) > 0:
                 game_state.supply[choice.name] -= 1
                 game_state.gain_card(player, choice, to_deck=True)
-
-        trashed_name = trash_choice.name
 
         def attack(target):
             if len(target.hand) < 5:
@@ -56,12 +58,8 @@ class Taxman(Card):
             card = matching[0]
             target.hand.remove(card)
             game_state.discard_card(target, card)
-            if game_state.supply.get("Silver", 0) > 0:
-                game_state.supply["Silver"] -= 1
-                game_state.gain_card(target, get_card("Silver"), to_deck=True)
 
         for other in game_state.players:
             if other is player:
                 continue
-            game_state.attack_player(other, attack)
-
+            game_state.attack_player(other, attack, attacker=player, attack_card=self)

--- a/tests/test_taxman_card.py
+++ b/tests/test_taxman_card.py
@@ -89,6 +89,21 @@ def test_taxman_trashes_copper_and_gains_silver_to_deck():
     assert state.supply["Silver"] == silver_before - 1
 
 
+def test_taxman_can_gain_same_treasure_when_it_is_only_valid_gain():
+    state = make_state(TaxmanAI(trash_name="Copper", gain_name="Copper"))
+    player = state.players[0]
+    copper = get_card("Copper")
+    player.hand = [get_card("Taxman"), copper]
+    state.supply["Silver"] = 0
+    copper_before = state.supply["Copper"]
+
+    play_taxman(state)
+
+    assert state.trash == [copper]
+    assert player.deck[-1].name == "Copper"
+    assert state.supply["Copper"] == copper_before - 1
+
+
 def test_taxman_opponents_discard_matching_copper_without_gaining_silver():
     state = make_state(TaxmanAI(trash_name="Copper", gain_name="Silver"), DummyAI())
     attacker, defender = state.players

--- a/tests/test_taxman_card.py
+++ b/tests/test_taxman_card.py
@@ -1,0 +1,129 @@
+from typing import Optional
+
+from dominion.cards.base_card import Card
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from tests.utils import DummyAI
+
+
+class TaxmanAI(DummyAI):
+    def __init__(self, trash_name: str | None = None, gain_name: str | None = None):
+        super().__init__()
+        self.trash_name = trash_name
+        self.gain_name = gain_name
+
+    def choose_card_to_trash(
+        self, state: GameState, choices: list[Card]
+    ) -> Optional[Card]:
+        if self.trash_name is None:
+            return None
+        return next((card for card in choices if card and card.name == self.trash_name), None)
+
+    def choose_buy(self, state: GameState, choices: list[Optional[Card]]) -> Optional[Card]:
+        if self.gain_name is None:
+            return None
+        return next((card for card in choices if card and card.name == self.gain_name), None)
+
+
+def make_state(*ais: DummyAI) -> GameState:
+    players = [PlayerState(ai) for ai in ais]
+    state = GameState(players=players)
+    state.setup_supply([])
+    state.current_player_index = 0
+    state.phase = "action"
+    for player in players:
+        player.hand = []
+        player.deck = []
+        player.discard = []
+        player.in_play = []
+        player.duration = []
+    return state
+
+
+def play_taxman(state: GameState) -> None:
+    player = state.current_player
+    taxman = next(card for card in player.hand if card.name == "Taxman")
+    player.hand.remove(taxman)
+    player.in_play.append(taxman)
+    taxman.on_play(state)
+
+
+def test_taxman_ai_can_decline_trashing_treasure():
+    state = make_state(TaxmanAI(), DummyAI())
+    attacker, defender = state.players
+    copper = get_card("Copper")
+    attacker.hand = [get_card("Taxman"), copper]
+    defender.hand = [
+        get_card("Copper"),
+        get_card("Estate"),
+        get_card("Estate"),
+        get_card("Estate"),
+        get_card("Estate"),
+    ]
+    silver_before = state.supply["Silver"]
+
+    play_taxman(state)
+
+    assert copper in attacker.hand
+    assert state.trash == []
+    assert attacker.deck == []
+    assert len(defender.hand) == 5
+    assert defender.discard == []
+    assert state.supply["Silver"] == silver_before
+
+
+def test_taxman_trashes_copper_and_gains_silver_to_deck():
+    state = make_state(TaxmanAI(trash_name="Copper", gain_name="Silver"))
+    player = state.players[0]
+    copper = get_card("Copper")
+    player.hand = [get_card("Taxman"), copper]
+    silver_before = state.supply["Silver"]
+
+    play_taxman(state)
+
+    assert copper not in player.hand
+    assert state.trash == [copper]
+    assert player.deck[-1].name == "Silver"
+    assert player.discard == []
+    assert state.supply["Silver"] == silver_before - 1
+
+
+def test_taxman_opponents_discard_matching_copper_without_gaining_silver():
+    state = make_state(TaxmanAI(trash_name="Copper", gain_name="Silver"), DummyAI())
+    attacker, defender = state.players
+    defender_copper = get_card("Copper")
+    attacker.hand = [get_card("Taxman"), get_card("Copper")]
+    defender.hand = [
+        defender_copper,
+        get_card("Estate"),
+        get_card("Estate"),
+        get_card("Estate"),
+        get_card("Estate"),
+    ]
+
+    play_taxman(state)
+
+    assert defender_copper not in defender.hand
+    assert defender.discard == [defender_copper]
+    assert [card.name for card in defender.deck] == []
+    assert all(card.name != "Silver" for card in defender.hand + defender.discard)
+
+
+def test_taxman_opponent_with_fewer_than_five_cards_is_unaffected():
+    state = make_state(TaxmanAI(trash_name="Copper", gain_name="Silver"), DummyAI())
+    attacker, defender = state.players
+    defender_copper = get_card("Copper")
+    attacker.hand = [get_card("Taxman"), get_card("Copper")]
+    defender.hand = [
+        defender_copper,
+        get_card("Estate"),
+        get_card("Estate"),
+        get_card("Estate"),
+    ]
+    original_hand = list(defender.hand)
+
+    play_taxman(state)
+
+    assert defender.hand == original_hand
+    assert defender.discard == []


### PR DESCRIPTION
## Summary

Taxman now respects declining the optional Treasure trash, gains a different Treasure up to +$3 onto the deck, and makes eligible opponents discard matching copies without giving them Silver.

## Why

The prior implementation forced a trash fallback and incorrectly awarded Silver to attacked opponents.

## Validation

- `pytest -q tests/test_taxman_card.py`
- Full combined suite was also run from the source workspace: `1474 passed`.