### PR TITLE
Fix Investment card behavior

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -1814,17 +1814,17 @@ class AI(ABC):
         return True
 
     def choose_investment_mode(
-        self, state: GameState, player: PlayerState, can_trash_treasure: bool
+        self, state: GameState, player: PlayerState, can_trash_this: bool
     ) -> str:
-        """Investment: 'coin' (+$1) or 'trash' (trash a Treasure for +1 VP per
-        differently-named Treasure revealed).
+        """Investment: 'coin' (+$1) or 'trash' (trash Investment for +1 VP
+        per differently named Treasure revealed).
 
         Default: trash if doing so reveals at least 2 distinct Treasure
         names, otherwise take the coin.
         """
-        if not can_trash_treasure:
+        if not can_trash_this:
             return "coin"
-        treasures = [c for c in player.hand if c.is_treasure]
+        treasures = [c for c in player.hand if state.is_treasure(c)]
         distinct = {c.name for c in treasures}
         if len(distinct) >= 2:
             return "trash"
@@ -1833,7 +1833,11 @@ class AI(ABC):
     def choose_treasure_to_trash_for_investment(
         self, state: GameState, player: PlayerState, choices: list[Card]
     ) -> "Card | None":
-        """Investment: pick which Treasure in hand to trash."""
+        """Legacy hook for the old Investment implementation.
+
+        Official Investment no longer trashes a Treasure from hand; card code
+        uses ``choose_card_to_trash`` for the mandatory hand trash instead.
+        """
         if not choices:
             return None
         # Prefer trashing the cheapest Treasure that still has duplicates.

--- a/dominion/cards/prosperity/investment.py
+++ b/dominion/cards/prosperity/investment.py
@@ -2,9 +2,8 @@ from ..base_card import Card, CardCost, CardStats, CardType
 
 
 class Investment(Card):
-    """Treasure ($4): Trash this. Choose one: +$1; or trash a Treasure from
-    your hand and reveal your hand for +1 VP per differently-named Treasure
-    revealed.
+    """Treasure ($4): Trash a card from your hand. Choose one: +$1; or trash
+    this, reveal your hand, and +1 VP per differently named Treasure in it.
     """
 
     def __init__(self):
@@ -18,44 +17,36 @@ class Investment(Card):
     def play_effect(self, game_state):
         player = game_state.current_player
 
-        # Self-trash from in-play.
-        if self in player.in_play:
+        if player.hand:
+            choice = player.ai.choose_card_to_trash(game_state, list(player.hand))
+            if choice is None or choice not in player.hand:
+                choice = min(
+                    player.hand,
+                    key=lambda c: (
+                        c.is_action,
+                        game_state.is_treasure(c),
+                        c.cost.coins,
+                        c.name,
+                    ),
+                )
+
+            player.hand.remove(choice)
+            game_state.trash_card(player, choice)
+
+        can_trash_this = self in player.in_play
+
+        mode = player.ai.choose_investment_mode(
+            game_state, player, can_trash_this
+        )
+
+        if mode == "trash" and can_trash_this:
             player.in_play.remove(self)
             game_state.trash_card(player, self)
 
-        treasures_in_hand = [
-            card for card in player.hand if game_state.is_treasure(card)
-        ]
-        can_trash_treasure = bool(treasures_in_hand)
-
-        mode = player.ai.choose_investment_mode(
-            game_state, player, can_trash_treasure
-        )
-        if mode == "trash" and not can_trash_treasure:
-            mode = "coin"
-
-        if mode == "coin":
-            player.coins += 1
+            distinct_treasure_names = {
+                card.name for card in player.hand if game_state.is_treasure(card)
+            }
+            player.vp_tokens += len(distinct_treasure_names)
             return
 
-        # mode == "trash"
-        choice = player.ai.choose_treasure_to_trash_for_investment(
-            game_state, player, list(treasures_in_hand)
-        )
-        if (
-            choice is None
-            or choice not in player.hand
-            or not game_state.is_treasure(choice)
-        ):
-            # Fall back to coin if AI declined despite committing to trash.
-            player.coins += 1
-            return
-
-        player.hand.remove(choice)
-        game_state.trash_card(player, choice)
-
-        # Reveal hand and count distinct treasure names (after trashing).
-        distinct_treasure_names = {
-            card.name for card in player.hand if game_state.is_treasure(card)
-        }
-        player.vp_tokens += len(distinct_treasure_names)
+        player.coins += 1

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -695,19 +695,22 @@ def test_crystal_ball_can_play_treasure_on_top():
 
 
 class InvestmentTrashAI(DummyAI):
-    def choose_investment_mode(self, state, player, can_trash_treasure):
-        return "trash" if can_trash_treasure else "coin"
-
-    def choose_treasure_to_trash_for_investment(self, state, player, choices):
+    def choose_card_to_trash(self, state, choices):
         return choices[0] if choices else None
+
+    def choose_investment_mode(self, state, player, can_trash_this):
+        return "trash" if can_trash_this else "coin"
 
 
 class InvestmentCoinAI(DummyAI):
-    def choose_investment_mode(self, state, player, can_trash_treasure):
+    def choose_card_to_trash(self, state, choices):
+        return choices[0] if choices else None
+
+    def choose_investment_mode(self, state, player, can_trash_this):
         return "coin"
 
 
-def test_investment_self_trashes_on_play():
+def test_investment_coin_mode_trashes_card_from_hand_without_trashing_self():
     ai = InvestmentCoinAI()
     player = PlayerState(ai)
     state = GameState([player])
@@ -715,14 +718,15 @@ def test_investment_self_trashes_on_play():
 
     inv = get_card("Investment")
     player.in_play = [inv]
+    player.hand = [get_card("Estate")]
     inv.on_play(state)
 
-    assert inv in state.trash
-    assert inv not in player.in_play
+    assert [c.name for c in state.trash] == ["Estate"]
+    assert inv in player.in_play
     assert player.coins == 1
 
 
-def test_investment_trash_treasure_grants_vp_for_distinct_treasures():
+def test_investment_trash_this_grants_vp_for_distinct_treasures_in_hand():
     ai = InvestmentTrashAI()
     player = PlayerState(ai)
     state = GameState([player])
@@ -730,14 +734,20 @@ def test_investment_trash_treasure_grants_vp_for_distinct_treasures():
 
     inv = get_card("Investment")
     player.in_play = [inv]
-    player.hand = [get_card("Copper"), get_card("Silver"), get_card("Gold")]
+    player.hand = [
+        get_card("Estate"),
+        get_card("Copper"),
+        get_card("Silver"),
+        get_card("Copper"),
+    ]
 
     inv.on_play(state)
 
-    # Trashed Copper. Hand now: Silver, Gold ⇒ 2 distinct ⇒ +2 VP
+    # Trashed Estate. Hand now has Copper, Silver, Copper => 2 distinct Treasures.
     assert player.vp_tokens == 2
-    assert any(c.name == "Copper" for c in state.trash)
+    assert [c.name for c in state.trash] == ["Estate", "Investment"]
     assert inv in state.trash
+    assert inv not in player.in_play
 
 
 # ---------------------------------------------------------------------------
@@ -1504,14 +1514,14 @@ def test_loan_recognizes_curse_as_treasure():
 
 
 class InvestmentTrashCurseAI(DummyAI):
-    def choose_investment_mode(self, state, player, can_trash):
-        return "trash" if can_trash else "coin"
-
-    def choose_treasure_to_trash_for_investment(self, state, player, choices):
+    def choose_card_to_trash(self, state, choices):
         for c in choices:
-            if c.name == "Curse":
+            if c.name == "Estate":
                 return c
         return choices[0] if choices else None
+
+    def choose_investment_mode(self, state, player, can_trash):
+        return "trash" if can_trash else "coin"
 
 
 def test_charlatan_latch_resets_between_games_on_same_state():
@@ -1665,8 +1675,8 @@ def test_charlatan_latches_at_setup_survives_pile_removal():
     assert player.coins == 1
 
 
-def test_investment_can_trash_curse_as_treasure():
-    """Investment's "trash a Treasure" must accept a Curse when Charlatan is
+def test_investment_counts_curse_as_treasure_for_vp_with_charlatan():
+    """Investment's reveal must count Curse as a Treasure when Charlatan is
     in the game."""
     player = PlayerState(InvestmentTrashCurseAI())
     state = GameState([player])
@@ -1674,11 +1684,12 @@ def test_investment_can_trash_curse_as_treasure():
 
     investment = get_card("Investment")
     player.in_play = [investment]
-    player.hand = [get_card("Curse"), get_card("Copper")]
+    player.hand = [get_card("Estate"), get_card("Curse"), get_card("Copper")]
 
     investment.play_effect(state)
 
-    # Investment self-trashes + Curse trashed
     trashed_names = [c.name for c in state.trash]
     assert "Investment" in trashed_names
-    assert "Curse" in trashed_names
+    assert "Estate" in trashed_names
+    assert "Curse" not in trashed_names
+    assert player.vp_tokens == 2


### PR DESCRIPTION
Updates Investment to match official Prosperity text: it trashes a card from hand before choosing +$1 or self-trash VP mode.
The old implementation self-trashed immediately and asked for a Treasure to trash, which inverted the card sequencing and counted the wrong hand state.
AI defaults now evaluate the remaining hand with game-aware Treasure checks, and tests cover coin mode, VP mode, and Charlatan making Curse count as a Treasure.
Validation: `pytest -q` (1601 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Investment card mechanics: players can now choose to either trash a card from hand for +$1, or trash the Investment card itself to gain victory points equal to the number of distinct Treasure cards remaining in hand (including Curses when Charlatan is in play).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/py-overlord/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->