### PR TITLE
Clean up stale defect markers

### DIFF
--- a/docs/plans/2026-05-19-endgame-guard-real-buy-simulation.md
+++ b/docs/plans/2026-05-19-endgame-guard-real-buy-simulation.md
@@ -4,6 +4,8 @@
 
 **Goal:** Replace `GameState.gain_would_lose_game`'s hand-rolled simulation (PR #275, merged `cd76f7e`) with a real-buy simulation: deep-copy the game state, run the actual buy on the copy via a shared `_commit_buy` method, evaluate the standard end-condition and scores on the post-buy clone. Eliminates the enumeration-and-stand-down whack-a-mole and the false-negative direction the prior approach could not catch.
 
+**Status:** Implemented in `dominion/game/game_state.py`.
+
 **Architecture:** A loose pre-check gate (game-is-near-ending) keeps `copy.deepcopy` off the hot path. `GameState.__deepcopy__` shares AIs by reference, detaches logger, fixes the player back-reference. `_commit_buy` is extracted from `handle_buy_phase` so the real game and the simulation execute the *same code*. RNG (module-global `random`) is saved/restored around the simulated buy. RL agents opt out via a `decision_hooks_are_pure = False` flag.
 
 **Tech Stack:** Python (the existing `dominion` package), `copy.deepcopy` with `__deepcopy__` + `memo` preseed, `random.getstate/setstate`, pytest.
@@ -548,12 +550,12 @@ def test_temple_endgame_correctly_handled():
 
 Run: `pytest tests/test_endgame_purchase_guard.py -v -k "false_negative or impure or rng_state or temple_endgame"`
 
-Expected:
+Historical RED expectations before Task 6:
 
 - `test_false_negative_blocked_when_hoard_empties_third_pile` — **FAIL** (current enumeration model misses Hoard's pile-emptying side effect; Province gets bought).
 - `test_guard_disabled_when_any_ai_marks_decision_hooks_impure` — likely PASS today only by coincidence; document expected; will be reasserted by Task 6 rewrite.
 - `test_gain_would_lose_game_preserves_rng_state` — likely PASS today (sim doesn't consume RNG); the test pins the *invariant* and protects against future regressions.
-- `test_temple_endgame_correctly_handled` — **FAIL** (current code stands down on landmarks but Temple is a card, not a landmark; the prior `_buy_pile_restorable` doesn't apply; the cheap sim adds Temple to discard with no VP bonus, so 1 vs 6 — vetoes correctly; assertion may actually PASS for the wrong reason). If it passes today, that's OK; it will pass for the right reason after Task 6.
+- `test_temple_endgame_correctly_handled` — **FAIL** under the old enumeration model (Temple is a card, not a landmark; the old `_buy_pile_restorable` path didn't apply; the cheap sim added Temple to discard with no VP bonus, so the assertion could pass without exercising the intended real-buy path). After Task 6, this passes through the shared `_commit_buy` simulation.
 
 ### Step 3 — commit the new tests (RED for the real ones)
 

--- a/docs/plans/2026-05-19-endgame-guard-real-simulation-design.md
+++ b/docs/plans/2026-05-19-endgame-guard-real-simulation-design.md
@@ -1,7 +1,7 @@
 # Endgame Guard via Real-Buy Simulation — Design
 
 **Date:** 2026-05-19
-**Status:** Validated; ready for implementation
+**Status:** Implemented
 **Successor to:** PR #275 — merged as `cd76f7e Veto buys that would end the game while losing` (enumeration-based interim guard)
 **Branch:** `start-philadelphia-claude` (workspace `minnetonka-v2`)
 
@@ -9,7 +9,8 @@
 
 ## Problem
 
-`GameState.gain_would_lose_game` (introduced in PR #275) *models* what a buy
+This design replaced the PR #275 version of `GameState.gain_would_lose_game`,
+which *modeled* what a buy
 does (`supply -= 1; player.discard.append(card)`) instead of performing it.
 The real buy path applies VP-token hooks (Goons, Groundskeeper, Collection,
 all VP-awarding Landmarks) and supply-restoring reactions (Exile reclamation,
@@ -24,10 +25,10 @@ a divergence between the model and reality:
   ends the game in a loss. No reviewer is guaranteed to catch these; the
   enumeration approach can't detect the failure direction at all.
 
-The current mitigation — enumerate divergences, stand the guard down when
-detected — is fragile by construction: it requires exhaustive understanding of
-a 4 k-line engine, has been incomplete three times, and only catches one of
-the two failure directions.
+The interim mitigation enumerated divergences and stood the guard down when
+they were detected. That approach required exhaustive understanding of a
+4 k-line engine and only covered one of the two failure directions, so it was
+replaced by the real-buy simulation below.
 
 ## Principle
 

--- a/dominion/analysis/trick_scanner.py
+++ b/dominion/analysis/trick_scanner.py
@@ -48,7 +48,7 @@ RETURN_TO_PILE_WAYS = frozenset({"Way of the Butterfly"})
 # Native Village is intentionally NOT here: its play_effect sets aside the
 # *top of the deck* onto the Native Village mat, while Native Village itself
 # stays in play and goes to discard at clean-up. Adding it would emit a
-# mechanically wrong hypothesis.
+# hypothesis for a state that cannot occur.
 SELF_EXILE_OR_SET_ASIDE_CARDS = frozenset({"Stockpile", "Island"})
 
 # Events that key on the player having an empty deck *and* empty discard.

--- a/dominion/cards/empires/charm.py
+++ b/dominion/cards/empires/charm.py
@@ -15,10 +15,8 @@ class Charm(Card):
             cost=CardCost(coins=5),
             stats=CardStats(buys=1),
             # Charm is a Treasure card that gives +1 Buy while offering one of its
-            # three options. The implementation previously (incorrectly) labeled
-            # it as an Action, which caused type checks to fail and prevented the
-            # card from interacting with treasure-specific effects. Mark it with
-            # the correct type.
+            # three options. Mark it with the correct Treasure type so type checks
+            # and treasure-specific effects see it properly.
             types=[CardType.TREASURE],
 
         )

--- a/dominion/cards/treasures.py
+++ b/dominion/cards/treasures.py
@@ -54,7 +54,7 @@ class Silver(Card):
             )
         # Mark that a Silver has been played this turn even if no Merchant
         # bonus was active. Otherwise a Silver played before any Merchant
-        # would let a later Silver (after Merchant) incorrectly claim the
+        # would let a later Silver (after Merchant) claim the
         # "first Silver this turn" bonus.
         player.merchant_silver_bonus_used = True
 

--- a/tests/test_allies_allies.py
+++ b/tests/test_allies_allies.py
@@ -384,8 +384,7 @@ def test_league_of_shopkeepers_uses_favors_not_liaisons_in_play():
     coins_before = player.coins
     buys_before = player.buys
     state.allies[0].on_play_card(state, player, underling)
-    # 1 Liaison in play → old (incorrect) impl would skip both bonuses.
-    # New (correct) impl: favors becomes 5 → +$1 (>=3) and +1 Buy (>=5).
+    # 1 Liaison in play: favors becomes 5, granting +$1 (>=3) and +1 Buy (>=5).
     assert player.coins == coins_before + 1
     assert player.buys == buys_before + 1
 

--- a/tests/test_endgame_purchase_guard.py
+++ b/tests/test_endgame_purchase_guard.py
@@ -222,7 +222,7 @@ def test_guard_skipped_when_exiled_copy_reclaimed():
     depleted and the game does not end — the guard must not veto."""
     ai = PriorityBuyAI(["Province"])
     # Distinct objects: all_cards() dedups by id, so aliased copies would
-    # under-count the opponent and make the buyer look (wrongly) ahead.
+    # under-count the opponent and make the buyer look ahead.
     state, me, _opp = make_state(
         ai, opponent_deck=provinces(3)
     )


### PR DESCRIPTION
Updates historical endgame-guard docs so the real-buy simulation is marked implemented instead of reading like pending work. Rewords comments in card, analysis, and regression-test files that described already-fixed bugs as active defects. Leaves the intentional strategy simplification feature untouched because it is a real API, not a cleanup target. Validation: 61 focused tests passed across endgame guard, Charm/treasure registry, trick scanner, genome simplification, Allies, and Merchant/Silver coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed League of Shopkeepers coin and buy threshold calculation to correctly depend on Favor count.

* **Documentation**
  * Updated implementation status and design documentation for Endgame Guard feature.
  * Clarified inline documentation for card behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/py-overlord/pull/281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->