### PR TITLE
Fix ordered-pile restore in gain_card; drop Displace/University workarounds

### DIFF
--- a/dominion/cards/alchemy/university.py
+++ b/dominion/cards/alchemy/university.py
@@ -60,31 +60,6 @@ class University(Card):
         if game_state.supply.get(pile_name, 0) <= 0:
             return
         game_state.supply[pile_name] -= 1
-        is_ordered_pile = pile_name in game_state.pile_order
-        if is_ordered_pile and game_state.pile_order[pile_name]:
+        if pile_name in game_state.pile_order and game_state.pile_order[pile_name]:
             game_state.pile_order[pile_name].pop()
-        # Snapshot pile state immediately after decrement+pop so we can
-        # detect, post-gain, whether something else (Changeling) restored
-        # the pile already. Mirrors Displace's ordered-pile bookkeeping.
-        post_decrement_supply = game_state.supply[pile_name]
-        post_decrement_order_len = (
-            len(game_state.pile_order[pile_name]) if is_ordered_pile else 0
-        )
-        gained = game_state.gain_card(player, choice)
-        # gain_card's Trader-replacement and Exile-reclamation paths both
-        # try to restore the Supply via gained.name, which for ordered
-        # piles (Knights, Ruins) is the specific top card name (e.g.
-        # "Sir Bailey") rather than the pile placeholder, so the restore
-        # silently no-ops there. Manually restore the placeholder pile
-        # in that case, but skip when the pile state was already restored
-        # for us (e.g. by Changeling's exchange).
-        if (
-            is_ordered_pile
-            and gained is not None
-            and gained is not choice
-            and game_state.supply.get(pile_name, 0) == post_decrement_supply
-            and len(game_state.pile_order.get(pile_name, []))
-            == post_decrement_order_len
-        ):
-            game_state.supply[pile_name] = game_state.supply.get(pile_name, 0) + 1
-            game_state.pile_order.setdefault(pile_name, []).append(choice.name)
+        game_state.gain_card(player, choice)

--- a/dominion/cards/menagerie/displace.py
+++ b/dominion/cards/menagerie/displace.py
@@ -104,36 +104,9 @@ class Displace(Card):
         if game_state.supply.get(pile_name, 0) <= 0:
             return
         game_state.supply[pile_name] -= 1
-        is_ordered_pile = pile_name in game_state.pile_order
-        if is_ordered_pile and game_state.pile_order[pile_name]:
+        if pile_name in game_state.pile_order and game_state.pile_order[pile_name]:
             game_state.pile_order[pile_name].pop()
-        # Snapshot the pile state immediately after decrement+pop so we can
-        # tell, post-gain, whether something else restored the pile already.
-        post_decrement_supply = game_state.supply[pile_name]
-        post_decrement_order_len = (
-            len(game_state.pile_order[pile_name]) if is_ordered_pile else 0
-        )
-        gained = game_state.gain_card(player, gain_choice)
-        # gain_card's Trader-replacement and Exile-reclamation paths both
-        # try to restore the Supply via gain_choice.name, which for
-        # ordered piles (Knights, Ruins) is the specific top card (e.g.
-        # "Dame Josephine") rather than the pile placeholder, so the
-        # restore silently no-ops there. Changeling's exchange, in
-        # contrast, restores the pile placeholder directly. We treat any
-        # case where gain_card returned a different object as
-        # potentially needing a manual restore, then use the post-
-        # decrement snapshot to skip the Changeling case (where the
-        # pile state was already restored for us).
-        if (
-            is_ordered_pile
-            and gained is not None
-            and gained is not gain_choice
-            and game_state.supply.get(pile_name, 0) == post_decrement_supply
-            and len(game_state.pile_order.get(pile_name, []))
-            == post_decrement_order_len
-        ):
-            game_state.supply[pile_name] = game_state.supply.get(pile_name, 0) + 1
-            game_state.pile_order.setdefault(pile_name, []).append(gain_choice.name)
+        game_state.gain_card(player, gain_choice)
 
     @staticmethod
     def _exile_priority(card):

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -3609,11 +3609,13 @@ class GameState:
         ):
             destination_is_deck = True
 
-        if reclaimed and from_supply and card.name in self.supply:
+        if reclaimed and from_supply:
             # Caller already decremented the supply; restore it since the
             # Exiled card is being used instead. Only valid for from-supply
-            # gains — trash-origin gains never decremented in the first place.
-            self.supply[card.name] = self.supply.get(card.name, 0) + 1
+            # gains — trash-origin gains never decremented in the first
+            # place. Uses pile-aware restoration so ordered piles (Knights,
+            # Ruins) get their placeholder key + pile_order put back.
+            self._restore_to_supply_pile(card)
 
         if destination_is_deck:
             # PlayerState.draw_cards() draws with deck.pop(), so the end of
@@ -3847,6 +3849,24 @@ class GameState:
                 return pile_key
         return None
 
+    def _restore_to_supply_pile(self, card: Card) -> bool:
+        """Restore one copy of ``card`` to its Supply pile.
+
+        Handles ordered piles (Knights, Ruins) where the supply key is the
+        pile placeholder, not the specific card name — bumps the placeholder
+        count AND pushes the card name back onto the top of ``pile_order``
+        so the next gain hands out the same card. Returns True if a pile
+        was actually restored, False otherwise.
+        """
+
+        pile_name = self._resolve_changeling_pile_name(card)
+        if pile_name is None:
+            return False
+        self.supply[pile_name] = self.supply.get(pile_name, 0) + 1
+        if pile_name in self.pile_order:
+            self.pile_order[pile_name].append(card.name)
+        return True
+
     def _handle_sailor_gain(self, player: PlayerState, gained_card: Card) -> None:
         """Trigger Sailor's "may play this gain" effect for the gainer's own gains."""
         if getattr(player, "sailor_play_uses", 0) <= 0:
@@ -4054,8 +4074,12 @@ class GameState:
         if not player.ai.should_reveal_trader(self, player, original_card, to_deck=to_deck):
             return actual_card
 
-        if from_supply and original_card.name in self.supply:
-            self.supply[original_card.name] = self.supply.get(original_card.name, 0) + 1
+        if from_supply:
+            # Pile-aware restoration: ordered piles (Knights, Ruins) need
+            # both the placeholder count and pile_order put back, not just
+            # ``supply[original_card.name]`` (which silently no-ops since
+            # the supply key is the placeholder name).
+            self._restore_to_supply_pile(original_card)
 
         self.supply["Silver"] -= 1
         replacement = get_card("Silver")

--- a/tests/test_ordered_pile_gain_restore.py
+++ b/tests/test_ordered_pile_gain_restore.py
@@ -1,0 +1,93 @@
+"""Regression tests for ordered-pile (Knights, Ruins) restoration through
+the Trader and Exile-reclamation paths in ``GameState.gain_card``.
+
+Both restoration paths historically used ``card.name`` to bump the supply
+count, which silently no-ops for ordered piles whose supply key is the
+pile placeholder (``"Knights"``, ``"Ruins"``) rather than the specific
+top card's name (e.g. ``"Sir Bailey"``). This let supply leak and
+``pile_order`` desynchronise from ``supply``.
+"""
+
+from typing import Optional, Set
+
+from dominion.cards.dark_ages.knights import KNIGHT_NAMES
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+
+from tests.utils import DummyAI
+
+
+class _RevealTraderAI(DummyAI):
+    def __init__(self, reveal_for: Set[str]) -> None:
+        super().__init__()
+        self.reveal_for = reveal_for
+
+    def should_reveal_trader(self, state, player, gained_card, *, to_deck) -> bool:
+        return gained_card.name in self.reveal_for
+
+
+def _prepare_state_with_knights(ai) -> tuple[GameState, "PlayerState", str]:
+    """Initialise a game with the Knights pile present and return the state,
+    the (only) player, and the name of the current top-of-pile Knight."""
+
+    state = GameState(players=[])
+    state.initialize_game(
+        [ai],
+        [get_card("Knights"), get_card("Trader")],
+    )
+    player = state.players[0]
+    player.actions = 1
+    player.hand = []
+    player.discard = []
+    player.deck = []
+    player.in_play = []
+    top_name = state.pile_order["Knights"][-1]
+    return state, player, top_name
+
+
+def test_trader_restores_ordered_knights_pile():
+    """When Trader replaces a Knight gain with Silver, the Knights pile
+    placeholder count and pile_order must both be restored."""
+
+    ai = _RevealTraderAI(reveal_for=set(KNIGHT_NAMES))
+    state, player, top_name = _prepare_state_with_knights(ai)
+    player.hand = [get_card("Trader")]
+    state.supply["Silver"] = 40
+
+    knights_before = state.supply["Knights"]
+    order_len_before = len(state.pile_order["Knights"])
+
+    # Caller decrements supply + pops pile_order before calling gain_card,
+    # mirroring how University / Displace gain from an ordered pile.
+    state.supply["Knights"] -= 1
+    state.pile_order["Knights"].pop()
+    gained = state.gain_card(player, get_card(top_name))
+
+    assert gained.name == "Silver", "Trader should have swapped to Silver"
+    # The Knights pile must be fully restored — supply count AND pile_order.
+    assert state.supply["Knights"] == knights_before
+    assert len(state.pile_order["Knights"]) == order_len_before
+    assert state.pile_order["Knights"][-1] == top_name
+
+
+def test_exile_reclaim_restores_ordered_knights_pile():
+    """When a gain is reclaimed from the Exile mat, the Supply pile that
+    was decremented for the gain must be restored. For ordered piles this
+    means the placeholder key and pile_order, not the card-specific name."""
+
+    state, player, top_name = _prepare_state_with_knights(DummyAI())
+    # Put a matching Knight on the Exile mat so the next gain is reclaimed.
+    exiled = get_card(top_name)
+    player.exile.append(exiled)
+
+    knights_before = state.supply["Knights"]
+    order_len_before = len(state.pile_order["Knights"])
+
+    state.supply["Knights"] -= 1
+    state.pile_order["Knights"].pop()
+    gained = state.gain_card(player, get_card(top_name))
+
+    assert gained is exiled, "Exile mat copy should be reclaimed"
+    assert state.supply["Knights"] == knights_before
+    assert len(state.pile_order["Knights"]) == order_len_before
+    assert state.pile_order["Knights"][-1] == top_name

--- a/tests/test_ordered_pile_gain_restore.py
+++ b/tests/test_ordered_pile_gain_restore.py
@@ -8,17 +8,16 @@ top card's name (e.g. ``"Sir Bailey"``). This let supply leak and
 ``pile_order`` desynchronise from ``supply``.
 """
 
-from typing import Optional, Set
-
 from dominion.cards.dark_ages.knights import KNIGHT_NAMES
 from dominion.cards.registry import get_card
 from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
 
 from tests.utils import DummyAI
 
 
 class _RevealTraderAI(DummyAI):
-    def __init__(self, reveal_for: Set[str]) -> None:
+    def __init__(self, reveal_for: set[str]) -> None:
         super().__init__()
         self.reveal_for = reveal_for
 
@@ -26,7 +25,7 @@ class _RevealTraderAI(DummyAI):
         return gained_card.name in self.reveal_for
 
 
-def _prepare_state_with_knights(ai) -> tuple[GameState, "PlayerState", str]:
+def _prepare_state_with_knights(ai) -> tuple[GameState, PlayerState, str]:
     """Initialise a game with the Knights pile present and return the state,
     the (only) player, and the name of the current top-of-pile Knight."""
 


### PR DESCRIPTION
## Summary

- `gain_card`'s Trader-replacement and Exile-reclamation paths previously restored the supply via `card.name`, which silently no-ops for ordered piles (Knights, Ruins) whose supply key is the pile placeholder. Supply count and `pile_order` would desynchronise.
- Adds a pile-aware `_restore_to_supply_pile` helper that resolves the correct supply key, bumps the placeholder count, and pushes the card back onto `pile_order` for ordered piles. Trader + Exile restore paths now use it.
- Deletes the manual snapshot/restore workarounds in `cards/menagerie/displace.py` and `cards/alchemy/university.py` — the engine handles this correctly now.

## Why

Both Displace and University had near-identical workarounds with comments explaining the bug. The right fix is in the engine, not duplicated per-card.

This is step 2 of the architectural cleanup series.

## Test plan

- [x] New tests in `tests/test_ordered_pile_gain_restore.py` covering both the Trader-replace and Exile-reclaim paths against a Knights pile
- [x] Existing `tests/test_trader.py` still passes
- [x] Full suite: 1589 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed supply restoration for special interactions so ordered card piles (e.g., Knights-style piles) reliably resync their counts and top-card order after Trader/Exile exchanges.

* **Tests**
  * Added regression tests covering restoration of ordered piles during Trader swaps and Exile reclamation to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/py-overlord/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->