### PR TITLE
Cap mid-turn phase loops to prevent simulator hangs

### DIFF
--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -8,6 +8,26 @@ from dominion.cards.split_pile import SplitPileMixin
 from dominion.game.player_state import PlayerState
 
 
+# Mid-turn safety cap. Real Dominion turns rarely exceed a few hundred plays
+# even with aggressive engines; this bound is far above legitimate play and
+# fires only on runaway loops (self-replenishing actions, evolved genomes
+# that exploit unbounded composition, future card-impl bugs). When hit, the
+# phase aborts with PhaseStepLimitExceeded, which the trainer's existing
+# exception handler scores as -inf — so the GA naturally selects against
+# pathological genomes instead of hanging the worker process.
+PHASE_STEP_LIMIT = 10000
+
+
+class PhaseStepLimitExceeded(RuntimeError):
+    """Raised when a phase's main loop exceeds PHASE_STEP_LIMIT iterations.
+
+    Indicates a runaway mid-turn loop — e.g. a card whose play replenishes
+    the hand and Actions without bound, or an evolved strategy that
+    composes such effects. Catchable so simulation harnesses can mark the
+    offending genome as a loss rather than crashing.
+    """
+
+
 @dataclass
 class GameState:
     players: list[PlayerState]
@@ -1478,7 +1498,16 @@ class GameState:
             and self.prophecy.name == "Enlightenment"
         )
 
+        steps = 0
         while True:
+            steps += 1
+            if steps > PHASE_STEP_LIMIT:
+                raise PhaseStepLimitExceeded(
+                    f"action phase exceeded {PHASE_STEP_LIMIT} plays in a single turn "
+                    f"(player={getattr(player.ai, 'name', '?')}, "
+                    f"turn={self.turn_number}, hand_size={len(player.hand)}, "
+                    f"actions_left={player.actions})"
+                )
             action_cards = [card for card in player.hand if card.is_action]
             # Adventures Inheritance: each Estate in hand can be played as the
             # inherited Action card.
@@ -1887,7 +1916,14 @@ class GameState:
             getattr(p, "name", "") == "Capitalism" for p in player.projects
         )
 
+        steps = 0
         while True:
+            steps += 1
+            if steps > PHASE_STEP_LIMIT:
+                raise PhaseStepLimitExceeded(
+                    f"treasure phase exceeded {PHASE_STEP_LIMIT} plays in a single turn "
+                    f"(player={getattr(player.ai, 'name', '?')}, turn={self.turn_number})"
+                )
             # ``is_treasure`` respects game-level type modifiers — notably
             # Charlatan, which makes Curses Treasures for the whole game.
             treasures = [card for card in player.hand if self.is_treasure(card)]
@@ -2003,7 +2039,15 @@ class GameState:
         """Handle the buy phase of a turn."""
         player = self.current_player
 
+        steps = 0
         while True:
+            steps += 1
+            if steps > PHASE_STEP_LIMIT:
+                raise PhaseStepLimitExceeded(
+                    f"buy phase exceeded {PHASE_STEP_LIMIT} iterations in a single turn "
+                    f"(player={getattr(player.ai, 'name', '?')}, turn={self.turn_number}, "
+                    f"buys_left={player.buys}, coins={player.coins})"
+                )
             if player.debt > 0:
                 if player.coins > 0:
                     paid = min(player.debt, player.coins)
@@ -2155,7 +2199,14 @@ class GameState:
         """
 
         player = self.current_player
+        steps = 0
         while True:
+            steps += 1
+            if steps > PHASE_STEP_LIMIT:
+                raise PhaseStepLimitExceeded(
+                    f"night phase exceeded {PHASE_STEP_LIMIT} plays in a single turn "
+                    f"(player={getattr(player.ai, 'name', '?')}, turn={self.turn_number})"
+                )
             night_cards = [card for card in player.hand if card.is_night]
             if not night_cards:
                 break

--- a/tests/test_phase_step_caps.py
+++ b/tests/test_phase_step_caps.py
@@ -1,0 +1,62 @@
+"""Mid-turn safety caps for phase loops.
+
+The phase handlers (`handle_action_phase`, `handle_treasure_phase`,
+`handle_buy_phase`, `handle_night_phase`) iterate in `while True:` loops with
+no bound on the number of plays per turn. A genome that produces a card
+whose play keeps replenishing the hand and granting +Actions can hang the
+simulator indefinitely — the existing `turn_number > 100` cap in
+`is_game_over` only fires at turn boundaries.
+
+These tests pin a per-phase step cap that raises ``PhaseStepLimitExceeded``
+on runaway, so the trainer's existing exception handler scores the offender
+as ``-inf`` instead of hanging the worker.
+"""
+
+from dominion.cards.base_card import Card, CardCost, CardStats, CardType
+from dominion.game.game_state import GameState, PhaseStepLimitExceeded
+from dominion.game.player_state import PlayerState
+from tests.utils import ChooseFirstActionAI
+
+
+class _SelfReplenishingAction(Card):
+    """Pathological action: returns to hand on play and grants +1 Action.
+
+    Net effect per play: +1 Action and hand size unchanged → the action
+    phase loop would iterate forever without a cap.
+    """
+
+    def __init__(self):
+        super().__init__(
+            name="_LoopCard",
+            cost=CardCost(coins=0),
+            stats=CardStats(),
+            types=[CardType.ACTION],
+        )
+
+    def on_play(self, game_state):
+        player = game_state.current_player
+        player.actions += 1
+        if self in player.in_play:
+            player.in_play.remove(self)
+        player.hand.append(self)
+
+
+def test_action_phase_step_cap_aborts_runaway():
+    ai = ChooseFirstActionAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([])
+    state.phase = "action"
+
+    player.hand = [_SelfReplenishingAction()]
+    player.actions = 1
+
+    try:
+        state.handle_action_phase()
+    except PhaseStepLimitExceeded as exc:
+        assert "action" in str(exc).lower()
+        return
+    raise AssertionError(
+        "handle_action_phase did not raise PhaseStepLimitExceeded on a "
+        "self-replenishing action card; the cap is missing or too high."
+    )


### PR DESCRIPTION
## Summary
The four phase handlers (`handle_action_phase` / `treasure` / `buy` / `night`) iterate in unbounded `while True:` loops, and the existing `turn_number > 100` safeguard only fires at turn boundaries — so a strategy whose play replenishes hand+actions can hang the simulator mid-turn. This was hit during a GA run on a 578-card "all cards available" supply, where a gen-12 candidate pegged a worker at 100% CPU for 8+ hours.

Adds `PHASE_STEP_LIMIT = 10000` and a `PhaseStepLimitExceeded` exception raised by each phase loop on overflow; the trainer's existing `except Exception → return -inf` handler scores offending genomes as losers, so the GA selects against pathological compositions instead of hanging. New test in `tests/test_phase_step_caps.py` pins the action-phase cap with a self-replenishing stub card; all 1,446 existing tests still pass.

## Test plan
- [x] `pytest tests/` — 1446 passed
- [x] New `tests/test_phase_step_caps.py::test_action_phase_step_cap_aborts_runaway` — passes (RED before fix, GREEN after)
- [x] Smoke test: `Lisbon City Engine` vs `Big Money` on a 578-card supply — 4/4 wins, avg 18 turns (no regression in normal play)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented safety limits to prevent infinite loops during game phases (action, treasure, buy, and night), ensuring gameplay doesn't become unresponsive if edge cases cause excessive iterations.

* **Tests**
  * Added regression tests to verify phase loop protection mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/py-overlord/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->