### PR TITLE
Implement real Bury mat for Plunder Bury event

### DIFF
--- a/dominion/events/plunder_events.py
+++ b/dominion/events/plunder_events.py
@@ -24,8 +24,8 @@ def _gain_random_loot(game_state, player):
 
 
 class Bury(Event):
-    """$1: +1 Buy. Take a card from your discard onto your Bury mat
-    (top-decked next shuffle)."""
+    """$1: +1 Buy. Take a card from your discard onto your Bury mat. When
+    you next shuffle your deck, put your Bury mat on top of it."""
 
     def __init__(self):
         super().__init__("Bury", CardCost(coins=1))
@@ -41,8 +41,7 @@ class Bury(Event):
         )
         pick = candidates[0]
         player.discard.remove(pick)
-        # Approximation: top-deck immediately so it is drawn next.
-        player.deck.append(pick)
+        player.bury_mat.append(pick)
 
 
 class Avoid(Event):

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -461,7 +461,15 @@ class PlayerState:
             if card.name != "Stash" and not getattr(card, "is_shadow", False)
         ]
         random.shuffle(others)
-        self.deck = shadows + others + stash_cards + fated_top + avoid_set_aside
+        # Plunder Bury: cards on the Bury mat are placed on top of the
+        # newly-shuffled deck and the mat is emptied.
+        bury_top: list = []
+        if self.bury_mat:
+            bury_top = list(self.bury_mat)
+            self.bury_mat = []
+        self.deck = (
+            shadows + others + stash_cards + fated_top + avoid_set_aside + bury_top
+        )
         self.discard = []
 
     def count_in_deck(self, card_name: str) -> int:

--- a/tests/test_plunder_events.py
+++ b/tests/test_plunder_events.py
@@ -90,16 +90,55 @@ def test_all_15_plunder_events_registered():
         assert evt.name == name
 
 
-def test_bury_takes_card_from_discard_to_top():
+def test_bury_moves_card_from_discard_to_bury_mat():
     state = _make_state()
     player = state.current_player
     player.discard = [get_card("Copper"), get_card("Gold")]
+    player.deck = []
     bury = get_event("Bury")
     pre_buys = player.buys
     bury.on_buy(state, player)
     assert player.buys == pre_buys + 1
-    # Gold (more expensive) should be top of deck.
+    # The chosen card belongs on the Bury mat, NOT on top of the deck.
+    # It only joins the deck on the next shuffle.
+    assert player.deck == []
+    assert any(c.name == "Gold" for c in player.bury_mat)
+    assert all(c.name != "Gold" for c in player.discard)
+
+
+def test_bury_mat_top_decks_on_next_shuffle():
+    state = _make_state()
+    player = state.current_player
+    player.discard = [get_card("Copper"), get_card("Gold")]
+    player.deck = []
+    bury = get_event("Bury")
+    bury.on_buy(state, player)
+    # Refill the discard with junk before the shuffle so the buried card
+    # can't just happen to land on top by luck of the shuffle.
+    for _ in range(5):
+        player.discard.append(get_card("Copper"))
+    player.shuffle_discard_into_deck()
+    # After the shuffle, the Bury mat is consumed and its cards are on top
+    # of the new deck (deck.pop() draws from the end).
+    assert player.bury_mat == []
     assert player.deck[-1].name == "Gold"
+
+
+def test_bury_then_draw_returns_buried_card_first():
+    """End-to-end: buy Bury, draw cards (which triggers shuffle), the
+    buried card is the first one drawn."""
+    state = _make_state()
+    player = state.current_player
+    player.discard = [get_card("Copper"), get_card("Gold")]
+    player.deck = []
+    player.hand = []
+    bury = get_event("Bury")
+    bury.on_buy(state, player)
+    # Pad discard so shuffle is non-trivial.
+    for _ in range(3):
+        player.discard.append(get_card("Copper"))
+    player.draw_cards(1)
+    assert any(c.name == "Gold" for c in player.hand)
 
 
 def test_avoid_sets_avoid_pending():


### PR DESCRIPTION
## Summary

- Bury previously top-decked the chosen card immediately, which only matched the official rule by accident when the deck was nearly empty. With anything left in the deck, the buried card was drawn much sooner than allowed.
- Uses the existing (and previously unused) ``player.bury_mat`` field. The mat is consumed at the next shuffle in ``shuffle_discard_into_deck`` and its contents placed on top of the new deck.

## Why

Step 3 of the architectural cleanup series. The Bury mat field already existed in ``PlayerState``; this hooks it up.

## Test plan

- [x] Existing ``test_bury_takes_card_from_discard_to_top`` rewritten as ``test_bury_moves_card_from_discard_to_bury_mat``
- [x] New ``test_bury_mat_top_decks_on_next_shuffle`` proves the mat is consumed and lands on top after a shuffle
- [x] New ``test_bury_then_draw_returns_buried_card_first`` covers the end-to-end "buy → draw triggers shuffle → buried card drawn first" flow
- [x] Full suite: 1589 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Bury card mechanics: selected cards now move to a staging area and are properly shuffled into the deck on the next shuffle cycle, rather than being immediately placed on top.

* **Tests**
  * Expanded test coverage for Bury card with comprehensive end-to-end verification of card movement, shuffling behavior, and draw sequencing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/py-overlord/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->