### PR TITLE
[codex] Fix Catapult mandatory trash attacks

### DIFF
--- a/dominion/cards/empires/catapult.py
+++ b/dominion/cards/empires/catapult.py
@@ -20,18 +20,18 @@ class Catapult(TopSplitPileCard):
         if not player.hand:
             return
 
-        to_trash = player.ai.choose_card_to_trash(
-            game_state, list(player.hand) + [None]
-        )
+        get_cost = getattr(game_state, "get_card_cost", None)
+
+        def card_cost(card):
+            return get_cost(player, card) if get_cost is not None else card.cost.coins
+
+        to_trash = player.ai.choose_card_to_trash(game_state, list(player.hand))
         if to_trash is None:
-            return
+            to_trash = min(player.hand, key=card_cost)
         if to_trash not in player.hand:
             return
 
-        get_cost = getattr(game_state, "get_card_cost", None)
-        trashed_cost = (
-            get_cost(player, to_trash) if get_cost is not None else to_trash.cost.coins
-        )
+        trashed_cost = card_cost(to_trash)
         player.hand.remove(to_trash)
         game_state.trash_card(player, to_trash)
         player.coins += min(2, trashed_cost)

--- a/dominion/cards/empires/catapult.py
+++ b/dominion/cards/empires/catapult.py
@@ -37,7 +37,7 @@ class Catapult(TopSplitPileCard):
         player.coins += min(2, trashed_cost)
 
         gives_curse = trashed_cost >= 3
-        discards_to_three = to_trash.is_treasure
+        discards_to_three = game_state.is_treasure(to_trash)
         if not gives_curse and not discards_to_three:
             return
 

--- a/dominion/cards/empires/catapult.py
+++ b/dominion/cards/empires/catapult.py
@@ -3,7 +3,7 @@ from ..split_pile import TopSplitPileCard
 
 
 class Catapult(TopSplitPileCard):
-    """Simplified Catapult that trashes a card for coins and attacks opponents."""
+    """Catapult: trash a card for coins and conditional attacks."""
 
     partner_card_name = "Rocks"
 
@@ -22,18 +22,52 @@ class Catapult(TopSplitPileCard):
 
         to_trash = player.ai.choose_card_to_trash(game_state, list(player.hand))
         if to_trash is None:
-            # Default to trashing lowest-cost card to keep the effect flowing
-            to_trash = min(player.hand, key=lambda c: c.cost.coins)
-        if to_trash in player.hand:
-            player.hand.remove(to_trash)
-            game_state.trash_card(player, to_trash)
-            player.coins += min(2, to_trash.cost.coins)
+            return
+        if to_trash not in player.hand:
+            return
+
+        get_cost = getattr(game_state, "get_card_cost", None)
+        trashed_cost = (
+            get_cost(player, to_trash) if get_cost is not None else to_trash.cost.coins
+        )
+        player.hand.remove(to_trash)
+        game_state.trash_card(player, to_trash)
+        player.coins += min(2, trashed_cost)
+
+        gives_curse = trashed_cost >= 3
+        discards_to_three = to_trash.is_treasure
+        if not gives_curse and not discards_to_three:
+            return
 
         def attack(target):
-            while len(target.hand) > 3:
-                game_state.discard_card(target, target.hand.pop())
+            if gives_curse:
+                game_state.give_curse_to_player(target)
+
+            excess = len(target.hand) - 3
+            if discards_to_three and excess > 0:
+                choices = target.ai.choose_cards_to_discard(
+                    game_state, target, list(target.hand), excess, reason="catapult"
+                )
+                chosen = []
+                for card in choices or []:
+                    if (
+                        card in target.hand
+                        and card not in chosen
+                        and len(chosen) < excess
+                    ):
+                        chosen.append(card)
+                if len(chosen) < excess:
+                    for card in list(target.hand):
+                        if card not in chosen:
+                            chosen.append(card)
+                        if len(chosen) == excess:
+                            break
+                for card in chosen:
+                    if card in target.hand:
+                        target.hand.remove(card)
+                        game_state.discard_card(target, card)
 
         for other in game_state.players:
             if other is player:
                 continue
-            game_state.attack_player(other, attack)
+            game_state.attack_player(other, attack, attacker=player, attack_card=self)

--- a/dominion/cards/empires/catapult.py
+++ b/dominion/cards/empires/catapult.py
@@ -20,7 +20,9 @@ class Catapult(TopSplitPileCard):
         if not player.hand:
             return
 
-        to_trash = player.ai.choose_card_to_trash(game_state, list(player.hand))
+        to_trash = player.ai.choose_card_to_trash(
+            game_state, list(player.hand) + [None]
+        )
         if to_trash is None:
             return
         if to_trash not in player.hand:

--- a/tests/test_catapult_card.py
+++ b/tests/test_catapult_card.py
@@ -1,0 +1,126 @@
+from dominion.cards.empires.catapult import Catapult
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from tests.utils import DummyAI
+
+
+class CatapultAI(DummyAI):
+    def __init__(self, trash_name=None, discard_names=None):
+        super().__init__()
+        self.trash_name = trash_name
+        self.discard_names = discard_names or []
+        self.discard_calls = 0
+
+    def choose_card_to_trash(self, state, choices):
+        if self.trash_name is None:
+            return None
+        return next((card for card in choices if card.name == self.trash_name), None)
+
+    def choose_cards_to_discard(self, state, player, choices, count, *, reason=None):
+        self.discard_calls += 1
+        selected = []
+        for name in self.discard_names:
+            for card in choices:
+                if card.name == name and card not in selected:
+                    selected.append(card)
+                    break
+            if len(selected) == count:
+                break
+        return selected
+
+
+def make_state(attacker_ai, defender_ai=None):
+    defender_ai = defender_ai or CatapultAI()
+    players = [PlayerState(attacker_ai), PlayerState(defender_ai)]
+    state = GameState(players=players)
+    state.setup_supply([])
+    state.current_player_index = 0
+    for player in players:
+        player.hand = []
+        player.deck = []
+        player.discard = []
+        player.in_play = []
+        player.duration = []
+        player.coins = 0
+    return state
+
+
+def play_catapult(state):
+    Catapult().on_play(state)
+
+
+def test_catapult_ai_can_skip_trashing_and_attack():
+    state = make_state(CatapultAI(trash_name=None))
+    attacker, defender = state.players
+    attacker.hand = [get_card("Copper")]
+    defender.hand = [get_card("Copper") for _ in range(5)]
+
+    play_catapult(state)
+
+    assert [card.name for card in attacker.hand] == ["Copper"]
+    assert attacker.coins == 1
+    assert state.trash == []
+    assert len(defender.hand) == 5
+    assert not any(card.name == "Curse" for card in defender.discard)
+
+
+def test_catapult_trashing_copper_gives_coins_but_no_curse():
+    state = make_state(CatapultAI(trash_name="Copper"))
+    attacker, defender = state.players
+    attacker.hand = [get_card("Copper")]
+    defender.hand = [get_card("Copper") for _ in range(3)]
+
+    play_catapult(state)
+
+    assert attacker.coins == 1
+    assert [card.name for card in state.trash] == ["Copper"]
+    assert attacker.hand == []
+    assert len(defender.hand) == 3
+    assert defender.discard == []
+
+
+def test_catapult_trashing_silver_curses_and_discards_to_three():
+    defender_ai = CatapultAI(discard_names=["Estate", "Duchy"])
+    state = make_state(CatapultAI(trash_name="Silver"), defender_ai)
+    attacker, defender = state.players
+    attacker.hand = [get_card("Silver")]
+    defender.hand = [
+        get_card("Copper"),
+        get_card("Estate"),
+        get_card("Silver"),
+        get_card("Duchy"),
+        get_card("Gold"),
+    ]
+
+    play_catapult(state)
+
+    assert attacker.coins == 3
+    assert [card.name for card in state.trash] == ["Silver"]
+    assert sum(1 for card in defender.discard if card.name == "Curse") == 1
+    assert [card.name for card in defender.discard[:2]] == ["Curse", "Estate"]
+    assert defender.discard[2].name == "Duchy"
+    assert [card.name for card in defender.hand] == ["Copper", "Silver", "Gold"]
+    assert defender_ai.discard_calls == 1
+
+
+def test_catapult_trashing_non_treasure_cost_three_only_curses():
+    defender_ai = CatapultAI(discard_names=["Copper", "Estate"])
+    state = make_state(CatapultAI(trash_name="Village"), defender_ai)
+    attacker, defender = state.players
+    attacker.hand = [get_card("Village")]
+    defender.hand = [
+        get_card("Copper"),
+        get_card("Estate"),
+        get_card("Silver"),
+        get_card("Duchy"),
+        get_card("Gold"),
+    ]
+
+    play_catapult(state)
+
+    assert attacker.coins == 3
+    assert [card.name for card in state.trash] == ["Village"]
+    assert sum(1 for card in defender.discard if card.name == "Curse") == 1
+    assert len(defender.hand) == 5
+    assert defender_ai.discard_calls == 0

--- a/tests/test_catapult_card.py
+++ b/tests/test_catapult_card.py
@@ -11,8 +11,10 @@ class CatapultAI(DummyAI):
         self.trash_name = trash_name
         self.discard_names = discard_names or []
         self.discard_calls = 0
+        self.trash_choices = None
 
     def choose_card_to_trash(self, state, choices):
+        self.trash_choices = choices
         if self.trash_name is None:
             return None
         return next((card for card in choices if card.name == self.trash_name), None)
@@ -51,13 +53,18 @@ def play_catapult(state):
 
 
 def test_catapult_ai_can_skip_trashing_and_attack():
-    state = make_state(CatapultAI(trash_name=None))
+    attacker_ai = CatapultAI(trash_name=None)
+    state = make_state(attacker_ai)
     attacker, defender = state.players
     attacker.hand = [get_card("Copper")]
     defender.hand = [get_card("Copper") for _ in range(5)]
 
     play_catapult(state)
 
+    assert [card.name if card is not None else None for card in attacker_ai.trash_choices] == [
+        "Copper",
+        None,
+    ]
     assert [card.name for card in attacker.hand] == ["Copper"]
     assert attacker.coins == 1
     assert state.trash == []

--- a/tests/test_catapult_card.py
+++ b/tests/test_catapult_card.py
@@ -52,7 +52,7 @@ def play_catapult(state):
     Catapult().on_play(state)
 
 
-def test_catapult_ai_can_skip_trashing_and_attack():
+def test_catapult_ai_decline_falls_back_to_mandatory_trash():
     attacker_ai = CatapultAI(trash_name=None)
     state = make_state(attacker_ai)
     attacker, defender = state.players
@@ -61,14 +61,11 @@ def test_catapult_ai_can_skip_trashing_and_attack():
 
     play_catapult(state)
 
-    assert [card.name if card is not None else None for card in attacker_ai.trash_choices] == [
-        "Copper",
-        None,
-    ]
-    assert [card.name for card in attacker.hand] == ["Copper"]
+    assert [card.name for card in attacker_ai.trash_choices] == ["Copper"]
+    assert attacker.hand == []
     assert attacker.coins == 1
-    assert state.trash == []
-    assert len(defender.hand) == 5
+    assert [card.name for card in state.trash] == ["Copper"]
+    assert len(defender.hand) == 3
     assert not any(card.name == "Curse" for card in defender.discard)
 
 

--- a/tests/test_catapult_card.py
+++ b/tests/test_catapult_card.py
@@ -128,3 +128,26 @@ def test_catapult_trashing_non_treasure_cost_three_only_curses():
     assert sum(1 for card in defender.discard if card.name == "Curse") == 1
     assert len(defender.hand) == 5
     assert defender_ai.discard_calls == 0
+
+
+def test_catapult_trashing_curse_with_charlatan_discards_to_three():
+    defender_ai = CatapultAI(discard_names=["Estate", "Duchy"])
+    state = make_state(CatapultAI(trash_name="Curse"), defender_ai)
+    state.setup_supply([get_card("Charlatan")])
+    attacker, defender = state.players
+    attacker.hand = [get_card("Curse")]
+    defender.hand = [
+        get_card("Copper"),
+        get_card("Estate"),
+        get_card("Silver"),
+        get_card("Duchy"),
+        get_card("Gold"),
+    ]
+
+    play_catapult(state)
+
+    assert [card.name for card in state.trash] == ["Curse"]
+    assert not any(card.name == "Curse" for card in defender.discard)
+    assert [card.name for card in defender.discard] == ["Estate", "Duchy"]
+    assert [card.name for card in defender.hand] == ["Copper", "Silver", "Gold"]
+    assert defender_ai.discard_calls == 1


### PR DESCRIPTION
Catapult now keeps its mandatory trash behavior: if an AI declines while cards remain, it falls back to the lowest-cost hand card. It applies conditional attacks based on the trashed card: cost $3+ cards give Curses and live Treasures force opponents to discard down to 3, including Curse under Charlatan. The discard attack asks defenders which cards to discard and passes attack metadata through `attack_player`. Added focused tests for mandatory fallback, low-cost trash, Treasure trash, non-Treasure cost-$3 trash, and Charlatan Curse-as-Treasure behavior.

Validation: `pytest -q tests/test_catapult_card.py`.