### PR TITLE
Register Madman / Mercenary / Spoils as non-Supply piles

### DIFF
--- a/dominion/cards/base_card.py
+++ b/dominion/cards/base_card.py
@@ -321,13 +321,13 @@ class Card:
     def get_additional_non_supply_piles(self) -> dict[str, int]:
         """Return additional non-Supply piles required by this card.
 
-        These piles live alongside the Supply (so cards can be looked up and
-        gained from them via ``state.supply``) but they must NOT count toward
-        the three-empty-piles game-end condition. Examples: Tournament Prize
-        piles, Madman, Mercenary, Spirits, Wishes, Bats, Zombies, Horses,
-        Spoils. Currently used by Tournament; older callers still register
-        their non-Supply piles directly in ``state.supply`` without flagging
-        them, which is a known limitation tracked separately.
+        These piles live alongside the Supply (so cards can be looked up
+        and gained from them via ``state.supply``) but they must NOT
+        count toward the three-empty-piles game-end condition. Used by
+        Tournament (Prizes), Supplies (Horse), Hermit (Madman), Urchin
+        (Mercenary), Marauder / Bandit Camp / Pillage (Spoils), plus
+        Nocturne extras registered through the parallel ``nocturne_piles``
+        attribute (Bat, Wish, Imp, Ghost, Will-o'-Wisp).
         """
         return {}
 

--- a/dominion/cards/dark_ages/bandit_camp.py
+++ b/dominion/cards/dark_ages/bandit_camp.py
@@ -14,7 +14,7 @@ class BanditCamp(Card):
             types=[CardType.ACTION],
         )
 
-    def get_additional_piles(self) -> dict[str, int]:
+    def get_additional_non_supply_piles(self) -> dict[str, int]:
         return {"Spoils": 15}
 
     def play_effect(self, game_state):

--- a/dominion/cards/dark_ages/hermit.py
+++ b/dominion/cards/dark_ages/hermit.py
@@ -19,6 +19,9 @@ class Hermit(Card):
             types=[CardType.ACTION],
         )
 
+    def get_additional_non_supply_piles(self) -> dict[str, int]:
+        return {"Madman": 10}
+
     def play_effect(self, game_state):
         from ..registry import get_card
 

--- a/dominion/cards/dark_ages/marauder.py
+++ b/dominion/cards/dark_ages/marauder.py
@@ -13,7 +13,10 @@ class Marauder(Card):
         )
 
     def get_additional_piles(self) -> dict[str, int]:
-        return {"Ruins": 10, "Spoils": 15}
+        return {"Ruins": 10}
+
+    def get_additional_non_supply_piles(self) -> dict[str, int]:
+        return {"Spoils": 15}
 
     def play_effect(self, game_state):
         from ..registry import get_card

--- a/dominion/cards/dark_ages/pillage.py
+++ b/dominion/cards/dark_ages/pillage.py
@@ -16,7 +16,7 @@ class Pillage(Card):
             types=[CardType.ACTION, CardType.ATTACK],
         )
 
-    def get_additional_piles(self) -> dict[str, int]:
+    def get_additional_non_supply_piles(self) -> dict[str, int]:
         return {"Spoils": 15}
 
     def play_effect(self, game_state):

--- a/dominion/cards/dark_ages/urchin.py
+++ b/dominion/cards/dark_ages/urchin.py
@@ -18,6 +18,9 @@ class Urchin(Card):
             types=[CardType.ACTION, CardType.ATTACK],
         )
 
+    def get_additional_non_supply_piles(self) -> dict[str, int]:
+        return {"Mercenary": 10}
+
     def play_effect(self, game_state):
         attacker = game_state.current_player
 

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -990,11 +990,10 @@ class GameState:
             self.pile_order["Knights"] = order
             self.supply["Knights"] = len(order)
 
-        if any(card.name == "Hermit" for card in kingdom_cards):
-            self.supply["Madman"] = 10
-
-        if any(card.name == "Urchin" for card in kingdom_cards):
-            self.supply["Mercenary"] = 10
+        # Madman (Hermit) and Mercenary (Urchin) piles are registered via
+        # ``get_additional_non_supply_piles`` on those cards, so they land
+        # in ``non_supply_pile_names`` and never count toward the
+        # three-empty-piles game end.
 
         # Latch the Charlatan game-level rule at setup time. If Charlatan is
         # part of this game (Supply or Black Market deck), the "Curses are

--- a/tests/test_non_supply_pile_registration.py
+++ b/tests/test_non_supply_pile_registration.py
@@ -1,0 +1,72 @@
+"""Regression tests for Dark Ages non-Supply pile registration.
+
+Madman (from Hermit), Mercenary (from Urchin), and Spoils (from
+Marauder / Bandit Camp / Pillage) were historically added directly to
+``state.supply`` during game setup without being marked in
+``state.non_supply_pile_names``. That meant if all 10 Madman or all 15
+Spoils were gained, the pile would count toward the three-empty-piles
+game-end condition — wrong, since per the official rules these are
+non-Supply piles and never count.
+
+These tests pin the corrected behaviour: each of those piles is
+registered in ``non_supply_pile_names`` and depleting them does not
+advance ``empty_piles``.
+"""
+
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+
+from tests.utils import DummyAI
+
+
+def _initialize_with(kingdom_names):
+    state = GameState(players=[])
+    state.log_callback = lambda *_: None
+    state.initialize_game(
+        [DummyAI()], [get_card(n) for n in kingdom_names]
+    )
+    return state
+
+
+def test_madman_is_a_non_supply_pile():
+    state = _initialize_with(["Hermit"])
+    assert "Madman" in state.supply, "Madman pile must exist for lookup/gain"
+    assert "Madman" in state.non_supply_pile_names, (
+        "Madman must be flagged non-Supply so it does not count toward "
+        "the three-empty-piles game end"
+    )
+
+
+def test_mercenary_is_a_non_supply_pile():
+    state = _initialize_with(["Urchin"])
+    assert "Mercenary" in state.supply
+    assert "Mercenary" in state.non_supply_pile_names
+
+
+def test_spoils_is_a_non_supply_pile_via_marauder():
+    state = _initialize_with(["Marauder"])
+    assert "Spoils" in state.supply
+    assert "Spoils" in state.non_supply_pile_names
+
+
+def test_spoils_is_a_non_supply_pile_via_bandit_camp():
+    state = _initialize_with(["Bandit Camp"])
+    assert "Spoils" in state.supply
+    assert "Spoils" in state.non_supply_pile_names
+
+
+def test_spoils_is_a_non_supply_pile_via_pillage():
+    state = _initialize_with(["Pillage"])
+    assert "Spoils" in state.supply
+    assert "Spoils" in state.non_supply_pile_names
+
+
+def test_emptied_dark_ages_non_supply_piles_do_not_advance_empty_count():
+    """Three depleted Dark Ages non-Supply piles must NOT advance the
+    three-empty-piles end-game counter on their own."""
+    state = _initialize_with(["Hermit", "Urchin", "Marauder"])
+    assert state.empty_piles == 0
+    for name in ("Madman", "Mercenary", "Spoils"):
+        assert name in state.supply
+        state.supply[name] = 0
+    assert state.empty_piles == 0


### PR DESCRIPTION
## Summary

Hermit (Madman), Urchin (Mercenary), and Marauder / Bandit Camp / Pillage (Spoils) added their piles to `state.supply` for lookup but never registered them in `state.non_supply_pile_names`. The 3-empty-piles game-end check counts every entry of `state.supply` unless flagged non-Supply, so depleting any of these piles could spuriously trip end-of-game — wrong per the official rules.

Migrates each card to the existing `Card.get_additional_non_supply_piles` mechanism (Tournament's path for Prizes, Supplies' path for Horse), which adds to both `supply` and `non_supply_pile_names`. Drops the now-redundant Madman/Mercenary setup in `GameState._setup_dark_ages_piles`. Drops the "known limitation" wording in the base method's docstring.

## Why

Last remaining architectural item from the original code-rot catalog. Tournament was already using the right mechanism; this brings the older cards into the same path.

## Test plan

- [x] New `tests/test_non_supply_pile_registration.py`:
  - Madman / Mercenary / Spoils each register in `non_supply_pile_names` from their triggering kingdom card
  - With all three depleted, `empty_piles == 0` (game-end counter is not advanced)
- [x] Full suite: 1607 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of support piles in Dark Ages. Spoils (from Marauder, Bandit Camp, and Pillage), Madman (from Hermit), and Mercenary (from Urchin) are no longer counted toward the three-empty-piles end-game condition. This fix ensures games don't end prematurely when these piles are depleted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/py-overlord/pull/287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->