### PR TITLE
Defer Ball's -$1 token to next turn

### DIFF
--- a/dominion/events/adventures_events.py
+++ b/dominion/events/adventures_events.py
@@ -287,8 +287,9 @@ class Ball(Event):
         super().__init__("Ball", CardCost(coins=5))
 
     def on_buy(self, game_state, player) -> None:
-        # -$1 token: deduct $1 next turn (we apply immediately for simplicity)
-        player.coins = max(0, player.coins - 1)
+        # -$1 token: queue a $1 penalty for the start of the player's
+        # next turn (applied in GameState.handle_start_phase).
+        player.minus_coin_tokens += 1
         # Gain 2 cards costing up to $4 each.
         for _ in range(2):
             candidates = []

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1168,6 +1168,15 @@ class GameState:
         # Renaissance Priest's rest-of-turn trigger resets each turn.
         player.priest_played_this_turn = 0
 
+        # Adventures Ball: -$1 tokens queued by Ball buys on previous turns
+        # apply at the start of this turn, then clear. Coins were already
+        # reset to 0 by the prior turn's cleanup, so this drives them
+        # negative; treasures / actions played this turn bring them back up.
+        minus_coin_tokens = getattr(player, "minus_coin_tokens", 0)
+        if minus_coin_tokens:
+            player.coins -= minus_coin_tokens
+            player.minus_coin_tokens = 0
+
         # Nocturne — reset per-turn counter
         player.cards_gained_this_turn_count = 0
 

--- a/dominion/game/player_state.py
+++ b/dominion/game/player_state.py
@@ -174,6 +174,9 @@ class PlayerState:
     distant_lands_played: int = 0
     # Adventures: -1 Card tokens on deck reduce next end-of-turn redraw.
     minus_card_tokens: int = 0
+    # Adventures Ball: each Ball buy queues a -$1 token applied at the
+    # start of the player's next turn (then cleared).
+    minus_coin_tokens: int = 0
     # Adventures Champion: persistent Action-immunity giver.
     champions_in_play: int = 0
     # Adventures Hireling: stays in play, +1 Card per turn.
@@ -381,6 +384,7 @@ class PlayerState:
         self.tavern_mat = []
         self.distant_lands_played = 0
         self.minus_card_tokens = 0
+        self.minus_coin_tokens = 0
         self.champions_in_play = 0
         self.hirelings_in_play = 0
         self.mission_used_this_turn = False

--- a/tests/test_adventures_events.py
+++ b/tests/test_adventures_events.py
@@ -192,14 +192,35 @@ def test_pilgrimage_gains_action_copies():
     assert "Smithy" in names
 
 
-def test_ball_costs_one_and_gains_two():
+def test_ball_does_not_deduct_coin_this_turn():
+    """Ball's -$1 token applies at the START of the player's next turn,
+    not immediately. Buying Ball must not change the current turn's coins."""
     state = _new_state()
     player = state.players[0]
     player.coins = 5
     Ball = get_event("Ball")
     Ball.on_buy(state, player)
-    assert player.coins == 4  # -$1 token
+    assert player.coins == 5, "Ball must not deduct $1 from the current turn"
+    assert player.minus_coin_tokens == 1
     assert len(player.discard) == 2
+
+
+def test_ball_minus_coin_token_applies_at_next_turn_start():
+    """After Ball is bought, the player's next handle_start_phase must
+    apply the -$1 and clear the pending token."""
+    state = _new_state()
+    player = state.players[0]
+    player.coins = 5
+    Ball = get_event("Ball")
+    Ball.on_buy(state, player)
+    # End this turn, start the next.
+    state.handle_cleanup_phase()
+    state.current_player_index = 0
+    state.handle_start_phase()
+    # Coins are reset to 0 at cleanup, then Ball's token subtracts 1 at
+    # the next start-of-turn.
+    assert player.coins == -1
+    assert player.minus_coin_tokens == 0
 
 
 def test_raid_minus_card_tokens_and_silvers():


### PR DESCRIPTION
## Summary

- Ball's `-$1` token previously deducted \$1 from the current turn's coins on buy. Per the card, the token applies at the start of the *next* turn, not retroactively.
- Adds `player.minus_coin_tokens` (counter, since multiple Balls can be bought across turns) and applies it in `handle_start_phase`, mirroring the existing `minus_card_tokens` pattern.

## Why

Step 5 — the smallest of the architectural cleanup series.

## Test plan

- [x] Replaces `test_ball_costs_one_and_gains_two` with `test_ball_does_not_deduct_coin_this_turn`
- [x] New `test_ball_minus_coin_token_applies_at_next_turn_start` proves the token fires at the next start-of-turn and is then cleared
- [x] Full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Gameplay Changes**
  * The Ball card's "-$1" coin penalty now applies at the start of your next turn instead of immediately when purchased.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/py-overlord/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->