### PR TITLE
Add per-shuffle project hook and fix Star Chart

### DIFF
--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -430,10 +430,25 @@ class PlayerState:
         """Shuffle discard pile to create new deck.
 
         Respects Stash (top), Rising Sun Shadow cards (bottom), Plunder
-        Avoid event (top up to 3), and Plunder Fated trait (top of deck).
+        Avoid event (top up to 3), Plunder Fated trait (top of deck), and
+        per-shuffle project hooks (e.g. Star Chart).
         Cards at index 0 are the bottom of the deck (drawn last); cards at
         the end are the top (drawn first via ``deck.pop()``).
         """
+        # Per-shuffle project hooks (Star Chart). Each hook may pull a
+        # card from ``self.discard`` and return it to be placed on top of
+        # the new deck.
+        project_top: list = []
+        game_state = getattr(self, "game_state", None)
+        if game_state is not None:
+            for project in list(self.projects):
+                chosen = project.on_shuffle(game_state, self)
+                if chosen is None:
+                    continue
+                if isinstance(chosen, list):
+                    project_top.extend(chosen)
+                else:
+                    project_top.append(chosen)
         avoid_set_aside: list = []
         if self.avoid_pending > 0 and self.discard:
             n = min(3, len(self.discard))
@@ -461,7 +476,14 @@ class PlayerState:
             if card.name != "Stash" and not getattr(card, "is_shadow", False)
         ]
         random.shuffle(others)
-        self.deck = shadows + others + stash_cards + fated_top + avoid_set_aside
+        self.deck = (
+            shadows
+            + others
+            + stash_cards
+            + fated_top
+            + avoid_set_aside
+            + project_top
+        )
         self.discard = []
 
     def count_in_deck(self, card_name: str) -> int:

--- a/dominion/projects/base_project.py
+++ b/dominion/projects/base_project.py
@@ -18,6 +18,15 @@ class Project:
     def on_trash(self, game_state, player, card) -> None:
         pass
 
+    def on_shuffle(self, game_state, player):
+        """Fires after a player shuffles their discard into the deck.
+
+        May optionally return a card (or list of cards) removed from the
+        discard during the hook; those cards are placed on top of the
+        newly-shuffled deck. Return ``None`` for no-op.
+        """
+        return None
+
     @property
     def is_project(self) -> bool:
         return True

--- a/dominion/projects/star_chart.py
+++ b/dominion/projects/star_chart.py
@@ -1,5 +1,5 @@
-"""Star Chart: when you shuffle, you may pick one card from your discard
-to put on top of the new deck."""
+"""Star Chart: when you shuffle, you may pick one of the cards being
+shuffled to put on top of your deck."""
 
 from dominion.cards.base_card import CardCost
 
@@ -10,31 +10,15 @@ class StarChart(Project):
     def __init__(self) -> None:
         super().__init__("Star Chart", CardCost(coins=3))
 
-    # The shuffle hook is fired by ``PlayerState.shuffle_discard_into_deck``
-    # via Star Chart's owner check at start-of-turn / draw time. Since the
-    # engine doesn't expose a per-shuffle hook, we approximate Star Chart
-    # by topdecking a card right before drawing if the player just shuffled.
-    # We implement Star Chart's effect by intercepting at on_turn_start:
-    # we pull a strong Action from the discard up onto the top of the deck
-    # whenever there is one. This is a slight simplification of the official
-    # rules (which fires on every shuffle), but the practical effect for
-    # the bot is equivalent for the common case where shuffles happen at
-    # turn boundaries.
-    def on_turn_start(self, game_state, player) -> None:
+    def on_shuffle(self, game_state, player):
         if not player.discard:
-            return
-        # Only trigger if the deck looks like it was just shuffled — i.e.
-        # the discard was non-empty when the deck became empty. As a
-        # heuristic, only act when the deck is small (<=5) and discard has
-        # something worth promoting.
-        if len(player.deck) > 5:
-            return
+            return None
         candidates = [c for c in player.discard if c.is_action or c.is_treasure]
         if not candidates:
-            return
+            return None
         best = max(
             candidates,
             key=lambda c: (c.is_action, c.cost.coins, c.stats.cards, c.name),
         )
         player.discard.remove(best)
-        player.deck.append(best)
+        return best

--- a/tests/test_renaissance_projects.py
+++ b/tests/test_renaissance_projects.py
@@ -71,18 +71,55 @@ def test_pageant_pays_one_for_coffer():
     assert p.coin_tokens == 1
 
 
-def test_star_chart_promotes_action_from_discard():
+def test_star_chart_promotes_action_on_shuffle():
     state = make_state(StarChart())
     p = state.players[0]
     p.projects.append(state.projects[0])
     state.current_player_index = 0
-    p.deck = [get_card("Copper")]
-    p.discard = [get_card("Village"), get_card("Estate")]
+    p.deck = []
+    p.discard = [
+        get_card("Copper"),
+        get_card("Village"),
+        get_card("Estate"),
+        get_card("Silver"),
+        get_card("Copper"),
+    ]
+    p.hand = []
+    p.shuffle_discard_into_deck()
+    # Star Chart promotes the best action/treasure to the top of the deck.
+    # Top of deck is the last element (drawn via deck.pop()).
+    assert p.deck[-1].name == "Village"
+    assert p.discard == []
+
+
+def test_star_chart_fires_on_midturn_shuffle_via_draw():
+    """Star Chart should fire whenever the deck is reshuffled mid-turn,
+    not only at start-of-turn."""
+    state = make_state(StarChart())
+    p = state.players[0]
+    p.projects.append(state.projects[0])
+    state.current_player_index = 0
+    p.deck = []
+    p.discard = [get_card("Copper"), get_card("Village"), get_card("Estate")]
+    p.hand = []
+    # draw_cards triggers the shuffle internally.
+    p.draw_cards(1)
+    assert any(c.name == "Village" for c in p.hand)
+
+
+def test_star_chart_does_nothing_without_shuffle():
+    """If no shuffle happens, Star Chart should not promote anything."""
+    state = make_state(StarChart())
+    p = state.players[0]
+    p.projects.append(state.projects[0])
+    state.current_player_index = 0
+    p.deck = [get_card("Copper"), get_card("Copper")]
+    p.discard = [get_card("Village")]
     p.hand = []
     state.phase = "start"
     state.handle_start_phase()
-    # The Village should have been moved out of discard.
-    assert not any(c.name == "Village" for c in p.discard)
+    # No shuffle occurred, so Village stays in discard.
+    assert any(c.name == "Village" for c in p.discard)
 
 
 def test_exploration_grants_bonus_when_no_action_treasure_gain():


### PR DESCRIPTION
## Summary

- Adds a first-class `Project.on_shuffle` hook fired from `PlayerState.shuffle_discard_into_deck`. Hooks may return a card pulled from the discard to be placed on top of the new deck.
- Rewrites **Star Chart** to use this hook, removing the previous start-of-turn heuristic that only fired when the deck happened to be small (`len <= 5`).

## Why

Star Chart's official rule fires on *every* shuffle, including mid-turn ones triggered by `draw_cards`. The old approximation missed those shuffles and could also fire spuriously when no shuffle had actually occurred.

This is step 1 of a series of architectural cleanups that enable several per-card simplifications to be replaced with correct implementations.

## Test plan

- [x] New tests in `tests/test_renaissance_projects.py`:
  - `test_star_chart_promotes_action_on_shuffle` — top of deck after shuffle is the chosen card
  - `test_star_chart_fires_on_midturn_shuffle_via_draw` — promoted card is drawn first when shuffle is triggered by `draw_cards`
  - `test_star_chart_does_nothing_without_shuffle` — no shuffle means no promotion
- [x] Full suite: 1589 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects can now react when a player shuffles their discard into their deck, allowing project-specific top-of-deck effects.

* **Bug Fixes**
  * Star Chart now reliably activates on reshuffles (including mid-turn reshuffles), promoting the best action/treasure from discard to the top and correctly handling set-aside/avoid cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/py-overlord/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->