### PR TITLE
[codex] Preserve optional AI choices

### DIFF
--- a/dominion/ai/genetic_ai.py
+++ b/dominion/ai/genetic_ai.py
@@ -22,10 +22,16 @@ class GeneticAI(AI):
         return self._name
 
     def choose_action(self, state: GameState, choices: list[Optional[Card]]) -> Optional[Card]:
-        if not choices:
+        valid_choices = [c for c in choices if c is not None]
+        if not valid_choices:
             return None
 
-        return self.strategy.choose_action(state, state.current_player, choices)
+        strategy_choices = (
+            valid_choices
+            if getattr(state, "_choosing_main_action_phase", False)
+            else choices
+        )
+        return self.strategy.choose_action(state, state.current_player, strategy_choices)
 
     def choose_treasure(self, state: GameState, choices: list[Optional[Card]]) -> Optional[Card]:
         valid_choices = [c for c in choices if c is not None]

--- a/dominion/ai/genetic_ai.py
+++ b/dominion/ai/genetic_ai.py
@@ -22,11 +22,10 @@ class GeneticAI(AI):
         return self._name
 
     def choose_action(self, state: GameState, choices: list[Optional[Card]]) -> Optional[Card]:
-        valid_choices = [c for c in choices if c is not None]
-        if not valid_choices:
+        if not choices:
             return None
 
-        return self.strategy.choose_action(state, state.current_player, valid_choices)
+        return self.strategy.choose_action(state, state.current_player, choices)
 
     def choose_treasure(self, state: GameState, choices: list[Optional[Card]]) -> Optional[Card]:
         valid_choices = [c for c in choices if c is not None]
@@ -36,11 +35,10 @@ class GeneticAI(AI):
         return self.strategy.choose_treasure(state, state.current_player, valid_choices)
 
     def choose_buy(self, state: GameState, choices: list[Optional[Card]]) -> Optional[Card]:
-        valid_choices = [c for c in choices if c is not None]
-        if not valid_choices:
+        if not choices:
             return None
 
-        return self.strategy.choose_gain(state, state.current_player, valid_choices)
+        return self.strategy.choose_gain(state, state.current_player, choices)
 
     def choose_way(self, state: GameState, card: Card, ways: list) -> Optional[object]:
         if hasattr(self.strategy, 'choose_way'):

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1518,7 +1518,12 @@ class GameState:
                 else:
                     break
 
-            choice = player.ai.choose_action(self, playable + [None])
+            was_choosing_main_action = getattr(self, "_choosing_main_action_phase", False)
+            self._choosing_main_action_phase = True
+            try:
+                choice = player.ai.choose_action(self, playable + [None])
+            finally:
+                self._choosing_main_action_phase = was_choosing_main_action
             if choice is None:
                 break
 

--- a/dominion/strategy/enhanced_strategy.py
+++ b/dominion/strategy/enhanced_strategy.py
@@ -295,7 +295,11 @@ class EnhancedStrategy:
 
     # ------------------------------------------------------------------
     def _choose_from_priority(
-        self, priority: list[PriorityRule], choices: list[Card], state: GameState, player: PlayerState
+        self,
+        priority: list[PriorityRule],
+        choices: list[Optional[Card]],
+        state: GameState,
+        player: PlayerState,
     ) -> Optional[Card]:
         """Return the first card whose rule condition evaluates to True.
 
@@ -347,6 +351,9 @@ class EnhancedStrategy:
         result = self._choose_from_priority(self.action_priority, choices, state, player)
         if result is not None:
             return result
+
+        if any(card is None for card in choices):
+            return None
 
         # Fallback: play unexpected action cards not covered by any priority rule
         # (e.g. cards gained via Swindle or other opponent effects).

--- a/tests/test_genetic_ai_optional_choices.py
+++ b/tests/test_genetic_ai_optional_choices.py
@@ -33,6 +33,18 @@ def test_choose_action_can_decline_when_none_offered_and_no_action_priority_matc
     assert choice is None
 
 
+def test_choose_action_keeps_unexpected_fallback_in_main_action_phase():
+    strategy = EnhancedStrategy()
+    strategy.action_priority = [PriorityRule("Smithy")]
+    state, ai = _state_with_strategy(strategy)
+    state._choosing_main_action_phase = True
+
+    choice = ai.choose_action(state, [get_card("Village"), None])
+
+    assert choice is not None
+    assert choice.name == "Village"
+
+
 def test_priority_matches_still_win_when_none_is_present():
     strategy = EnhancedStrategy()
     strategy.action_priority = [PriorityRule("Village")]

--- a/tests/test_genetic_ai_optional_choices.py
+++ b/tests/test_genetic_ai_optional_choices.py
@@ -1,0 +1,48 @@
+from dominion.ai.genetic_ai import GeneticAI
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+def _state_with_strategy(strategy: EnhancedStrategy) -> tuple[GameState, GeneticAI]:
+    ai = GeneticAI(strategy)
+    player = PlayerState(ai)
+    state = GameState(players=[player])
+    state.log_callback = lambda *args, **kwargs: None
+    return state, ai
+
+
+def test_choose_buy_can_decline_when_none_offered_and_no_gain_priority_matches():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [PriorityRule("Gold")]
+    state, ai = _state_with_strategy(strategy)
+
+    choice = ai.choose_buy(state, [get_card("Silver"), None])
+
+    assert choice is None
+
+
+def test_choose_action_can_decline_when_none_offered_and_no_action_priority_matches():
+    strategy = EnhancedStrategy()
+    strategy.action_priority = [PriorityRule("Smithy")]
+    state, ai = _state_with_strategy(strategy)
+
+    choice = ai.choose_action(state, [get_card("Village"), None])
+
+    assert choice is None
+
+
+def test_priority_matches_still_win_when_none_is_present():
+    strategy = EnhancedStrategy()
+    strategy.action_priority = [PriorityRule("Village")]
+    strategy.gain_priority = [PriorityRule("Silver")]
+    state, ai = _state_with_strategy(strategy)
+
+    action_choice = ai.choose_action(state, [get_card("Smithy"), None, get_card("Village")])
+    buy_choice = ai.choose_buy(state, [get_card("Copper"), None, get_card("Silver")])
+
+    assert action_choice is not None
+    assert action_choice.name == "Village"
+    assert buy_choice is not None
+    assert buy_choice.name == "Silver"


### PR DESCRIPTION
## Summary

GeneticAI now preserves `None` in action and buy choices so optional card effects can be skipped. EnhancedStrategy still ignores `None` for priority matching, but returns `None` instead of falling back to unexpected-action play when a skip option was explicitly offered.

## Why

Many card implementations pass `choices + [None]` to model optional effects. Stripping `None` made those effects automatic for GeneticAI.

## Validation

- `pytest -q tests/test_genetic_ai_optional_choices.py tests/test_strategy_library.py`
- Full combined suite was also run from the source workspace: `1474 passed`.