### PR TITLE
[codex] Convert Clerk to reaction and add strategy hooks

### DIFF
--- a/dominion/ai/base_ai.py
+++ b/dominion/ai/base_ai.py
@@ -1807,11 +1807,22 @@ class AI(ABC):
     def should_replay_clerk(
         self, state: GameState, player: PlayerState
     ) -> bool:
-        """At start of turn, may play a Clerk that was set aside.
+        """Backward-compatible Clerk hook.
 
-        Default: yes — the +$2 is essentially free.
+        Older simulator code modeled Clerk as a Duration replay and called this
+        hook from the duration phase. The current model uses
+        ``should_play_clerk_reaction`` for the printed start-of-turn hand
+        reaction; keep this method as an alias for existing test AIs and
+        strategies that override it.
         """
         return True
+
+    def should_play_clerk_reaction(
+        self, state: GameState, player: PlayerState, clerk: Card | None = None
+    ) -> bool:
+        """Clerk reaction: at start of turn, may play this from hand."""
+
+        return self.should_replay_clerk(state, player)
 
     def choose_investment_mode(
         self, state: GameState, player: PlayerState, can_trash_treasure: bool

--- a/dominion/ai/genetic_ai.py
+++ b/dominion/ai/genetic_ai.py
@@ -61,3 +61,52 @@ class GeneticAI(AI):
             return None
 
         return self.strategy.choose_trash(state, state.current_player, choices)
+
+    def choose_watchtower_reaction(
+        self, state: GameState, player, gained_card: Card
+    ) -> Optional[str]:
+        hook = getattr(self.strategy, "choose_watchtower_reaction", None)
+        if hook is not None:
+            return hook(state, player, gained_card)
+        return super().choose_watchtower_reaction(state, player, gained_card)
+
+    def choose_card_to_topdeck_for_clerk(
+        self, state: GameState, player, choices: list[Card]
+    ) -> Optional[Card]:
+        hook = getattr(self.strategy, "choose_card_to_topdeck_for_clerk", None)
+        if hook is not None:
+            return hook(state, player, choices)
+        return super().choose_card_to_topdeck_for_clerk(state, player, choices)
+
+    def should_play_clerk_reaction(
+        self, state: GameState, player, clerk: Card | None = None
+    ) -> bool:
+        hook = getattr(self.strategy, "should_play_clerk_reaction", None)
+        if hook is not None:
+            return bool(hook(state, player, clerk))
+        legacy_hook = getattr(self.strategy, "should_replay_clerk", None)
+        if legacy_hook is not None:
+            return bool(legacy_hook(state, player))
+        return super().should_play_clerk_reaction(state, player, clerk)
+
+    def should_replay_clerk(self, state: GameState, player) -> bool:
+        legacy_hook = getattr(self.strategy, "should_replay_clerk", None)
+        if legacy_hook is not None:
+            return bool(legacy_hook(state, player))
+        return super().should_replay_clerk(state, player)
+
+    def choose_investment_mode(
+        self, state: GameState, player, can_trash_treasure: bool
+    ) -> str:
+        hook = getattr(self.strategy, "choose_investment_mode", None)
+        if hook is not None:
+            return hook(state, player, can_trash_treasure)
+        return super().choose_investment_mode(state, player, can_trash_treasure)
+
+    def choose_treasure_to_trash_for_investment(
+        self, state: GameState, player, choices: list[Card]
+    ) -> Optional[Card]:
+        hook = getattr(self.strategy, "choose_treasure_to_trash_for_investment", None)
+        if hook is not None:
+            return hook(state, player, choices)
+        return super().choose_treasure_to_trash_for_investment(state, player, choices)

--- a/dominion/cards/prosperity/clerk.py
+++ b/dominion/cards/prosperity/clerk.py
@@ -2,9 +2,9 @@ from ..base_card import Card, CardCost, CardStats, CardType
 
 
 class Clerk(Card):
-    """Action-Attack-Duration ($4): +$2. Each other player with 5 or more
+    """Action-Attack-Reaction ($4): +$2. Each other player with 5 or more
     cards in hand puts one of them onto their deck. At the start of your
-    next turn, you may play this.
+    turn, you may play this from your hand.
     """
 
     def __init__(self):
@@ -12,11 +12,8 @@ class Clerk(Card):
             name="Clerk",
             cost=CardCost(coins=4),
             stats=CardStats(coins=2),
-            types=[CardType.ACTION, CardType.ATTACK, CardType.DURATION],
+            types=[CardType.ACTION, CardType.ATTACK, CardType.REACTION],
         )
-        self.duration_persistent = False
-        # Tracks whether this play is a "may play again" start-of-turn replay.
-        self._replaying = False
 
     def play_effect(self, game_state):
         player = game_state.current_player
@@ -39,33 +36,3 @@ class Clerk(Card):
             if other is player:
                 continue
             game_state.attack_player(other, attack_target)
-
-        if not self._replaying:
-            # Set up the duration trigger so we may replay next turn.
-            if self in player.in_play:
-                player.in_play.remove(self)
-            if self not in player.duration:
-                player.duration.append(self)
-            self.duration_persistent = True
-
-    def on_duration(self, game_state):
-        """At the start of the next turn the player may play this again.
-
-        After the replay the engine moves us from duration to discard
-        because we set ``duration_persistent`` back to False here.
-        """
-
-        player = game_state.current_player
-
-        if player.ai.should_replay_clerk(game_state, player):
-            self._replaying = True
-            try:
-                # Resolve the on-play effects again ($2 + attack) with the
-                # standard indirect-action-play bookkeeping, but don't
-                # re-queue another duration trigger (gated by _replaying).
-                game_state.play_action_indirectly(player, self)
-            finally:
-                self._replaying = False
-
-        # The engine will discard us once duration_persistent is False.
-        self.duration_persistent = False

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -274,15 +274,22 @@ class GameState:
         if not self.move_card_from_hand_to_play(player, card):
             return False
         original_index = self.current_player_index
+        is_players_turn = self.players[original_index] is player
         try:
             self.current_player_index = self.players.index(player)
         except ValueError:
             return self.play_action_indirectly(
-                player, card, blocked_return_zone=player.hand
+                player,
+                card,
+                blocked_return_zone=player.hand,
+                apply_enchantress=is_players_turn,
             )
         try:
             return self.play_action_indirectly(
-                player, card, blocked_return_zone=player.hand
+                player,
+                card,
+                blocked_return_zone=player.hand,
+                apply_enchantress=is_players_turn,
             )
         finally:
             self.current_player_index = original_index
@@ -293,6 +300,7 @@ class GameState:
         card: Card,
         *,
         blocked_return_zone: list[Card] | None = None,
+        apply_enchantress: bool | None = None,
     ) -> bool:
         """Resolve a single Action play that originates outside the main
         action-phase loop, applying the bookkeeping that loop would.
@@ -315,8 +323,12 @@ class GameState:
         beforehand and for any helper-specific bookkeeping (e.g. Procession
         trashes the multiplied card after both replays). If Warlord blocks a
         freshly moved card, ``blocked_return_zone`` lets the caller preserve
-        that card's source-zone semantics.
+        that card's source-zone semantics. ``apply_enchantress`` defaults to
+        whether this is the player's own turn; off-turn Reaction plays are not
+        covered by Enchantress.
         """
+        if apply_enchantress is None:
+            apply_enchantress = self.current_player is player
         card_was_in_play = card in player.in_play
         check_warlord = blocked_return_zone is player.hand
         if check_warlord and self._warlord_blocks_action_play(
@@ -342,7 +354,8 @@ class GameState:
         player.actions_this_turn += 1
         player.actions_played += 1
         if (
-            card.is_action
+            apply_enchantress
+            and card.is_action
             and getattr(player, "enchantress_active", False)
             and not getattr(player, "enchantress_used_this_turn", False)
         ):
@@ -360,6 +373,10 @@ class GameState:
             self._fire_urchin_reaction(player, card)
         else:
             card.on_play(self)
+        training_pile = getattr(player, "training_pile", None)
+        if training_pile and card.name == training_pile:
+            player.coins += 1
+        self._maybe_kiln_gain(player, card)
         self.fire_prophecy_action_hooks(player, card)
         self.fire_ally_play_hooks(player, card)
         self._call_tavern_triggers(player, "action_played", card)

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -305,7 +305,7 @@ class GameState:
         - bump ``player.actions_this_turn`` / ``player.actions_played`` so
           cards keying off "Actions played this turn" (Conspirator, Peddler)
           see the correct count
-        - call ``card.on_play``
+        - call ``card.on_play`` or Enchantress's substitute effect
         - fire Prophecy hooks (Rising Sun: Great Leader, Approaching Army)
         - fire Ally on-play hooks (League of Shopkeepers, etc.)
         - fire Tavern "action_played" triggers (Coin of the Realm,
@@ -341,7 +341,25 @@ class GameState:
             return False
         player.actions_this_turn += 1
         player.actions_played += 1
-        card.on_play(self)
+        if (
+            card.is_action
+            and getattr(player, "enchantress_active", False)
+            and not getattr(player, "enchantress_used_this_turn", False)
+        ):
+            player.enchantress_used_this_turn = True
+            self.draw_cards(player, 1)
+            player.actions += 1
+            self.log_callback(
+                (
+                    "action",
+                    player.ai.name,
+                    f"is enchanted while playing {card} (gets +1 Card +1 Action instead)",
+                    {},
+                )
+            )
+            self._fire_urchin_reaction(player, card)
+        else:
+            card.on_play(self)
         self.fire_prophecy_action_hooks(player, card)
         self.fire_ally_play_hooks(player, card)
         self._call_tavern_triggers(player, "action_played", card)

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1279,6 +1279,8 @@ class GameState:
             self.current_player.hand.extend(self.current_player.save_set_aside)
             self.current_player.save_set_aside = []
 
+        self._handle_clerk_start_of_turn(self.current_player)
+
         # Promo Summon: play any cards set aside by Summon last turn.
         # Increment ``actions_this_turn`` before ``on_play`` so cards keyed
         # off that counter (e.g. Conspirator) see the Summoned play, matching
@@ -1429,6 +1431,28 @@ class GameState:
         self._handle_quartermaster_start_of_turn(self.current_player)
 
         self.phase = "action"
+
+    def _handle_clerk_start_of_turn(self, player: PlayerState) -> None:
+        """Play any Clerks the player wants to reveal at start of turn."""
+
+        while True:
+            clerk = next((card for card in player.hand if card.name == "Clerk"), None)
+            if clerk is None:
+                return
+
+            if not player.ai.should_play_clerk_reaction(self, player, clerk):
+                return
+
+            self.log_callback(
+                (
+                    "action",
+                    player.ai.name,
+                    "plays Clerk from hand at start of turn",
+                    {},
+                )
+            )
+            if not self.play_action_from_hand_indirectly(player, clerk):
+                return
 
     def _resolve_farmhands_set_aside(self, player: PlayerState) -> None:
         """Play any cards queued by Farmhands' on-gain trigger."""

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1279,8 +1279,6 @@ class GameState:
             self.current_player.hand.extend(self.current_player.save_set_aside)
             self.current_player.save_set_aside = []
 
-        self._handle_clerk_start_of_turn(self.current_player)
-
         # Promo Summon: play any cards set aside by Summon last turn.
         # Increment ``actions_this_turn`` before ``on_play`` so cards keyed
         # off that counter (e.g. Conspirator) see the Summoned play, matching
@@ -1429,6 +1427,10 @@ class GameState:
 
         # Plunder Quartermaster: gain a card or take all from mat.
         self._handle_quartermaster_start_of_turn(self.current_player)
+
+        # Prosperity 2E Clerk: resolve after start-of-turn setup and draws so
+        # extra-turn caps are active and newly drawn Clerks are eligible.
+        self._handle_clerk_start_of_turn(self.current_player)
 
         self.phase = "action"
 

--- a/dominion/strategy/enhanced_strategy.py
+++ b/dominion/strategy/enhanced_strategy.py
@@ -421,6 +421,7 @@ class EnhancedStrategy:
 
     def choose_gain(self, state, player, choices):
         normal = self._choose_from_priority(self.gain_priority, choices, state, player, "gain")
+        normal = self._collection_action_gain_choice(state, player, choices, normal)
 
         # Trail → Butterfly trick: buy Trail at $4 to gain a $5 card
         trail = next((c for c in choices if c is not None and c.name == "Trail"), None)
@@ -441,6 +442,47 @@ class EnhancedStrategy:
             return trail
 
         return normal
+
+    def _collection_action_gain_choice(self, state, player, choices, normal):
+        """Prefer useful Action gains over low-value money while Collection is active."""
+
+        if getattr(player, "collection_played", 0) <= 0:
+            return normal
+
+        if normal is not None and normal.is_action:
+            return normal
+
+        if normal is not None and normal.name not in {"Copper", "Silver"}:
+            return normal
+
+        actions = [
+            card
+            for card in choices
+            if card is not None
+            and card.is_action
+            and getattr(state, "supply", {}).get(card.name, 1) > 0
+        ]
+        if not actions:
+            return normal
+
+        priority_names = [rule.card_name for rule in self.gain_priority]
+
+        def action_score(card: Card) -> tuple:
+            try:
+                priority = priority_names.index(card.name)
+            except ValueError:
+                priority = len(priority_names)
+            return (
+                -priority,
+                card.cost.coins,
+                card.stats.cards,
+                card.stats.actions,
+                card.stats.coins,
+                card.stats.buys,
+                card.name,
+            )
+
+        return max(actions, key=action_score)
 
     def choose_trash(self, state, player, choices):
         return self._choose_from_priority(self.trash_priority, choices, state, player, "trash")
@@ -518,6 +560,85 @@ class EnhancedStrategy:
             if cond is None or (callable(cond) and cond(state, player)):
                 return i
         return float("inf")
+
+    # -- Card-specific tactical defaults -----------------------------------
+    def choose_watchtower_reaction(self, state, player, gained_card: Card) -> Optional[str]:
+        """Default Watchtower reaction policy.
+
+        Strategies should not have to rediscover that Watchtower trashes junk
+        and topdecks newly gained engine cards. Victory cards stay in discard
+        by default so they do not clog the next hand.
+        """
+
+        if gained_card.name in {"Curse", "Copper", "Ruins"}:
+            return "trash"
+        if gained_card.is_victory and not gained_card.is_action:
+            return None
+        if gained_card.is_action or gained_card.is_treasure:
+            if gained_card.cost.coins >= 4:
+                return "topdeck"
+        return None
+
+    def choose_card_to_topdeck_for_clerk(
+        self, state, player, choices: list[Card]
+    ) -> Optional[Card]:
+        """Clerk attack response: put the least useful card on deck."""
+
+        if not choices:
+            return None
+
+        def burden(card: Card) -> tuple:
+            return (
+                card.name not in {"Curse", "Copper", "Estate", "Hovel", "Overgrown Estate"},
+                not (card.is_victory and not card.is_action and card.cost.coins <= 2),
+                card.is_action,
+                card.is_treasure,
+                card.cost.coins,
+                card.name,
+            )
+
+        return min(choices, key=burden)
+
+    def should_replay_clerk(self, state, player) -> bool:
+        """Backward-compatible alias for old Clerk duration strategies."""
+
+        return True
+
+    def should_play_clerk_reaction(self, state, player, clerk: Card | None = None) -> bool:
+        """Play Clerk from hand at start of turn by default."""
+
+        return self.should_replay_clerk(state, player)
+
+    def choose_investment_mode(self, state, player, can_trash_treasure: bool) -> str:
+        """Default Investment choice.
+
+        Trash for VP when enough Treasure variety remains after trashing the
+        weakest Treasure; otherwise take the +$1.
+        """
+
+        if not can_trash_treasure:
+            return "coin"
+
+        choices = [card for card in player.hand if getattr(card, "is_treasure", False)]
+        trash = self.choose_treasure_to_trash_for_investment(state, player, choices)
+        remaining_names = {
+            card.name
+            for card in choices
+            if card is not trash and getattr(card, "is_treasure", False)
+        }
+        return "trash" if len(remaining_names) >= 2 else "coin"
+
+    def choose_treasure_to_trash_for_investment(
+        self, state, player, choices: list[Card]
+    ) -> Optional[Card]:
+        """Investment: trash the weakest Treasure from hand."""
+
+        if not choices:
+            return None
+        coppers = [card for card in choices if card.name == "Copper"]
+        if coppers:
+            return coppers[0]
+        return min(choices, key=lambda card: (card.cost.coins, card.name))
 
 
 def create_big_money_strategy() -> EnhancedStrategy:

--- a/tests/test_empires_enchantress.py
+++ b/tests/test_empires_enchantress.py
@@ -16,6 +16,11 @@ class _PlayFirstActionAI(DummyAI):
         return None
 
 
+class _PlayClerkReactionAI(_PlayFirstActionAI):
+    def should_play_clerk_reaction(self, state, player, clerk=None):
+        return True
+
+
 def _make_game(num_players=2):
     players = [PlayerState(_PlayFirstActionAI()) for _ in range(num_players)]
     state = GameState(players=players)
@@ -79,6 +84,29 @@ def test_enchantress_only_first_action_overridden():
     # but action count came from Enchantress override (+1 Action).
     # We expect the player drew at least Smithy's 3 cards on the second play.
     assert other.enchantress_used_this_turn
+
+
+def test_enchantress_overrides_start_of_turn_clerk_reaction():
+    state = GameState(
+        [PlayerState(DummyAI()), PlayerState(_PlayClerkReactionAI())]
+    )
+    state.current_player_index = 1
+    defender = state.players[0]
+    other = state.players[1]
+    other.enchantress_active = True
+    clerk = get_card("Clerk")
+    other.hand = [clerk]
+    other.deck = [get_card("Copper") for _ in range(5)]
+    defender.hand = [get_card("Copper") for _ in range(5)]
+
+    state.handle_start_phase()
+
+    assert clerk in other.in_play
+    assert other.enchantress_used_this_turn
+    assert other.coins == 0
+    assert len(other.hand) == 1
+    assert len(defender.hand) == 5
+    assert len(defender.deck) == 0
 
 
 def test_enchantress_persists_across_opponent_extra_turn():

--- a/tests/test_empires_enchantress.py
+++ b/tests/test_empires_enchantress.py
@@ -21,6 +21,11 @@ class _PlayClerkReactionAI(_PlayFirstActionAI):
         return True
 
 
+class _ReactWithBlackCatAI(DummyAI):
+    def should_react_with_black_cat(self, state, player, gainer, gained_card):
+        return True
+
+
 def _make_game(num_players=2):
     players = [PlayerState(_PlayFirstActionAI()) for _ in range(num_players)]
     state = GameState(players=players)
@@ -107,6 +112,27 @@ def test_enchantress_overrides_start_of_turn_clerk_reaction():
     assert len(other.hand) == 1
     assert len(defender.hand) == 5
     assert len(defender.deck) == 0
+
+
+def test_enchantress_does_not_override_off_turn_black_cat_reaction():
+    state = GameState(
+        [PlayerState(DummyAI()), PlayerState(_ReactWithBlackCatAI())]
+    )
+    state.supply["Curse"] = 10
+    state.current_player_index = 0
+    gainer = state.players[0]
+    reactor = state.players[1]
+    reactor.enchantress_active = True
+    black_cat = get_card("Black Cat")
+    reactor.hand = [black_cat]
+    reactor.deck = [get_card("Copper") for _ in range(5)]
+
+    black_cat.on_opponent_gain(state, reactor, gainer, get_card("Estate"))
+
+    assert black_cat in reactor.in_play
+    assert reactor.enchantress_used_this_turn is False
+    assert len(reactor.hand) == 2
+    assert any(card.name == "Curse" for card in gainer.discard)
 
 
 def test_enchantress_persists_across_opponent_extra_turn():

--- a/tests/test_genetic_ai_hooks.py
+++ b/tests/test_genetic_ai_hooks.py
@@ -1,0 +1,85 @@
+from dominion.ai.genetic_ai import GeneticAI
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from dominion.game.player_state import PlayerState
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class HookStrategy(EnhancedStrategy):
+    def choose_watchtower_reaction(self, state, player, gained_card):
+        return "topdeck"
+
+    def choose_card_to_topdeck_for_clerk(self, state, player, choices):
+        return choices[-1]
+
+    def should_play_clerk_reaction(self, state, player, clerk=None):
+        return False
+
+    def choose_investment_mode(self, state, player, can_trash_treasure):
+        return "trash"
+
+    def choose_treasure_to_trash_for_investment(self, state, player, choices):
+        return choices[-1]
+
+
+def test_genetic_ai_delegates_card_specific_strategy_hooks():
+    strategy = HookStrategy()
+    ai = GeneticAI(strategy)
+    player = PlayerState(ai)
+    gained = get_card("City")
+    choices = [get_card("Copper"), get_card("Silver")]
+
+    assert ai.choose_watchtower_reaction(None, player, gained) == "topdeck"
+    assert ai.choose_card_to_topdeck_for_clerk(None, player, choices).name == "Silver"
+    assert ai.should_play_clerk_reaction(None, player, get_card("Clerk")) is False
+    assert ai.choose_investment_mode(None, player, True) == "trash"
+    assert ai.choose_treasure_to_trash_for_investment(None, player, choices).name == "Silver"
+
+
+def test_enhanced_strategy_default_watchtower_policy_handles_common_gains():
+    strategy = EnhancedStrategy()
+    ai = GeneticAI(strategy)
+    player = PlayerState(ai)
+
+    assert ai.choose_watchtower_reaction(None, player, get_card("Curse")) == "trash"
+    assert ai.choose_watchtower_reaction(None, player, get_card("Copper")) == "trash"
+    assert ai.choose_watchtower_reaction(None, player, get_card("City")) == "topdeck"
+    assert ai.choose_watchtower_reaction(None, player, get_card("Silver")) is None
+    assert ai.choose_watchtower_reaction(None, player, get_card("Province")) is None
+
+
+def test_enhanced_strategy_default_clerk_response_topdecks_junk():
+    strategy = EnhancedStrategy()
+    ai = GeneticAI(strategy)
+    player = PlayerState(ai)
+    choices = [get_card("Gold"), get_card("Estate"), get_card("Village")]
+
+    assert ai.should_play_clerk_reaction(None, player, get_card("Clerk")) is True
+    assert ai.choose_card_to_topdeck_for_clerk(None, player, choices).name == "Estate"
+
+
+def test_enhanced_strategy_default_investment_policy_uses_treasure_variety():
+    strategy = EnhancedStrategy()
+    ai = GeneticAI(strategy)
+    player = PlayerState(ai)
+    player.hand = [get_card("Copper"), get_card("Silver"), get_card("Gold")]
+
+    assert ai.choose_investment_mode(None, player, True) == "trash"
+    assert ai.choose_treasure_to_trash_for_investment(None, player, list(player.hand)).name == "Copper"
+
+    player.hand = [get_card("Copper"), get_card("Copper")]
+    assert ai.choose_investment_mode(None, player, True) == "coin"
+
+
+def test_enhanced_strategy_collection_bias_prefers_action_over_low_value_treasure():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [PriorityRule("Silver"), PriorityRule("City")]
+    ai = GeneticAI(strategy)
+    player = PlayerState(ai)
+    player.collection_played = 1
+    state = GameState([player])
+    state.supply = {"Silver": 40, "City": 10}
+
+    choice = ai.choose_buy(state, [get_card("Silver"), get_card("City")])
+
+    assert choice.name == "City"

--- a/tests/test_indirect_action_play.py
+++ b/tests/test_indirect_action_play.py
@@ -207,3 +207,28 @@ def test_vassal_bumps_actions_this_turn_for_revealed_action():
     state.handle_action_phase()
     # Vassal (1) + revealed Smithy (2) = 2.
     assert p1.actions_this_turn == 2
+
+
+def test_indirect_action_play_gets_training_bonus():
+    state, p1, _ = _two_player_state()
+    p1.training_pile = "Village"
+    village = get_card("Village")
+    p1.in_play.append(village)
+    p1.deck = [get_card("Copper") for _ in range(5)]
+
+    state.play_action_indirectly(p1, village)
+
+    assert p1.coins == 1
+
+
+def test_indirect_action_play_triggers_kiln_gain():
+    state, p1, _ = _two_player_state()
+    state.supply["Village"] = 10
+    p1.kiln_pending = 1
+    village = get_card("Village")
+    p1.in_play.append(village)
+
+    state.play_action_indirectly(p1, village)
+
+    assert p1.kiln_pending == 0
+    assert any(card.name == "Village" for card in p1.discard)

--- a/tests/test_inheritance_reserve_duration.py
+++ b/tests/test_inheritance_reserve_duration.py
@@ -56,8 +56,8 @@ def test_inheritance_filters_unsupported_reserve_duration_cards():
     candidate_names = {c.name for c in candidates}
 
     assert {"Guide", "Caravan"} <= candidate_names
+    assert "Clerk" in candidate_names
     assert "Amulet" not in candidate_names
-    assert "Clerk" not in candidate_names
     assert "Dungeon" not in candidate_names
     assert "Garrison" not in candidate_names
     assert "Grotto" not in candidate_names

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -927,12 +927,12 @@ def test_war_chest_excludes_previously_named_card():
 
 
 # ---------------------------------------------------------------------------
-# Clerk ($4 Action-Attack-Duration)
+# Clerk ($4 Action-Attack-Reaction)
 # ---------------------------------------------------------------------------
 
 
-class ClerkReplayAI(DummyAI):
-    def should_replay_clerk(self, state, player):
+class ClerkReactionAI(DummyAI):
+    def should_play_clerk_reaction(self, state, player, clerk=None):
         return True
 
 
@@ -970,7 +970,7 @@ def test_clerk_skips_opponent_with_fewer_than_5_cards():
     assert len(defender.hand) == 4  # Untouched
 
 
-def test_clerk_stays_in_duration_for_replay_next_turn():
+def test_clerk_play_does_not_create_duration_replay():
     attacker = PlayerState(DummyAI())
     defender = PlayerState(DummyAI())
     state = GameState([attacker, defender])
@@ -982,33 +982,28 @@ def test_clerk_stays_in_duration_for_replay_next_turn():
     attacker.hand = [clerk]
     play_action(state, attacker, "Clerk")
 
-    # Clerk should now sit in duration awaiting next-turn replay
-    assert clerk in attacker.duration
+    assert clerk in attacker.in_play
+    assert clerk not in attacker.duration
 
 
-def test_clerk_replays_at_start_of_next_turn():
-    attacker = PlayerState(ClerkReplayAI())
+def test_clerk_reaction_plays_from_hand_at_start_of_turn():
+    attacker = PlayerState(ClerkReactionAI())
     defender = PlayerState(DummyAI())
     state = GameState([attacker, defender])
     state.setup_supply([get_card("Clerk")])
 
     defender.hand = [get_card("Copper") for _ in range(5)]
-    initial_def_hand = len(defender.hand)
 
     clerk = get_card("Clerk")
     attacker.hand = [clerk]
-    play_action(state, attacker, "Clerk")
-    coins_after_first = attacker.coins
-    # First play attacked once
+
+    state.current_player_index = 0
+    state.handle_start_phase()
+
+    assert clerk not in attacker.hand
+    assert clerk in attacker.in_play
+    assert attacker.coins == 2
     assert len(defender.deck) == 1
-
-    # Simulate next-turn duration replay
-    defender.hand = [get_card("Copper") for _ in range(5)]  # restock for second attack
-    state.do_duration_phase()
-
-    # Replay should have given another +$2 and another attack
-    assert attacker.coins == coins_after_first + 2
-    assert len(defender.deck) >= 2  # Second attack added another card
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prosperity_cards.py
+++ b/tests/test_prosperity_cards.py
@@ -1006,6 +1006,45 @@ def test_clerk_reaction_plays_from_hand_at_start_of_turn():
     assert len(defender.deck) == 1
 
 
+def test_clerk_reaction_counts_against_voyage_extra_turn_limit():
+    attacker = PlayerState(ClerkReactionAI())
+    defender = PlayerState(DummyAI())
+    state = GameState([attacker, defender])
+    state.setup_supply([get_card("Clerk")])
+
+    defender.hand = [get_card("Copper") for _ in range(5)]
+    clerk = get_card("Clerk")
+    attacker.hand = [clerk]
+    attacker.voyage_extra_turn_pending = True
+
+    state.current_player_index = 0
+    state.handle_start_phase()
+
+    assert clerk in attacker.in_play
+    assert attacker.voyage_cards_from_hand_remaining == 2
+
+
+def test_clerk_reaction_can_play_clerk_drawn_at_start_of_turn():
+    attacker = PlayerState(ClerkReactionAI())
+    defender = PlayerState(DummyAI())
+    state = GameState([attacker, defender])
+    state.setup_supply([get_card("Clerk"), get_card("Hireling")])
+
+    defender.hand = [get_card("Copper") for _ in range(5)]
+    hireling = get_card("Hireling")
+    clerk = get_card("Clerk")
+    attacker.duration = [hireling]
+    attacker.deck = [clerk]
+    attacker.hand = []
+
+    state.current_player_index = 0
+    state.handle_start_phase()
+
+    assert clerk in attacker.in_play
+    assert clerk not in attacker.hand
+    assert attacker.coins == 2
+
+
 # ---------------------------------------------------------------------------
 # Watchtower reaction (regression)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Corrects Clerk to play as a start-of-turn hand Reaction instead of a Duration replay, and wires the game state to resolve that hook.
Adds strategy-level defaults for Watchtower, Clerk, Investment, and Collection tactics so individual strategies do not have to rediscover common card usage.
Extends GeneticAI to delegate those card-specific hooks to strategies and adds regression coverage for the defaults.
Validation: pytest -q (1606 passed), plus board comparison smoke runs for the Copenhagen board.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clerk now acts as a start-of-turn Reaction and is played from hand at turn start (no duration replay).
  * AI enhancements: new, backward-compatible hooks for Clerk reaction timing, topdeck choice, Watchtower reaction, Investment mode, and which treasure to trash.
  * Game flow: start-of-turn resolves Clerk reactions before action phase; Enchantress replacement correctly applies to indirect plays.

* **Tests**
  * Updated and expanded tests for Clerk reaction behavior, Enchantress interaction, AI hooks, Investment choices, and gain bias.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/py-overlord/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->