### PR TITLE
Add strategy linting, roles, and phase-aware planning

### DIFF
--- a/dominion/reporting/html_report.py
+++ b/dominion/reporting/html_report.py
@@ -33,6 +33,18 @@ def _decision_firings_section(results: dict) -> str:
         strategy_name = escape(str(stats.get("strategy_name", role)))
         rows = []
 
+        for list_name, firings in sorted((stats.get("priority_rules") or {}).items()):
+            top = sorted(firings.items(), key=lambda item: item[1], reverse=True)[:8]
+            for rule_key, count in top:
+                rows.append(
+                    "<tr>"
+                    f"<td>priority:{escape(str(list_name))}</td>"
+                    "<td>Rule fired</td>"
+                    f"<td>{escape(str(rule_key))}</td>"
+                    f"<td>{count}</td>"
+                    "</tr>"
+                )
+
         for card_name, ways in sorted((stats.get("choose_way") or {}).items()):
             for way_name, count in sorted(ways.items()):
                 rows.append(

--- a/dominion/runner.py
+++ b/dominion/runner.py
@@ -11,6 +11,7 @@ from dominion.boards.loader import BoardConfig, load_board
 from dominion.analysis.strategy_library import find_compatible_strategies
 from dominion.simulation.genetic_trainer import GeneticTrainer
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
+from dominion.strategy.lint import lint_strategy, normalize_strategy
 
 logger = logging.getLogger(__name__)
 coloredlogs.install(level="INFO", logger=logger)
@@ -230,6 +231,7 @@ def main():
         mutation_rate=mutation_rate,
         games_per_eval=games_per_eval,
         board_config=board_config,
+        default_baseline_panel=True,
     )
 
     # Load strategies from module:function paths
@@ -321,6 +323,15 @@ def main():
                 ", ".join(strategy.name for strategy in reused_panel),
             )
 
+    if not panel and trainer.default_baseline_panel:
+        panel = trainer.build_default_baseline_panel()
+        if len(panel) > 1:
+            trainer.set_baseline_panel(panel)
+            logger.info("Using default baseline panel: %s", ", ".join(p.name for p in panel))
+        elif panel:
+            trainer.set_baseline_strategy(panel[0])
+            logger.info("Using default baseline: %s", panel[0].name)
+
     logger.info("Training parameters:")
     logger.info("  Population size: %d", population_size)
     logger.info("  Generations: %d", generations)
@@ -336,6 +347,22 @@ def main():
     if best_strategy is None:
         logger.info("No viable strategy was found.")
     else:
+        best_strategy = normalize_strategy(best_strategy)
+        lint_warnings = lint_strategy(best_strategy)
+        if lint_warnings:
+            logger.info("Strategy lint diagnostics:")
+            for warning in lint_warnings[:10]:
+                logger.info(
+                    "  [%s] %s[%d] %s: %s",
+                    warning.severity,
+                    warning.list_name,
+                    warning.index,
+                    warning.card_name,
+                    warning.message,
+                )
+            if len(lint_warnings) > 10:
+                logger.info("  ... %d more diagnostics", len(lint_warnings) - 10)
+
         logger.info("Best strategy card priorities:")
         for rule in best_strategy.gain_priority:
             condition_str = f" (condition: {rule.condition})" if rule.condition else ""

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -49,6 +49,7 @@ class GeneticTrainer:
         rule_pruning: bool = True,
         prune_warmup_generations: int = 3,
         prune_min_rules: int = 3,
+        default_baseline_panel: bool = False,
     ):
         if kingdom_cards is None:
             if board_config is None:
@@ -69,6 +70,7 @@ class GeneticTrainer:
         self.rule_pruning = rule_pruning
         self.prune_warmup_generations = prune_warmup_generations
         self.prune_min_rules = prune_min_rules
+        self.default_baseline_panel = default_baseline_panel
         self.battle_system = StrategyBattle(kingdom_cards, log_folder, board_config=board_config)
         if not self.kingdom_cards:
             raise ValueError("kingdom_cards cannot be empty")
@@ -108,6 +110,42 @@ class GeneticTrainer:
         self._kingdom_ways: list[str] = []
         if board_config is not None and board_config.ways:
             self._kingdom_ways = [canonical_way_name(w) for w in board_config.ways]
+
+    _DEFAULT_BASELINE_NAMES = (
+        "Big Money",
+        "Big Money Smithy",
+        "Chapel Witch",
+        "Village Smithy Lab",
+    )
+
+    def build_default_baseline_panel(self) -> list[BaseStrategy]:
+        """Return built-in baseline opponents compatible with this kingdom."""
+
+        kingdom_set = set(self.kingdom_cards)
+        panel: list[BaseStrategy] = []
+        seen_names: set[str] = set()
+
+        for name in self._DEFAULT_BASELINE_NAMES:
+            strategy = self.battle_system.strategy_loader.get_strategy(name)
+            if strategy is None:
+                continue
+            refs = self.battle_system._split_board_references(
+                self.battle_system._extract_cards_from_strategy(strategy)
+            )
+            if not set(refs.kingdom_cards).issubset(kingdom_set):
+                continue
+            if refs.events or refs.projects or refs.ways or refs.landmarks or refs.allies:
+                continue
+            if strategy.name in seen_names:
+                continue
+            seen_names.add(strategy.name)
+            panel.append(strategy)
+
+        if not panel:
+            big_money = self.battle_system.strategy_loader.get_strategy("Big Money")
+            if big_money is not None:
+                panel.append(big_money)
+        return panel
 
     # Probability that ``_random_condition_with_compound`` wraps a normally
     # sampled inner condition in ``and_(card_in_play(X), inner)``. Tunable.
@@ -334,6 +372,10 @@ class GeneticTrainer:
             return self._baseline_panel
         if self._baseline_strategy is not None:
             return [self._baseline_strategy]
+        if self.default_baseline_panel:
+            panel = self.build_default_baseline_panel()
+            if panel:
+                return panel
         big_money = self.battle_system.strategy_loader.get_strategy("Big Money")
         if not big_money:
             raise ValueError("Big Money strategy not found")

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -79,6 +79,7 @@ class GeneticTrainer:
         self._strategies_to_inject: list[BaseStrategy] = []
         self._baseline_strategy = None
         self._baseline_panel: list[BaseStrategy] = []
+        self._default_baseline_panel_cache: list[BaseStrategy] | None = None
         # List of per-opponent breakdown tuples. With ``shape_rewards=False``
         # each entry is ``(name, win_rate)``; with shaping on each entry is
         # ``(name, win_rate, avg_margin, shaped_fitness)``. Stored as a list
@@ -373,9 +374,10 @@ class GeneticTrainer:
         if self._baseline_strategy is not None:
             return [self._baseline_strategy]
         if self.default_baseline_panel:
-            panel = self.build_default_baseline_panel()
-            if panel:
-                return panel
+            if self._default_baseline_panel_cache is None:
+                self._default_baseline_panel_cache = self.build_default_baseline_panel()
+            if self._default_baseline_panel_cache:
+                return self._default_baseline_panel_cache
         big_money = self.battle_system.strategy_loader.get_strategy("Big Money")
         if not big_money:
             raise ValueError("Big Money strategy not found")

--- a/dominion/simulation/strategy_battle.py
+++ b/dominion/simulation/strategy_battle.py
@@ -247,6 +247,12 @@ class StrategyBattle:
     def _empty_decision_firings(strategy_name: str) -> dict[str, Any]:
         return {
             "strategy_name": strategy_name,
+            "priority_rules": {
+                "gain": {},
+                "action": {},
+                "treasure": {},
+                "trash": {},
+            },
             "choose_way": {},
             "choose_gain_overrides": {
                 "total": 0,
@@ -265,6 +271,13 @@ class StrategyBattle:
 
     @staticmethod
     def _merge_decision_firings(total: dict[str, Any], game: dict[str, Any]) -> None:
+        for list_name, rules in (game.get("priority_rules") or {}).items():
+            total["priority_rules"].setdefault(list_name, {})
+            for rule_key, count in rules.items():
+                total["priority_rules"][list_name][rule_key] = (
+                    total["priority_rules"][list_name].get(rule_key, 0) + count
+                )
+
         for card_name, ways in game["choose_way"].items():
             for way_name, count in ways.items():
                 total["choose_way"].setdefault(card_name, {})
@@ -293,6 +306,16 @@ class StrategyBattle:
     def _instrument_ai_decisions(self, ai: GeneticAI, stats: dict[str, Any]) -> None:
         original_choose_way = ai.choose_way
         original_choose_buy = ai.choose_buy
+        original_callback = getattr(ai.strategy, "_decision_trace_callback", None)
+
+        def trace_priority_rule(list_name, rule, _card, _state, _player):
+            bucket = stats["priority_rules"].setdefault(list_name, {})
+            condition_source = getattr(getattr(rule, "condition", None), "_source", None)
+            condition_label = condition_source or "always"
+            key = f"{rule.card_name} [{condition_label}]"
+            self._increment_count(bucket, key)
+            if original_callback is not None:
+                original_callback(list_name, rule, _card, _state, _player)
 
         def tracked_choose_way(state, card, ways):
             way = original_choose_way(state, card, ways)
@@ -307,7 +330,12 @@ class StrategyBattle:
         def tracked_choose_buy(state, choices):
             valid_choices = [c for c in choices if c is not None]
             player = getattr(state, "current_player", None)
-            top_priority = self._top_gain_priority_choice(ai.strategy, state, player, valid_choices)
+            current_callback = getattr(ai.strategy, "_decision_trace_callback", None)
+            ai.strategy._decision_trace_callback = None
+            try:
+                top_priority = self._top_gain_priority_choice(ai.strategy, state, player, valid_choices)
+            finally:
+                ai.strategy._decision_trace_callback = current_callback
             selected = original_choose_buy(state, choices)
             if (
                 selected is not None
@@ -323,6 +351,7 @@ class StrategyBattle:
                 )
             return selected
 
+        ai.strategy._decision_trace_callback = trace_priority_rule
         ai.choose_way = tracked_choose_way
         ai.choose_buy = tracked_choose_buy
 
@@ -679,6 +708,14 @@ def log_decision_firings(results: dict[str, Any]) -> None:
                 logger.info("      %s -> %s: %d", card_name, way_name, count)
         else:
             logger.info("    choose_way: 0")
+
+        priority_rules = stats.get("priority_rules") or {}
+        for list_name, firings in sorted(priority_rules.items()):
+            if not firings:
+                continue
+            logger.info("    priority:%s top firings:", list_name)
+            for rule_key, count in sorted(firings.items(), key=lambda item: item[1], reverse=True)[:5]:
+                logger.info("      %s: %d", rule_key, count)
 
         gain_stats = stats.get("choose_gain_overrides") or {}
         logger.info("    choose_gain special cases: %d", gain_stats.get("total", 0))

--- a/dominion/strategy/card_roles.py
+++ b/dominion/strategy/card_roles.py
@@ -1,0 +1,96 @@
+"""Lightweight card-role inference for strategy planning.
+
+These roles are intentionally heuristic. They give phase-aware strategies and
+seed builders a shared vocabulary ("village", "terminal_draw", "payload",
+"gainer", etc.) without requiring every card implementation to maintain a
+manual metadata table.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from functools import lru_cache
+
+from dominion.cards.base_card import Card
+from dominion.cards.registry import get_card
+
+
+@dataclass(frozen=True)
+class CardRoleProfile:
+    name: str
+    roles: frozenset[str]
+
+    def has(self, role: str) -> bool:
+        return role in self.roles
+
+
+def _class_source(card: Card) -> str:
+    try:
+        return inspect.getsource(type(card))
+    except (OSError, TypeError):
+        return ""
+
+
+@lru_cache(maxsize=None)
+def infer_card_roles(card_name: str) -> CardRoleProfile:
+    """Infer broad strategic roles for a card name."""
+
+    card = get_card(card_name)
+    roles: set[str] = set()
+    source = _class_source(card)
+
+    if card.is_action:
+        roles.add("action")
+        if card.stats.actions > 0:
+            roles.add("nonterminal")
+            roles.add("village")
+        else:
+            roles.add("terminal")
+        if card.stats.cards >= 1 and card.stats.actions >= 1:
+            roles.add("cantrip")
+        if card.stats.cards >= 2:
+            roles.add("draw")
+        if card.stats.cards >= 2 and card.stats.actions == 0:
+            roles.add("terminal_draw")
+        if card.stats.coins >= 2 or card.stats.buys > 0:
+            roles.add("payload")
+        if card.is_attack:
+            roles.add("attack")
+        if card.is_duration:
+            roles.add("duration")
+        if card.is_command:
+            roles.add("command")
+
+    if card.is_treasure:
+        roles.add("treasure")
+        if card.stats.coins >= 2:
+            roles.add("payload")
+
+    if card.is_victory:
+        roles.add("victory")
+
+    lowered = source.lower()
+    if "trash" in lowered:
+        roles.add("trasher")
+    if "gain_card(" in source:
+        roles.add("gainer")
+    if "discard" in lowered and card.is_action:
+        roles.add("sifter")
+    if "choose_" in source or "should_" in source:
+        roles.add("mode_or_choice")
+
+    return CardRoleProfile(card.name, frozenset(roles))
+
+
+def cards_with_role(card_names: list[str], role: str) -> list[str]:
+    """Return the subset of ``card_names`` inferred to have ``role``."""
+
+    matched: list[str] = []
+    for card_name in card_names:
+        try:
+            if infer_card_roles(card_name).has(role):
+                matched.append(card_name)
+        except (KeyError, ValueError):
+            continue
+    return matched

--- a/dominion/strategy/card_roles.py
+++ b/dominion/strategy/card_roles.py
@@ -36,7 +36,13 @@ def _class_source(card: Card) -> str:
 def infer_card_roles(card_name: str) -> CardRoleProfile:
     """Infer broad strategic roles for a card name."""
 
-    card = get_card(card_name)
+    try:
+        card = get_card(card_name)
+    except (KeyError, ValueError):
+        return CardRoleProfile(card_name, frozenset())
+    if card is None:
+        return CardRoleProfile(card_name, frozenset())
+
     roles: set[str] = set()
     source = _class_source(card)
 

--- a/dominion/strategy/enhanced_strategy.py
+++ b/dominion/strategy/enhanced_strategy.py
@@ -77,9 +77,27 @@ class PriorityRule:
 
     @staticmethod
     def has_cards(cards: Iterable[str], amount: int) -> Callable[["GameState", "PlayerState"], bool]:
+        """True when the player has at least ``amount`` matching cards.
+
+        ``amount=0`` is treated as "has none" rather than the mathematically
+        tautological "has at least zero". Older evolved strategies commonly
+        used ``has_cards(["X"], 0)`` to mean "do not have X yet"; preserving
+        that intent avoids always-true rules that look strategic but fire
+        unconditionally.
+        """
         card_list = list(cards)
-        fn = lambda _s, me, _amount=amount, _cards=card_list: sum(me.count_in_deck(c) for c in _cards) >= _amount
+        if amount <= 0:
+            fn = lambda _s, me, _cards=card_list: sum(me.count_in_deck(c) for c in _cards) == 0
+        else:
+            fn = lambda _s, me, _amount=amount, _cards=card_list: sum(me.count_in_deck(c) for c in _cards) >= _amount
         return PriorityRule._tag_source(fn, f"PriorityRule.has_cards({card_list!r}, {amount!r})")
+
+    @staticmethod
+    def has_no_cards(cards: Iterable[str]) -> Callable[["GameState", "PlayerState"], bool]:
+        """Explicit spelling for "none of these cards are in the deck"."""
+        card_list = list(cards)
+        fn = lambda _s, me, _cards=card_list: sum(me.count_in_deck(c) for c in _cards) == 0
+        return PriorityRule._tag_source(fn, f"PriorityRule.has_no_cards({card_list!r})")
 
     @staticmethod
     def max_in_deck(card_name: str, amount: int) -> Callable[["GameState", "PlayerState"], bool]:
@@ -292,6 +310,7 @@ class EnhancedStrategy:
         self.trash_priority: list[PriorityRule] = []
         self.treasure_priority: list[PriorityRule] = []
         self.way_policy: list[WayRule] = []
+        self._decision_trace_callback = None
 
     # ------------------------------------------------------------------
     def _choose_from_priority(
@@ -300,6 +319,7 @@ class EnhancedStrategy:
         choices: list[Optional[Card]],
         state: GameState,
         player: PlayerState,
+        list_name: str = "priority",
     ) -> Optional[Card]:
         """Return the first card whose rule condition evaluates to True.
 
@@ -334,6 +354,12 @@ class EnhancedStrategy:
                     # evolution to drop rules that never affect a buy/play
                     # decision across an entire fitness-eval window.
                     rule._fired = True
+                    callback = getattr(self, "_decision_trace_callback", None)
+                    if callback is not None:
+                        try:
+                            callback(list_name, rule, card, state, player)
+                        except Exception:
+                            pass
                     return card
 
         return None
@@ -348,7 +374,7 @@ class EnhancedStrategy:
                 and self._can_butterfly(state)
                 and self._best_butterfly_target(state, player, real[0].cost.coins + 1)):
             return real[0]
-        result = self._choose_from_priority(self.action_priority, choices, state, player)
+        result = self._choose_from_priority(self.action_priority, choices, state, player, "action")
         if result is not None:
             return result
 
@@ -384,7 +410,7 @@ class EnhancedStrategy:
         return max(unexpected, key=_t_score)
 
     def choose_treasure(self, state, player, choices):
-        result = self._choose_from_priority(self.treasure_priority, choices, state, player)
+        result = self._choose_from_priority(self.treasure_priority, choices, state, player, "treasure")
         if result is not None:
             return result
 
@@ -394,7 +420,7 @@ class EnhancedStrategy:
         return unexpected[0] if unexpected else None
 
     def choose_gain(self, state, player, choices):
-        normal = self._choose_from_priority(self.gain_priority, choices, state, player)
+        normal = self._choose_from_priority(self.gain_priority, choices, state, player, "gain")
 
         # Trail → Butterfly trick: buy Trail at $4 to gain a $5 card
         trail = next((c for c in choices if c is not None and c.name == "Trail"), None)
@@ -417,7 +443,7 @@ class EnhancedStrategy:
         return normal
 
     def choose_trash(self, state, player, choices):
-        return self._choose_from_priority(self.trash_priority, choices, state, player)
+        return self._choose_from_priority(self.trash_priority, choices, state, player, "trash")
 
     def choose_way(self, state, player, card, ways):
         """Consult ``way_policy`` first; fall back to hardcoded Trail/Butterfly.
@@ -533,7 +559,7 @@ def create_chapel_witch_strategy() -> EnhancedStrategy:
             "Witch", PriorityRule.and_(PriorityRule.turn_number(">=", 3), PriorityRule.resources("actions", ">=", 1))
         ),
         # Laboratory for draw
-        PriorityRule("Laboratory", PriorityRule.always_true),
+        PriorityRule("Laboratory", PriorityRule.always_true()),
     ]
 
     # Gain priorities

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -1,0 +1,197 @@
+"""Diagnostics for generated and hand-written strategies.
+
+The strategy executor is deliberately simple: it walks ordered priority lists
+and picks the first matching card. That makes several mistakes easy to write
+and hard to notice from win-rate alone: duplicate rules, unreachable rules
+after an unconditional rule for the same card, old ``has_cards(..., 0)``
+conditions, and unconditional early greening.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, Literal, Optional
+
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
+from dominion.strategy.genome_simplification import simplify_strategy
+
+Severity = Literal["info", "warning", "error"]
+
+_HAS_CARDS_ZERO_RE = re.compile(r"^PriorityRule\.has_cards\(.+,\s*0\)$")
+
+
+@dataclass(frozen=True)
+class StrategyLintWarning:
+    """A single strategy diagnostic."""
+
+    code: str
+    message: str
+    list_name: str
+    index: int
+    card_name: str
+    severity: Severity = "warning"
+
+
+def _condition_source(condition) -> Optional[str]:
+    if condition is None:
+        return None
+    return getattr(condition, "_source", repr(condition))
+
+
+def _rule_signature(rule: PriorityRule) -> tuple[str, Optional[str]]:
+    return rule.card_name, _condition_source(rule.condition)
+
+
+def _lint_priority_list(
+    list_name: str,
+    rules: Iterable[PriorityRule],
+) -> list[StrategyLintWarning]:
+    warnings: list[StrategyLintWarning] = []
+    seen_signatures: set[tuple[str, Optional[str]]] = set()
+    first_unconditional: dict[str, int] = {}
+    seen_province = False
+
+    for idx, rule in enumerate(rules):
+        card_name = rule.card_name
+        condition_source = _condition_source(rule.condition)
+
+        if condition_source and _HAS_CARDS_ZERO_RE.match(condition_source):
+            warnings.append(
+                StrategyLintWarning(
+                    code="HAS_CARDS_ZERO",
+                    message=(
+                        "has_cards(..., 0) now means 'has none'; prefer "
+                        "has_no_cards(...) for readability."
+                    ),
+                    list_name=list_name,
+                    index=idx,
+                    card_name=card_name,
+                    severity="info",
+                )
+            )
+
+        if card_name in first_unconditional:
+            warnings.append(
+                StrategyLintWarning(
+                    code="UNREACHABLE_AFTER_UNCONDITIONAL",
+                    message=(
+                        f"Earlier unconditional {card_name} rule at index "
+                        f"{first_unconditional[card_name]} always wins first."
+                    ),
+                    list_name=list_name,
+                    index=idx,
+                    card_name=card_name,
+                )
+            )
+
+        sig = _rule_signature(rule)
+        if sig in seen_signatures:
+            warnings.append(
+                StrategyLintWarning(
+                    code="DUPLICATE_RULE",
+                    message="An identical card/condition rule already appears earlier.",
+                    list_name=list_name,
+                    index=idx,
+                    card_name=card_name,
+                )
+            )
+        seen_signatures.add(sig)
+
+        if list_name == "gain":
+            if card_name == "Province":
+                seen_province = True
+            if (
+                card_name in {"Duchy", "Estate"}
+                and rule.condition is None
+                and not seen_province
+            ):
+                warnings.append(
+                    StrategyLintWarning(
+                        code="UNCONDITIONAL_GREEN_BEFORE_PROVINCE",
+                        message=(
+                            f"Unconditional {card_name} appears before any "
+                            "Province rule; this often indicates a noisy rush."
+                        ),
+                        list_name=list_name,
+                        index=idx,
+                        card_name=card_name,
+                    )
+                )
+            if card_name in {"Copper", "Curse"} and rule.condition is None:
+                warnings.append(
+                    StrategyLintWarning(
+                        code="UNCONDITIONAL_JUNK_GAIN",
+                        message=f"Unconditional {card_name} gain is rarely intentional.",
+                        list_name=list_name,
+                        index=idx,
+                        card_name=card_name,
+                    )
+                )
+
+        if rule.condition is None:
+            first_unconditional.setdefault(card_name, idx)
+
+    return warnings
+
+
+def _lint_way_policy(rules: Iterable[WayRule]) -> list[StrategyLintWarning]:
+    warnings: list[StrategyLintWarning] = []
+    seen_signatures: set[tuple[str, str, Optional[str]]] = set()
+    first_unconditional: dict[tuple[str, str], int] = {}
+
+    for idx, rule in enumerate(rules):
+        source = _condition_source(rule.condition)
+        pair = (rule.card_name, rule.way_name)
+        sig = (rule.card_name, rule.way_name, source)
+
+        if pair in first_unconditional:
+            warnings.append(
+                StrategyLintWarning(
+                    code="UNREACHABLE_WAY_AFTER_UNCONDITIONAL",
+                    message=(
+                        f"Earlier unconditional {rule.card_name} -> {rule.way_name} "
+                        f"rule at index {first_unconditional[pair]} always wins first."
+                    ),
+                    list_name="way_policy",
+                    index=idx,
+                    card_name=rule.card_name,
+                )
+            )
+        if sig in seen_signatures:
+            warnings.append(
+                StrategyLintWarning(
+                    code="DUPLICATE_WAY_RULE",
+                    message="An identical card/way/condition rule already appears earlier.",
+                    list_name="way_policy",
+                    index=idx,
+                    card_name=rule.card_name,
+                )
+            )
+        seen_signatures.add(sig)
+        if rule.condition is None:
+            first_unconditional.setdefault(pair, idx)
+
+    return warnings
+
+
+def lint_strategy(strategy: EnhancedStrategy) -> list[StrategyLintWarning]:
+    """Return diagnostics for the strategy without mutating it."""
+
+    warnings: list[StrategyLintWarning] = []
+    for list_name, rules in (
+        ("gain", getattr(strategy, "gain_priority", []) or []),
+        ("action", getattr(strategy, "action_priority", []) or []),
+        ("treasure", getattr(strategy, "treasure_priority", []) or []),
+        ("trash", getattr(strategy, "trash_priority", []) or []),
+    ):
+        warnings.extend(_lint_priority_list(list_name, rules))
+
+    warnings.extend(_lint_way_policy(getattr(strategy, "way_policy", []) or []))
+    return warnings
+
+
+def normalize_strategy(strategy: EnhancedStrategy) -> EnhancedStrategy:
+    """Return a behavior-preserving simplified copy of ``strategy``."""
+
+    return simplify_strategy(strategy)

--- a/dominion/strategy/phase_strategy.py
+++ b/dominion/strategy/phase_strategy.py
@@ -1,0 +1,70 @@
+"""Phase-aware strategy helpers.
+
+Flat priority lists are useful for serialization and genetic mutation, but a
+good Dominion plan usually changes shape over time: opening, building, adding
+payload, and greening are different jobs. ``PhaseAwareStrategy`` keeps the old
+``EnhancedStrategy`` API while allowing strategies to provide phase-specific
+priority lists that override the global fallback lists.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class StrategyPhase(StrEnum):
+    OPENING = "opening"
+    BUILD = "build"
+    PAYLOAD = "payload"
+    GREEN = "green"
+    ENDGAME = "endgame"
+
+
+class PhaseAwareStrategy(EnhancedStrategy):
+    """EnhancedStrategy with optional phase-specific priorities."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.phase_gain_priority: dict[StrategyPhase, list[PriorityRule]] = {}
+        self.phase_action_priority: dict[StrategyPhase, list[PriorityRule]] = {}
+
+    def classify_phase(self, state: GameState, player: PlayerState) -> StrategyPhase:
+        provinces_left = state.supply.get("Province", 0)
+        empty_piles = getattr(state, "empty_piles", 0)
+
+        if provinces_left <= 2 or empty_piles >= 2:
+            return StrategyPhase.ENDGAME
+        if provinces_left <= 4:
+            return StrategyPhase.GREEN
+        if state.turn_number <= 4:
+            return StrategyPhase.OPENING
+
+        action_count = sum(1 for card in player.all_cards() if getattr(card, "is_action", False))
+        payload_count = sum(
+            1
+            for card in player.all_cards()
+            if getattr(card, "is_treasure", False) and getattr(card, "cost", None) and card.cost.coins >= 6
+        )
+        if action_count >= 3 and payload_count < 2:
+            return StrategyPhase.PAYLOAD
+        return StrategyPhase.BUILD
+
+    def choose_gain(self, state, player, choices):
+        phase = self.classify_phase(state, player)
+        phase_rules = self.phase_gain_priority.get(phase, [])
+        result = self._choose_from_priority(phase_rules, choices, state, player, f"gain:{phase.value}")
+        if result is not None:
+            return result
+        return super().choose_gain(state, player, choices)
+
+    def choose_action(self, state, player, choices):
+        phase = self.classify_phase(state, player)
+        phase_rules = self.phase_action_priority.get(phase, [])
+        result = self._choose_from_priority(phase_rules, choices, state, player, f"action:{phase.value}")
+        if result is not None:
+            return result
+        return super().choose_action(state, player, choices)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "py-overlord"
 version = "0.1.0"
 description = "Dominion AI Genetic Trainer"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dependencies = [
     "coloredlogs",
     "matplotlib",

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -140,6 +140,18 @@ class TestConditionsEvaluate:
         cond2 = PriorityRule.has_cards(["Silver", "Gold"], 5)
         assert cond2(_make_mock_state(), player) is False
 
+    def test_has_cards_zero_means_has_none(self):
+        cond = PriorityRule.has_cards(["Silver"], 0)
+        assert cond(_make_mock_state(), _make_mock_player()) is False
+
+        empty_player = _make_mock_player()
+        empty_player.count_in_deck = lambda _card_name: 0
+        assert cond(_make_mock_state(), empty_player) is True
+
+    def test_has_no_cards_source(self):
+        cond = PriorityRule.has_no_cards(["Witch"])
+        assert cond._source == "PriorityRule.has_no_cards(['Witch'])"
+
     def test_random_strategy_conditions_evaluate(self):
         """Every callable condition on a random strategy should evaluate without error."""
         trainer = GeneticTrainer(
@@ -568,6 +580,21 @@ class TestPanelEvaluation:
 
         breakdown = trainer.last_eval_breakdown
         assert breakdown == [("AlwaysLose", 100.0), ("AlwaysWin", 0.0)], breakdown
+
+    def test_default_baseline_panel_uses_compatible_builtins(self):
+        trainer = GeneticTrainer(
+            ["Village", "Smithy", "Market", "Festival", "Laboratory", "Mine", "Witch", "Moat", "Workshop", "Chapel"],
+            population_size=1,
+            generations=1,
+            default_baseline_panel=True,
+        )
+
+        panel = trainer.build_default_baseline_panel()
+        names = {strategy.name for strategy in panel}
+
+        assert "BigMoney" in names
+        assert "BigMoneySmithy" in names
+        assert "ChapelWitch" in names
 
 
 def _strategy_with_gain(*card_names: str) -> BaseStrategy:

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -596,6 +596,27 @@ class TestPanelEvaluation:
         assert "BigMoneySmithy" in names
         assert "ChapelWitch" in names
 
+    def test_default_baseline_panel_is_cached(self, monkeypatch):
+        trainer = GeneticTrainer(
+            ["Village", "Smithy"],
+            population_size=1,
+            generations=1,
+            default_baseline_panel=True,
+        )
+        calls = {"n": 0}
+
+        def fake_panel():
+            calls["n"] += 1
+            return [_make_dummy_opponent("CachedOpp")]
+
+        monkeypatch.setattr(trainer, "build_default_baseline_panel", fake_panel)
+
+        first = trainer._resolve_panel()
+        second = trainer._resolve_panel()
+
+        assert first is second
+        assert calls["n"] == 1
+
 
 def _strategy_with_gain(*card_names: str) -> BaseStrategy:
     s = BaseStrategy()

--- a/tests/test_strategy_battle_decision_firings.py
+++ b/tests/test_strategy_battle_decision_firings.py
@@ -25,6 +25,7 @@ def test_choose_gain_matching_top_priority_is_not_counted_as_override():
     assert selected.name == "Gold"
     assert stats["choose_gain_overrides"]["total"] == 0
     assert stats["choose_gain_overrides"]["by_selection"] == {}
+    assert stats["priority_rules"]["gain"]["Gold [always]"] == 1
 
 
 def test_choose_gain_bypassing_priority_and_choose_way_are_counted():
@@ -73,6 +74,27 @@ def test_custom_choose_gain_without_priority_baseline_is_not_counted_as_override
     assert selected.name == "Smithy"
     assert stats["choose_gain_overrides"]["total"] == 0
     assert stats["choose_gain_overrides"]["by_selection"] == {}
+
+
+def test_priority_rule_firings_are_counted_by_decision_list():
+    strategy = EnhancedStrategy()
+    strategy.action_priority = [PriorityRule("Village")]
+    strategy.treasure_priority = [PriorityRule("Silver")]
+    strategy.trash_priority = [PriorityRule("Estate")]
+    ai = GeneticAI(strategy)
+    battle = StrategyBattle()
+    stats = battle._empty_decision_firings("Trace Strategy")
+    state = SimpleNamespace(current_player=SimpleNamespace())
+
+    battle._instrument_ai_decisions(ai, stats)
+
+    ai.choose_action(state, [_card("Village"), None])
+    ai.choose_treasure(state, [_card("Silver")])
+    ai.choose_card_to_trash(state, [_card("Estate")])
+
+    assert stats["priority_rules"]["action"]["Village [always]"] == 1
+    assert stats["priority_rules"]["treasure"]["Silver [always]"] == 1
+    assert stats["priority_rules"]["trash"]["Estate [always]"] == 1
 
 
 def test_html_decision_firings_section_renders_zero_rows():

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -66,6 +66,14 @@ def test_card_role_inference_identifies_village_and_terminal_draw():
     assert "Village" in cards_with_role(["Village", "Smithy"], "village")
 
 
+def test_card_role_inference_handles_unknown_cards():
+    unknown = infer_card_roles("Definitely Not A Card")
+
+    assert unknown.name == "Definitely Not A Card"
+    assert unknown.roles == frozenset()
+    assert cards_with_role(["Village", "Definitely Not A Card"], "village") == ["Village"]
+
+
 def test_phase_aware_strategy_uses_phase_priority_then_fallback():
     strategy = PhaseAwareStrategy()
     strategy.gain_priority = [PriorityRule("Silver")]

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+
+from dominion.cards.registry import get_card
+from dominion.strategy.card_roles import cards_with_role, infer_card_roles
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+from dominion.strategy.lint import lint_strategy, normalize_strategy
+from dominion.strategy.phase_strategy import PhaseAwareStrategy, StrategyPhase
+
+
+def _state(turn_number=5, provinces_left=8, empty_piles=0):
+    return SimpleNamespace(
+        turn_number=turn_number,
+        supply={"Province": provinces_left},
+        empty_piles=empty_piles,
+    )
+
+
+def _player(cards=None):
+    cards = cards or []
+    return SimpleNamespace(
+        all_cards=lambda: list(cards),
+        count_in_deck=lambda name: sum(1 for card in cards if card.name == name),
+    )
+
+
+def test_lint_flags_unreachable_duplicate_and_green_noise():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [
+        PriorityRule("Duchy"),
+        PriorityRule("Gold"),
+        PriorityRule("Gold"),
+        PriorityRule("Province"),
+        PriorityRule("Gold", PriorityRule.turn_number("<=", 5)),
+        PriorityRule("Copper"),
+    ]
+
+    warnings = lint_strategy(strategy)
+    codes = {warning.code for warning in warnings}
+
+    assert "UNCONDITIONAL_GREEN_BEFORE_PROVINCE" in codes
+    assert "DUPLICATE_RULE" in codes
+    assert "UNREACHABLE_AFTER_UNCONDITIONAL" in codes
+    assert "UNCONDITIONAL_JUNK_GAIN" in codes
+
+
+def test_normalize_strategy_drops_behavior_preserving_dead_rules():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [
+        PriorityRule("Gold"),
+        PriorityRule("Gold"),
+        PriorityRule("Gold", PriorityRule.turn_number("<=", 5)),
+    ]
+
+    normalized = normalize_strategy(strategy)
+
+    assert [rule.card_name for rule in normalized.gain_priority] == ["Gold"]
+
+
+def test_card_role_inference_identifies_village_and_terminal_draw():
+    village = infer_card_roles("Village")
+    smithy = infer_card_roles("Smithy")
+
+    assert village.has("village")
+    assert village.has("nonterminal")
+    assert smithy.has("terminal_draw")
+    assert "Village" in cards_with_role(["Village", "Smithy"], "village")
+
+
+def test_phase_aware_strategy_uses_phase_priority_then_fallback():
+    strategy = PhaseAwareStrategy()
+    strategy.gain_priority = [PriorityRule("Silver")]
+    strategy.phase_gain_priority[StrategyPhase.OPENING] = [PriorityRule("Chapel")]
+
+    choice = strategy.choose_gain(
+        _state(turn_number=2),
+        _player(),
+        [get_card("Chapel"), get_card("Silver"), None],
+    )
+
+    assert choice.name == "Chapel"
+
+    fallback = strategy.choose_gain(
+        _state(turn_number=7),
+        _player(),
+        [get_card("Chapel"), get_card("Silver"), None],
+    )
+
+    assert fallback.name == "Silver"
+
+
+def test_phase_classifier_switches_to_endgame():
+    strategy = PhaseAwareStrategy()
+
+    phase = strategy.classify_phase(_state(provinces_left=2), _player())
+
+    assert phase == StrategyPhase.ENDGAME


### PR DESCRIPTION
## Summary
Adds strategy diagnostics, card-role inference, and phase-aware strategy helpers so generated strategies can express cleaner plans instead of only flat priority lists. Fixes `has_cards(..., 0)` to mean "has none", adds decision-rule firing traces to battle reports, and trains the CLI runner against a compatible baseline panel by default. New tests cover condition semantics, linting, phase behavior, default panels, and decision instrumentation.

## Validation
`pytest -q` passed locally before publishing, and the post-amend focused suite `pytest -q tests/test_strategy_lint_and_phase.py tests/test_genetic_trainer.py tests/test_strategy_battle_decision_firings.py` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reports now include priority-rule firing tables.
  * Decision-tracing emits per-rule firings and lint diagnostics (capped summaries).
  * Trainer can auto-select a default baseline panel when none provided.
  * Strategy linting and normalization utilities added.
  * Phase-aware strategies choose phase-specific priorities.
  * Card-role inference provides heuristic role labels.

* **Bug Fixes**
  * Corrected zero-count behavior for has_cards checks.
  * Fixed an incorrect priority-rule condition reference.

* **Tests**
  * Added tests for priority firings, baseline caching, linting, card roles, and phase logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/py-overlord/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->