### PR TITLE
Island-model evolution pipeline for Lisbon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ battle_logs/*
 /training_logs
 .worktrees/
 /checkpoints
+/island_logs
+/generated_strategies/island_champions
+/generated_strategies/island_merged

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -86,6 +86,13 @@ class GeneticTrainer:
         # (not a dict) so multiple panel members sharing a name (e.g. two
         # BigMoneySmithy variants) each contribute independently.
         self.last_eval_breakdown: list[tuple] = []
+        # Breakdown captured at the moment the best individual was found.
+        # ``last_eval_breakdown`` is overwritten by every evaluation, so by the
+        # time ``train()`` returns it reflects whichever candidate was scored
+        # last in the final generation -- not the saved champion. Callers that
+        # need the champion's per-opponent breakdown (e.g. island manifests)
+        # should read this attribute instead.
+        self.best_eval_breakdown: list[tuple] = []
 
         # Cache card type lookups for filtering
         from dominion.cards.registry import get_card
@@ -871,6 +878,12 @@ class GeneticTrainer:
                     if fitness > best_fitness:
                         best_fitness = fitness
                         best_strategy = deepcopy(strategy)
+                        # Snapshot the breakdown now -- ``last_eval_breakdown``
+                        # will be overwritten by the next candidate, so without
+                        # this copy callers reading it after train() returns
+                        # would see the last-evaluated candidate's breakdown,
+                        # not the champion's.
+                        self.best_eval_breakdown = list(self.last_eval_breakdown)
                         if self.last_eval_breakdown:
                             # Entry[1] is always the per-opponent win rate,
                             # whether the breakdown is 2-tuple or 4-tuple.

--- a/dominion/strategy/strategies/lisbon_festival_bigmoney.py
+++ b/dominion/strategy/strategies/lisbon_festival_bigmoney.py
@@ -1,0 +1,77 @@
+"""Island seed: Festival Big Money + Collection for Lisbon.
+
+Theory of victory
+-----------------
+Big Money with two thoughtful upgrades: Festival as a one-shot terminal
+that turns a $4 hand into $6 with +1 buy, and Collection as a treasure
+that adds VP every time we incidentally gain an Action (Festival,
+Watchtower) on the way to Colonies.
+
+This is the speed-test archetype. If a deck this simple is even close
+to the engines, the engines are over-thinking the kingdom.
+
+Plan
+----
+- Open Silver + Silver or Silver + Watchtower (Clerk defense).
+- Buy Gold/Silver normally. Pick up 1-2 Festivals for the +1 buy and
+  the +$2 (Festival itself doesn't draw, so don't stack more than 2).
+- Pick up 2-3 Collections — each gain of an Action while Collection is
+  in play scores +1 VP token. Even one Festival gain per turn over a
+  Big Money game adds up.
+- One Watchtower for Clerk reaction defense.
+- Buy Colonies aggressively from turn 8-10 onward.
+
+Why this is on the panel
+------------------------
+This is the "is the GA being unfair to Big Money?" check. The City
+Pile Engine docstring says BM is "too easy to crush" — this seed asks
+how true that is when BM is allowed to use the kingdom's cards.
+"""
+
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class LisbonFestivalBigMoney(EnhancedStrategy):
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Lisbon Festival BigMoney"
+        self.description = (
+            "Big Money chassis with Festival, Collection, and a defensive "
+            "Watchtower. The speed-test baseline for Lisbon."
+        )
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule("Colony"),
+            PriorityRule("Province", PriorityRule.resources("coins", ">=", 8)),
+            PriorityRule("Platinum"),
+            PriorityRule("Gold"),
+            PriorityRule("Festival", PriorityRule.max_in_deck("Festival", 2)),
+            PriorityRule("Collection", PriorityRule.max_in_deck("Collection", 3)),
+            PriorityRule("Watchtower", PriorityRule.max_in_deck("Watchtower", 1)),
+            PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
+            PriorityRule("Silver", PriorityRule.turn_number("<=", 10)),
+            PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),
+        ]
+
+        self.action_priority = [
+            PriorityRule("Festival"),
+            PriorityRule("Watchtower"),
+        ]
+
+        self.treasure_priority = [
+            PriorityRule("Collection"),
+            PriorityRule("Platinum"),
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+        self.trash_priority = [
+            PriorityRule("Curse"),
+            PriorityRule("Estate", PriorityRule.provinces_left(">", 2)),
+        ]
+
+
+def create_lisbon_festival_bigmoney() -> EnhancedStrategy:
+    return LisbonFestivalBigMoney()

--- a/dominion/strategy/strategies/lisbon_gardens_slog.py
+++ b/dominion/strategy/strategies/lisbon_gardens_slog.py
@@ -1,0 +1,74 @@
+"""Island seed: Gardens Slog for Lisbon.
+
+Theory of victory
+-----------------
+There are no thinners on the Lisbon board (no Chapel, no Remake, no
+Sentry). Every deck stays bloated. Gardens scores 1 VP per 10 cards.
+Workers' Village gives +1 card / +2 actions / +1 buy — the perfect
+gain-engine for stacking buys per turn. Festival adds +1 buy on top.
+
+Plan
+----
+- Open Silver + Silver.
+- Buy Workers' Villages and Festivals aggressively for the +1 buy.
+- Snap up Gardens early (the pile is only 8 in a 2p game; an opponent
+  may also want them).
+- Late game, spend extra buys on Copper and Estate to bloat the deck
+  count AND empty piles for a 3-pile finish. 30-40 cards = 3-4 Gardens
+  apiece, plus a few Estates and Duchies, totals 20+ VP in a Colony
+  game that the opponent might struggle to match without thinning.
+- Avoid Province/Colony entirely until the 3-pile finish — they're
+  expensive and we don't need the VP.
+
+Why this is on the panel
+------------------------
+A slog archetype attacks the engine archetypes on a different VP axis.
+City Pile Engine wants the City pile empty; Gardens Slog wants three
+piles empty AND tons of junk. They could collide productively or the
+slog could just be too slow. Worth testing.
+"""
+
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class LisbonGardensSlog(EnhancedStrategy):
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Lisbon Gardens Slog"
+        self.description = (
+            "No-Province slog: Gardens + Workers' Village + Festival, pile "
+            "out on cheap cards and copper-stuffing for the 3-pile ending."
+        )
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule("Gardens", PriorityRule.max_in_deck("Gardens", 8)),
+            PriorityRule("Workers' Village", PriorityRule.max_in_deck("Workers' Village", 8)),
+            PriorityRule("Festival", PriorityRule.max_in_deck("Festival", 6)),
+            PriorityRule("Watchtower", PriorityRule.max_in_deck("Watchtower", 2)),
+            PriorityRule("Silver", PriorityRule.turn_number("<=", 8)),
+            PriorityRule("Duchy", PriorityRule.empty_piles(">=", 1)),
+            PriorityRule("Estate", PriorityRule.empty_piles(">=", 1)),
+            PriorityRule("Copper", PriorityRule.empty_piles(">=", 1)),
+            PriorityRule("Silver"),
+        ]
+
+        self.action_priority = [
+            PriorityRule("Workers' Village"),
+            PriorityRule("Festival"),
+            PriorityRule("Watchtower"),
+        ]
+
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+        self.trash_priority = [
+            PriorityRule("Curse"),
+        ]
+
+
+def create_lisbon_gardens_slog() -> EnhancedStrategy:
+    return LisbonGardensSlog()

--- a/dominion/strategy/strategies/lisbon_investment_rush.py
+++ b/dominion/strategy/strategies/lisbon_investment_rush.py
@@ -1,0 +1,74 @@
+"""Island seed: Investment Colony Rush for the Lisbon Colony board.
+
+Theory of victory
+-----------------
+On the Lisbon kingdom (Watchtower, Clerk, Gardens, Investment, Workers'
+Village, City, Collection, Festival, Expand, Peddler) the dominant
+"engine" archetypes ignore Investment's other half: trash-this-for-VP.
+A small pile of Investments can convert distinct treasures into a fat
+VP-token pile while accelerating Colony purchases. Pair with Watchtower
+so Gold/Platinum/Colony gains topdeck.
+
+Plan
+----
+- Open Investment + Silver.
+- Buy a few Investments early. Each turn, Investment trashes a Copper
+  or Estate from hand and then takes +$1 to bridge to Gold/Platinum.
+- Once we have 4-5 distinct Treasure names in hand, detonate an
+  Investment: trash it, score +5 VP tokens, repeat.
+- Watchtower reactions topdeck Gold/Platinum/Province/Colony into the
+  next hand, so the Investment-detonation hands stay strong.
+
+Why this is on the panel
+------------------------
+The City Pile Engine docstring claims "City pile-out" is the dominant
+play. If a simple Investment rush is anywhere near competitive, that
+claim is wrong. This seed is the falsifier.
+"""
+
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class LisbonInvestmentRush(EnhancedStrategy):
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Lisbon Investment Rush"
+        self.description = (
+            "Investment-detonation Colony rush with Watchtower topdeck "
+            "reactions. No engine — just trash junk for VP and buy Colonies."
+        )
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule("Colony"),
+            PriorityRule("Platinum"),
+            PriorityRule("Province", PriorityRule.resources("coins", ">=", 8)),
+            PriorityRule("Gold"),
+            PriorityRule("Investment", PriorityRule.max_in_deck("Investment", 5)),
+            PriorityRule("Watchtower", PriorityRule.max_in_deck("Watchtower", 1)),
+            PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
+            PriorityRule("Silver", PriorityRule.turn_number("<=", 10)),
+            PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),
+        ]
+
+        self.action_priority = [
+            PriorityRule("Watchtower"),
+        ]
+
+        self.treasure_priority = [
+            PriorityRule("Platinum"),
+            PriorityRule("Gold"),
+            PriorityRule("Investment"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+        self.trash_priority = [
+            PriorityRule("Curse"),
+            PriorityRule("Estate", PriorityRule.provinces_left(">", 2)),
+            PriorityRule("Copper", PriorityRule.has_cards(["Silver", "Gold"], 2)),
+        ]
+
+
+def create_lisbon_investment_rush() -> EnhancedStrategy:
+    return LisbonInvestmentRush()

--- a/dominion/strategy/strategies/lisbon_watchtower_topdeck.py
+++ b/dominion/strategy/strategies/lisbon_watchtower_topdeck.py
@@ -1,0 +1,88 @@
+"""Island seed: Watchtower Topdeck Engine for Lisbon.
+
+Theory of victory
+-----------------
+Watchtower is a draw-to-6 cantrip AND a reaction that lets you topdeck
+or trash a gained card. The reaction transforms how Expand and
+Investment interact with deck composition: gain a Gold via Expand →
+topdeck it → it shows up in the next hand. Gain a Workers' Village →
+topdeck it → guaranteed engine fuel next turn.
+
+Plan
+----
+- Open Watchtower + Silver.
+- Buy a second Watchtower around turn 3-4.
+- Expand becomes a deck-shaping tool: trash Estate → gain Workers'
+  Village → topdeck via Watchtower → use it next turn. Trash Silver →
+  gain Festival → topdeck. Trash Festival → gain Gold → topdeck.
+- Investment provides additional gain pressure: each turn it trashes
+  a junk card (with Watchtower in hand to topdeck the next gain).
+- Workers' Village and Festival fill out the engine; Peddler stays
+  expensive without 3+ actions in play.
+
+Why this is on the panel
+------------------------
+Watchtower's reaction is the kingdom's hidden synergy — it punishes
+strategies that ignore it. The City Pile Engine treats Watchtower as
+an afterthought (it's #12 in its gain list). If a Watchtower-centric
+build wins, the GA missed a real combo.
+"""
+
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class LisbonWatchtowerTopdeck(EnhancedStrategy):
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Lisbon Watchtower Topdeck"
+        self.description = (
+            "Watchtower-as-engine: reaction topdecks every important gain. "
+            "Expand and Investment as the gain-pressure tools."
+        )
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule("Colony"),
+            PriorityRule("Province", PriorityRule.resources("coins", ">=", 8)),
+            PriorityRule("Watchtower", PriorityRule.max_in_deck("Watchtower", 2)),
+            PriorityRule("Workers' Village", PriorityRule.max_in_deck("Workers' Village", 4)),
+            PriorityRule("Gold"),
+            PriorityRule("Expand", PriorityRule.max_in_deck("Expand", 2)),
+            PriorityRule("Festival", PriorityRule.max_in_deck("Festival", 3)),
+            PriorityRule("Investment", PriorityRule.max_in_deck("Investment", 3)),
+            PriorityRule("Platinum", PriorityRule.turn_number("<=", 12)),
+            PriorityRule("Silver", PriorityRule.turn_number("<=", 6)),
+            PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
+            PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),
+        ]
+
+        self.action_priority = [
+            PriorityRule("Workers' Village"),
+            PriorityRule("Festival"),
+            PriorityRule("Watchtower"),
+            PriorityRule(
+                "Expand",
+                PriorityRule.and_(
+                    PriorityRule.card_in_play("Workers' Village"),
+                    PriorityRule.cards_gained_this_turn("<=", 1),
+                ),
+            ),
+        ]
+
+        self.treasure_priority = [
+            PriorityRule("Platinum"),
+            PriorityRule("Gold"),
+            PriorityRule("Investment"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+        self.trash_priority = [
+            PriorityRule("Curse"),
+            PriorityRule("Estate", PriorityRule.provinces_left(">", 2)),
+            PriorityRule("Copper", PriorityRule.has_cards(["Silver", "Gold"], 3)),
+        ]
+
+
+def create_lisbon_watchtower_topdeck() -> EnhancedStrategy:
+    return LisbonWatchtowerTopdeck()

--- a/dominion/strategy/strategies/lisbon_wv_peddler_engine.py
+++ b/dominion/strategy/strategies/lisbon_wv_peddler_engine.py
@@ -1,0 +1,89 @@
+"""Island seed: Workers' Village / Peddler / Expand Engine for Lisbon.
+
+Theory of victory
+-----------------
+A true engine that does not depend on City's piling-out trick. Workers'
+Village is a $4 *village* that also gives +1 buy — the foundation of the
+deck. Festival provides the terminal $2/+1 buy explosion. Peddler costs
+$8 normally but drops by $2 per Action in play during the Buy phase, so
+with 3+ actions in play it's a free cantrip-economy card.
+
+Plan
+----
+- Open Silver + Silver (or Workers' Village + Silver).
+- Pile up Workers' Villages and Festivals through turn 7.
+- Once 3-4 actions are in play per turn, start gaining Peddlers for $2
+  or $0 each.
+- Use Expand to upgrade Estates/Coppers into Gold or Workers' Village,
+  reserving it for turns where Workers' Village is in play (non-terminal
+  use) and we haven't already burned the buy.
+- Collection is a treasure that adds +$2/+1 buy AND gives +1 VP per
+  Action gained while in play. Pick up 2-3 to convert gain pressure
+  into a steady VP drip without slowing down.
+- Buy Colonies once we can repeatably hit $11.
+
+Why this is on the panel
+------------------------
+This is the "obvious" strong engine for the board. If the City Pile
+Engine genuinely beats this, then the City pile-out trick is the real
+deal. If this beats it, the original GA found a local optimum.
+"""
+
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class LisbonWvPeddlerEngine(EnhancedStrategy):
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Lisbon WV Peddler Engine"
+        self.description = (
+            "Workers' Village + Festival draw engine with Peddler economy "
+            "and Expand upgrades. The 'obvious' strong engine for Lisbon."
+        )
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule("Colony"),
+            PriorityRule("Province", PriorityRule.resources("coins", ">=", 8)),
+            PriorityRule("Workers' Village", PriorityRule.max_in_deck("Workers' Village", 5)),
+            PriorityRule("Festival", PriorityRule.max_in_deck("Festival", 4)),
+            PriorityRule("Peddler", PriorityRule.actions_in_play(">=", 3)),
+            PriorityRule("Gold"),
+            PriorityRule("Expand", PriorityRule.max_in_deck("Expand", 2)),
+            PriorityRule("Collection", PriorityRule.max_in_deck("Collection", 3)),
+            PriorityRule("Platinum", PriorityRule.turn_number("<=", 12)),
+            PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
+            PriorityRule("Silver", PriorityRule.turn_number("<=", 6)),
+            PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),
+        ]
+
+        self.action_priority = [
+            PriorityRule("Workers' Village"),
+            PriorityRule("Festival"),
+            PriorityRule("Peddler"),
+            PriorityRule(
+                "Expand",
+                PriorityRule.and_(
+                    PriorityRule.card_in_play("Workers' Village"),
+                    PriorityRule.cards_gained_this_turn("<=", 1),
+                ),
+            ),
+        ]
+
+        self.treasure_priority = [
+            PriorityRule("Collection"),
+            PriorityRule("Platinum"),
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+        self.trash_priority = [
+            PriorityRule("Curse"),
+            PriorityRule("Estate", PriorityRule.provinces_left(">", 2)),
+            PriorityRule("Copper", PriorityRule.has_cards(["Silver", "Gold"], 3)),
+        ]
+
+
+def create_lisbon_wv_peddler_engine() -> EnhancedStrategy:
+    return LisbonWvPeddlerEngine()

--- a/scripts/README_island_model.md
+++ b/scripts/README_island_model.md
@@ -1,0 +1,163 @@
+# Island-Model Evolution for Lisbon
+
+Three-stage pipeline for escaping the local-optimum problem on the Lisbon
+Colony board (see `boards/lisbon.txt`):
+
+1. **`island_evolve.py`** — one isolated GA per archetype, identical
+   hyperparameters, **same fixed opponent panel** across all islands.
+2. **`island_tournament.py`** — round-robin between the islands'
+   champions to pick the best archetype.
+3. **`island_merge.py`** *(optional)* — seed all champions into one
+   population and evolve a hybrid stage.
+
+The point of the model is fair comparison. Each archetype's seed is a
+distinct theory of the kingdom; without isolated training every theory
+would collapse into whatever the current dominant strategy is.
+
+## Why this exists
+
+The previous `Lisbon City Engine` was evolved against a panel that
+explicitly excluded Big Money ("too easy to crush"). That deleted the
+falsifier — a strategy that builds slowly should *struggle* against a
+speed test, and removing the speed test stops the GA from finding that
+out. The seed file's own docstring records this:
+
+> "No Big Money on the panel — too easy to crush, doesn't drive learning."
+
+This pipeline includes Big Money in the fixed panel for every island,
+and rounds out the panel with `ClerkCollectionColony` as a non-seed
+engine baseline.
+
+## Seeds
+
+Six islands, each a different theory:
+
+| Seed | Theory |
+|---|---|
+| Lisbon Investment Rush | Investment-detonation Colony rush, Watchtower topdecks |
+| Lisbon WV Peddler Engine | Workers' Village/Festival/Peddler draw + Expand upgrades |
+| Lisbon Watchtower Topdeck | Watchtower reaction as the deck-shaping engine |
+| Lisbon Festival BigMoney | Big Money chassis with Festival + Collection |
+| Lisbon Gardens Slog | No-Province slog, Gardens + Workers' Village + 3-pile finish |
+| Lisbon City Engine | Existing strategy from PR #243 — the control |
+
+Seed source: `dominion/strategy/strategies/lisbon_*.py`.
+All are auto-loaded by `StrategyLoader`.
+
+## How to run
+
+The scripts need `PYTHONPATH=.` from the repo root because they import
+`dominion.*` directly.
+
+### Smoke test (one minute total)
+
+```bash
+PYTHONPATH=. python scripts/island_evolve.py --smoke --parallel
+PYTHONPATH=. python scripts/island_tournament.py \
+    --manifest generated_strategies/island_champions/<RUN_ID>/manifest.json \
+    --games 30 --parallel --include-panel
+```
+
+`--smoke` forces population=12, generations=5, games-per-eval=8.
+Champions are not informative at this scale; this only validates the
+pipeline.
+
+### Real run (multi-hour)
+
+```bash
+PYTHONPATH=. python scripts/island_evolve.py \
+    --population 30 --generations 60 --games-per-eval 30 --parallel
+```
+
+Watch the `island_logs/<RUN_ID>/<seed>/` directories for per-island
+training logs. The script prints a summary table at the end and saves
+each champion as `generated_strategies/island_champions/<RUN_ID>/<seed>_champion.py`
+plus a `manifest.json`.
+
+Then the tournament:
+
+```bash
+PYTHONPATH=. python scripts/island_tournament.py \
+    --manifest generated_strategies/island_champions/<RUN_ID>/manifest.json \
+    --games 400 --parallel --include-panel \
+    --output reports/lisbon_island_tournament_<RUN_ID>.md
+```
+
+`--include-panel` adds Big Money and ClerkCollectionColony to the
+tournament so champions can be compared against the same opponents they
+were trained against.
+
+### Optional merged stage
+
+If the tournament shows two or three champions clustered together (e.g.
+within 5% of each other), evolve a final hybrid stage:
+
+```bash
+PYTHONPATH=. python scripts/island_merge.py \
+    --manifest generated_strategies/island_champions/<RUN_ID>/manifest.json \
+    --generations 30 --population 40 --games-per-eval 30
+```
+
+This seeds one fresh population with every island champion (plus
+mutated variants) and evolves against the same fixed panel for another
+30 generations. The output is `generated_strategies/island_merged/<RUN_ID>/merged_champion.py`.
+
+Once it finishes, rerun the tournament with the merged champion
+added via `--strategies`:
+
+```bash
+PYTHONPATH=. python scripts/island_tournament.py \
+    --strategies \
+      generated_strategies/island_champions/<RUN_ID>/lisbon_investment_rush_champion.py \
+      generated_strategies/island_champions/<RUN_ID>/lisbon_wv_peddler_engine_champion.py \
+      generated_strategies/island_champions/<RUN_ID>/lisbon_watchtower_topdeck_champion.py \
+      generated_strategies/island_champions/<RUN_ID>/lisbon_festival_bigmoney_champion.py \
+      generated_strategies/island_champions/<RUN_ID>/lisbon_gardens_slog_champion.py \
+      generated_strategies/island_champions/<RUN_ID>/lisbon_city_engine_champion.py \
+      generated_strategies/island_merged/<MERGE_RUN_ID>/merged_champion.py \
+      "Big Money" "ClerkCollectionColony" \
+    --games 400 --parallel
+```
+
+## Compute budget estimate
+
+With `--parallel` on a 6+ core machine, a real run is roughly:
+
+- Per island, sequential: population × generations × (games_per_eval / num_panel) games per panel member.
+  At pop=30, gens=60, games=30, 2 panel members → 30 × 60 × 30 ≈ 54,000 games.
+- 6 islands in parallel → wall time ≈ longest single island.
+- Per-game wall time on this codebase is roughly 50–150ms depending on
+  the strategy's deck size; figure ~30–90 minutes per island.
+
+Tournament with 8 entries × 28 matchups × 400 games ≈ 11,200 games,
+~10–30 min in parallel.
+
+Total wall time for the full pipeline: roughly 1–2 hours on a recent
+multi-core MacBook.
+
+## Reading the tournament report
+
+Three blocks of output:
+
+1. **Win-rate matrix** — `row vs col`. A 60% cell at (A, B) means A
+   wins 60% of games against B.
+2. **Average margin matrix** — `row VP minus col VP`. Useful for
+   distinguishing "barely wins" from "crushes."
+3. **Average win rate** — single number per strategy, averaged across
+   all opponents. This is the ranking.
+
+What you want to see: a non-City-Engine champion at the top of the
+average-win-rate table. If City Engine is still #1 after equal
+optimization budget, the original "City pile-out is dominant" claim
+holds up. If anything else wins, the GA was stuck in a local optimum.
+
+## What "same panel" means and why it matters
+
+Every island evolves against the same `panel = [BigMoney, ClerkCollectionColony]`.
+This is **the key methodological fix** — see the docstring of
+`scripts/island_evolve.py` for the full rationale.
+
+If you change the panel per island, fitness numbers are no longer
+comparable across islands, and the round-robin tournament can't be
+trusted to crown the actual best strategy. Resist any urge to "tune
+the panel for each archetype."

--- a/scripts/island_evolve.py
+++ b/scripts/island_evolve.py
@@ -1,0 +1,295 @@
+"""Island-model evolution for the Lisbon board.
+
+Runs one ``GeneticTrainer`` per seed strategy. Each trainer uses identical
+hyperparameters and the same fixed opponent panel, so fitness numbers are
+comparable across islands. The champions are saved as importable Python
+files for the tournament stage.
+
+The whole point of the island model is to escape local optima: each seed
+represents a distinct theory of the kingdom (Investment Rush, WV/Peddler
+Engine, Watchtower Topdeck, Festival BigMoney, Gardens Slog, City Pile
+Engine). After every island has had equal optimization budget against a
+neutral panel, the champions face each other in
+``scripts/island_tournament.py``.
+
+Usage
+-----
+    # Smoke test (sequential, small budget):
+    python scripts/island_evolve.py --smoke
+
+    # Real run, parallel across islands:
+    python scripts/island_evolve.py \
+        --population 30 --generations 60 --games-per-eval 30 --parallel
+
+    # Single island for debugging:
+    python scripts/island_evolve.py --only "Lisbon Investment Rush"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import multiprocessing as mp
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import coloredlogs
+
+from dominion.boards.loader import load_board
+from dominion.runner import save_strategy_as_python
+from dominion.simulation.genetic_trainer import GeneticTrainer
+from dominion.strategy.strategy_loader import StrategyLoader
+
+
+# Seeds the islands start from. Each is a distinct theory of the kingdom.
+# Order matters only for log readability — every island gets the same panel
+# and the same budget regardless of position in this list.
+LISBON_SEEDS = [
+    "Lisbon Investment Rush",
+    "Lisbon WV Peddler Engine",
+    "Lisbon Watchtower Topdeck",
+    "Lisbon Festival BigMoney",
+    "Lisbon Gardens Slog",
+    "Lisbon City Engine",
+]
+
+# Fixed panel for every island. Big Money is the non-negotiable speed-test
+# (a deck that builds slowly should win less vs BM than a deck that builds
+# fast — that's the signal previous panels filtered out). ClerkCollection-
+# Colony is the existing engine baseline. Neither is one of the seeds.
+LISBON_PANEL = [
+    "Big Money",
+    "ClerkCollectionColony",
+]
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class IslandResult:
+    seed_name: str
+    output_path: str
+    fitness: float
+    win_rate_vs_panel: float
+    panel_breakdown: list[tuple]
+    wall_seconds: float
+
+
+def _safe_class_name(name: str) -> str:
+    return "".join(ch for ch in name.title() if ch.isalnum()) + "Champion"
+
+
+def _safe_filename(name: str) -> str:
+    slug = name.lower().replace(" ", "_").replace("'", "")
+    return "".join(ch for ch in slug if ch.isalnum() or ch in ("_",))
+
+
+def run_one_island(
+    seed_name: str,
+    board_path: str,
+    panel_names: list[str],
+    population: int,
+    generations: int,
+    games_per_eval: int,
+    mutation_rate: float,
+    output_dir: str,
+    run_id: str,
+) -> IslandResult:
+    """Run a single island. Designed to be called in a subprocess: takes only
+    picklable arguments and constructs the trainer + loader inside."""
+
+    # Configure logging in the subprocess. Each island prefixes its logs with
+    # its seed name so a parallel run is still readable.
+    coloredlogs.install(
+        level="INFO",
+        logger=logging.getLogger(),
+        fmt=f"%(asctime)s [{seed_name}] %(message)s",
+    )
+
+    loader = StrategyLoader()
+    seed = loader.get_strategy(seed_name)
+    if seed is None:
+        raise ValueError(f"Seed strategy not found: {seed_name!r}")
+
+    panel = []
+    for name in panel_names:
+        opp = loader.get_strategy(name)
+        if opp is None:
+            raise ValueError(f"Panel strategy not found: {name!r}")
+        panel.append(opp)
+
+    board_config = load_board(board_path)
+
+    trainer = GeneticTrainer(
+        kingdom_cards=board_config.kingdom_cards,
+        population_size=population,
+        generations=generations,
+        mutation_rate=mutation_rate,
+        games_per_eval=games_per_eval,
+        board_config=board_config,
+        log_folder=f"island_logs/{run_id}/{_safe_filename(seed_name)}",
+    )
+    trainer.inject_strategy(seed)
+    trainer.set_baseline_panel(panel)
+
+    start = time.monotonic()
+    best, metrics = trainer.train()
+    elapsed = time.monotonic() - start
+
+    if best is None:
+        raise RuntimeError(f"Island {seed_name} produced no champion")
+
+    # Replace the GA's auto-generated internal name (e.g. "gen3-4773797616")
+    # with something readable so the tournament report identifies champions by
+    # their archetype rather than a memory address.
+    best.name = f"{seed_name} Champion"
+
+    output_path = Path(output_dir) / f"{_safe_filename(seed_name)}_champion.py"
+    save_strategy_as_python(best, output_path, _safe_class_name(seed_name))
+    logger.info(
+        "Island done: %s  fitness=%.2f  win_rate=%.1f%%  saved=%s",
+        seed_name,
+        metrics.get("fitness", 0.0),
+        metrics.get("win_rate", 0.0),
+        output_path,
+    )
+
+    return IslandResult(
+        seed_name=seed_name,
+        output_path=str(output_path),
+        fitness=float(metrics.get("fitness", 0.0)),
+        win_rate_vs_panel=float(metrics.get("win_rate", 0.0)),
+        panel_breakdown=list(trainer.last_eval_breakdown),
+        wall_seconds=elapsed,
+    )
+
+
+def main() -> None:
+    coloredlogs.install(level="INFO", logger=logging.getLogger())
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--board", default="boards/lisbon.txt")
+    parser.add_argument("--population", type=int, default=30)
+    parser.add_argument("--generations", type=int, default=60)
+    parser.add_argument("--games-per-eval", type=int, default=30)
+    parser.add_argument("--mutation-rate", type=float, default=0.15)
+    parser.add_argument(
+        "--output-dir",
+        default="generated_strategies/island_champions",
+        help="Where to save each island's champion as a Python file.",
+    )
+    parser.add_argument(
+        "--seeds",
+        nargs="+",
+        default=LISBON_SEEDS,
+        help="Seed strategy names. Defaults to the six Lisbon island seeds.",
+    )
+    parser.add_argument(
+        "--only",
+        help="Run only this seed (for debugging one island in isolation).",
+    )
+    parser.add_argument(
+        "--parallel",
+        action="store_true",
+        help="Run islands in parallel using multiprocessing.",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=0,
+        help="Cap parallel workers. 0 = number of seeds (one worker per island).",
+    )
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Override hyperparameters for a fast smoke test.",
+    )
+    args = parser.parse_args()
+
+    if args.smoke:
+        args.population = 12
+        args.generations = 5
+        args.games_per_eval = 8
+
+    seeds = [args.only] if args.only else list(args.seeds)
+
+    run_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_dir) / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info("Run id: %s", run_id)
+    logger.info("Seeds: %s", seeds)
+    logger.info("Panel: %s", LISBON_PANEL)
+    logger.info(
+        "Hyperparameters: pop=%d gens=%d games=%d mut=%.2f parallel=%s",
+        args.population, args.generations, args.games_per_eval, args.mutation_rate, args.parallel,
+    )
+
+    kwargs = dict(
+        board_path=args.board,
+        panel_names=LISBON_PANEL,
+        population=args.population,
+        generations=args.generations,
+        games_per_eval=args.games_per_eval,
+        mutation_rate=args.mutation_rate,
+        output_dir=str(output_dir),
+        run_id=run_id,
+    )
+
+    results: list[IslandResult] = []
+
+    if args.parallel and len(seeds) > 1:
+        max_workers = args.max_workers or len(seeds)
+        # 'spawn' is the safe default — 'fork' on macOS can deadlock with
+        # libraries that aren't fork-safe (notably some BLAS / logging stacks).
+        ctx = mp.get_context("spawn")
+        with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as ex:
+            futures = {
+                ex.submit(run_one_island, seed_name=seed, **kwargs): seed
+                for seed in seeds
+            }
+            for fut in as_completed(futures):
+                seed = futures[fut]
+                try:
+                    results.append(fut.result())
+                except Exception:
+                    logger.exception("Island %s failed", seed)
+    else:
+        for seed in seeds:
+            try:
+                results.append(run_one_island(seed_name=seed, **kwargs))
+            except Exception:
+                logger.exception("Island %s failed", seed)
+
+    # Persist a manifest so the tournament runner can pick it up automatically.
+    manifest = {
+        "run_id": run_id,
+        "board": args.board,
+        "panel": LISBON_PANEL,
+        "hyperparameters": {
+            "population": args.population,
+            "generations": args.generations,
+            "games_per_eval": args.games_per_eval,
+            "mutation_rate": args.mutation_rate,
+        },
+        "islands": [asdict(r) for r in results],
+    }
+    manifest_path = output_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    logger.info("Manifest written: %s", manifest_path)
+
+    print("\n=== Island summary ===")
+    print(f"{'Seed':<35} {'fitness':>8} {'win%':>7} {'time(s)':>9}")
+    for r in sorted(results, key=lambda r: -r.fitness):
+        print(f"{r.seed_name:<35} {r.fitness:>8.2f} {r.win_rate_vs_panel:>6.1f}% {r.wall_seconds:>9.1f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/island_evolve.py
+++ b/scripts/island_evolve.py
@@ -166,7 +166,11 @@ def run_one_island(
         output_path=str(output_path),
         fitness=float(metrics.get("fitness", 0.0)),
         win_rate_vs_panel=float(metrics.get("win_rate", 0.0)),
-        panel_breakdown=list(trainer.last_eval_breakdown),
+        # ``best_eval_breakdown`` is the snapshot taken when ``best`` was first
+        # selected as the champion. Using ``last_eval_breakdown`` here would
+        # publish the breakdown of whichever candidate was evaluated last in
+        # the final generation, not the saved champion.
+        panel_breakdown=list(trainer.best_eval_breakdown),
         wall_seconds=elapsed,
     )
 

--- a/scripts/island_evolve.py
+++ b/scripts/island_evolve.py
@@ -244,6 +244,11 @@ def main() -> None:
     )
 
     results: list[IslandResult] = []
+    # Track failures so a partial run can't silently produce a manifest the
+    # downstream tournament would treat as complete. The whole point of the
+    # island model is that every seed gets the same budget — if one island
+    # crashed mid-evolution, comparing the rest is meaningless.
+    failed_seeds: list[str] = []
 
     if args.parallel and len(seeds) > 1:
         max_workers = args.max_workers or len(seeds)
@@ -261,12 +266,21 @@ def main() -> None:
                     results.append(fut.result())
                 except Exception:
                     logger.exception("Island %s failed", seed)
+                    failed_seeds.append(seed)
     else:
         for seed in seeds:
             try:
                 results.append(run_one_island(seed_name=seed, **kwargs))
             except Exception:
                 logger.exception("Island %s failed", seed)
+                failed_seeds.append(seed)
+
+    if failed_seeds:
+        logger.error(
+            "Run incomplete — %d/%d islands failed: %s. Not writing manifest.",
+            len(failed_seeds), len(seeds), failed_seeds,
+        )
+        sys.exit(1)
 
     # Persist a manifest so the tournament runner can pick it up automatically.
     manifest = {

--- a/scripts/island_merge.py
+++ b/scripts/island_merge.py
@@ -130,6 +130,15 @@ def main() -> None:
             "Re-run with verbose logging to find the underlying training failure."
         )
 
+    # If the hybrid stage doesn't improve on the injected champions, ``best``
+    # is a deepcopy of one of them with its original ``name`` preserved (see
+    # GeneticTrainer._inject_strategies). Saving as-is would emit a file
+    # whose ``self.name`` collides with the matching island champion, and
+    # ``island_tournament.py`` then rejects the entrant list via its
+    # duplicate-name guard. Match island_evolve.py and assign a stable
+    # merged-stage display name before serialization.
+    best.name = "Lisbon Merged Champion"
+
     output_path = output_dir / "merged_champion.py"
     save_strategy_as_python(best, output_path, "LisbonMergedChampion")
     logger.info(

--- a/scripts/island_merge.py
+++ b/scripts/island_merge.py
@@ -1,0 +1,158 @@
+"""Merged-final-stage runner: take all island champions, seed them into one
+population, evolve a final stage to find hybrid strategies.
+
+Rationale
+---------
+After ``island_evolve.py``, each archetype has had equal optimization
+budget against a fixed panel. The tournament tells you which archetype
+won, but pure archetypes may still be sub-optimal compared to *hybrids*
+(e.g. a Workers'-Village engine that pivots to Expand-Colony late, or
+an Investment rush that opens with two Watchtowers). The merged stage
+seeds one population with every champion, evolves for N generations,
+and lets crossover/mutation discover those hybrids.
+
+Crucially, this stage uses the *same fixed panel* as the islands — so
+fitness numbers here are directly comparable to fitness on each island.
+A merged champion that scores higher than every island champion against
+the same panel is the genuinely better strategy.
+
+Usage
+-----
+    python scripts/island_merge.py \
+        --manifest generated_strategies/island_champions/<RUN_ID>/manifest.json \
+        --generations 30 --population 40 --games-per-eval 30
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import inspect
+import json
+import logging
+import time
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+
+import coloredlogs
+
+from dominion.boards.loader import load_board
+from dominion.runner import save_strategy_as_python
+from dominion.simulation.genetic_trainer import GeneticTrainer
+from dominion.strategy.enhanced_strategy import EnhancedStrategy
+from dominion.strategy.strategy_loader import StrategyLoader
+
+
+logger = logging.getLogger(__name__)
+
+
+def _load_strategy_from_path(path: Path) -> EnhancedStrategy:
+    spec = importlib.util.spec_from_file_location(f"champion_{path.stem}", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    for _, obj in inspect.getmembers(module, inspect.isclass):
+        if obj.__module__ != module.__name__:
+            continue
+        if issubclass(obj, EnhancedStrategy) and obj is not EnhancedStrategy:
+            return obj()
+    raise RuntimeError(f"No EnhancedStrategy subclass found in {path}")
+
+
+def main() -> None:
+    coloredlogs.install(level="INFO", logger=logging.getLogger())
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, help="Path to island_evolve manifest.json.")
+    parser.add_argument("--population", type=int, default=40)
+    parser.add_argument("--generations", type=int, default=30)
+    parser.add_argument("--games-per-eval", type=int, default=30)
+    parser.add_argument("--mutation-rate", type=float, default=0.15)
+    parser.add_argument(
+        "--output-dir",
+        default="generated_strategies/island_merged",
+    )
+    args = parser.parse_args()
+
+    manifest = json.loads(Path(args.manifest).read_text())
+    panel_names = manifest["panel"]
+    board_path = manifest["board"]
+
+    loader = StrategyLoader()
+
+    panel = []
+    for name in panel_names:
+        s = loader.get_strategy(name)
+        if s is None:
+            raise ValueError(f"Panel strategy not found: {name!r}")
+        panel.append(s)
+    logger.info("Panel: %s", [s.name for s in panel])
+
+    champions: list[EnhancedStrategy] = []
+    for island in manifest["islands"]:
+        path = Path(island["output_path"])
+        champ = _load_strategy_from_path(path)
+        champions.append(champ)
+        logger.info("Loaded champion: %s (from %s)", champ.name, path.name)
+
+    board_config = load_board(board_path)
+    run_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_dir) / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    trainer = GeneticTrainer(
+        kingdom_cards=board_config.kingdom_cards,
+        population_size=args.population,
+        generations=args.generations,
+        mutation_rate=args.mutation_rate,
+        games_per_eval=args.games_per_eval,
+        board_config=board_config,
+        log_folder=f"island_logs/{run_id}/merged",
+    )
+    trainer.inject_strategies(champions)
+    trainer.set_baseline_panel(panel)
+
+    start = time.monotonic()
+    best, metrics = trainer.train()
+    elapsed = time.monotonic() - start
+
+    if best is None:
+        logger.error("Merged stage produced no champion")
+        return
+
+    output_path = output_dir / "merged_champion.py"
+    save_strategy_as_python(best, output_path, "LisbonMergedChampion")
+    logger.info(
+        "Merged champion fitness=%.2f win_rate=%.1f%% saved=%s (%.1fs)",
+        metrics.get("fitness", 0.0),
+        metrics.get("win_rate", 0.0),
+        output_path,
+        elapsed,
+    )
+
+    summary = {
+        "run_id": run_id,
+        "source_manifest": str(args.manifest),
+        "board": board_path,
+        "panel": panel_names,
+        "hyperparameters": {
+            "population": args.population,
+            "generations": args.generations,
+            "games_per_eval": args.games_per_eval,
+            "mutation_rate": args.mutation_rate,
+        },
+        "champion": {
+            "output_path": str(output_path),
+            "fitness": float(metrics.get("fitness", 0.0)),
+            "win_rate_vs_panel": float(metrics.get("win_rate", 0.0)),
+            "panel_breakdown": list(trainer.last_eval_breakdown),
+            "wall_seconds": elapsed,
+        },
+    }
+    (output_dir / "summary.json").write_text(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/island_merge.py
+++ b/scripts/island_merge.py
@@ -164,7 +164,10 @@ def main() -> None:
             "output_path": str(output_path),
             "fitness": float(metrics.get("fitness", 0.0)),
             "win_rate_vs_panel": float(metrics.get("win_rate", 0.0)),
-            "panel_breakdown": list(trainer.last_eval_breakdown),
+            # See island_evolve.py: ``best_eval_breakdown`` is the breakdown of
+            # the champion ``best``; ``last_eval_breakdown`` would instead be
+            # the last candidate scored in the final generation.
+            "panel_breakdown": list(trainer.best_eval_breakdown),
             "wall_seconds": elapsed,
         },
     }

--- a/scripts/island_merge.py
+++ b/scripts/island_merge.py
@@ -125,8 +125,10 @@ def main() -> None:
     elapsed = time.monotonic() - start
 
     if best is None:
-        logger.error("Merged stage produced no champion")
-        return
+        raise RuntimeError(
+            "Merged stage produced no champion (GeneticTrainer.train() returned None). "
+            "Re-run with verbose logging to find the underlying training failure."
+        )
 
     output_path = output_dir / "merged_champion.py"
     save_strategy_as_python(best, output_path, "LisbonMergedChampion")

--- a/scripts/island_merge.py
+++ b/scripts/island_merge.py
@@ -97,6 +97,12 @@ def main() -> None:
         champions.append(champ)
         logger.info("Loaded champion: %s (from %s)", champ.name, path.name)
 
+    if not champions:
+        raise ValueError(
+            "No champions found in manifest; cannot run merged stage. "
+            "Re-run island_evolve.py first."
+        )
+
     board_config = load_board(board_path)
     run_id = datetime.now().strftime("%Y%m%d_%H%M%S")
     output_dir = Path(args.output_dir) / run_id

--- a/scripts/island_tournament.py
+++ b/scripts/island_tournament.py
@@ -1,0 +1,327 @@
+"""Round-robin tournament between island champions.
+
+Reads an island-evolution manifest (or a user-supplied list of strategy
+names / champion file paths), then runs ``--games`` games for every pair
+of strategies with alternating first player. Output is a Markdown win-rate
+matrix and average-margin matrix written to stdout and optionally to a
+file.
+
+This is the deferred fair-comparison step: each island has had equal
+optimization budget against the shared panel, so head-to-head results
+between champions actually mean something.
+
+Usage
+-----
+    # From a manifest (typical):
+    python scripts/island_tournament.py --manifest generated_strategies/island_champions/<RUN_ID>/manifest.json --games 400
+
+    # Ad-hoc strategy list (names or *.py paths):
+    python scripts/island_tournament.py --strategies "Big Money" "Lisbon City Engine" generated_strategies/island_champions/.../lisbon_investment_rush_champion.py --games 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import inspect
+import json
+import logging
+import multiprocessing as mp
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import coloredlogs
+
+from dominion.ai.genetic_ai import GeneticAI
+from dominion.boards.loader import load_board
+from dominion.simulation.strategy_battle import StrategyBattle
+from dominion.strategy.enhanced_strategy import EnhancedStrategy
+from dominion.strategy.strategy_loader import StrategyLoader
+
+
+logger = logging.getLogger(__name__)
+
+
+def _load_strategy_from_path(path: Path) -> tuple[str, EnhancedStrategy]:
+    """Load a champion Python file produced by ``save_strategy_as_python``.
+
+    Returns ``(display_name, strategy_instance)``. The display name comes
+    from the strategy's ``name`` attribute, fall back to the file stem.
+    """
+    spec = importlib.util.spec_from_file_location(f"champion_{path.stem}", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    # Find the EnhancedStrategy subclass defined in the module.
+    for _, obj in inspect.getmembers(module, inspect.isclass):
+        if obj.__module__ != module.__name__:
+            continue
+        if issubclass(obj, EnhancedStrategy) and obj is not EnhancedStrategy:
+            instance = obj()
+            name = getattr(instance, "name", path.stem)
+            return name, instance
+
+    raise RuntimeError(f"No EnhancedStrategy subclass found in {path}")
+
+
+def _resolve_strategy(ref: str, loader: StrategyLoader) -> tuple[str, EnhancedStrategy]:
+    """Resolve a strategy reference: file path or registered name."""
+    p = Path(ref)
+    if p.suffix == ".py" and p.exists():
+        return _load_strategy_from_path(p)
+    s = loader.get_strategy(ref)
+    if s is None:
+        raise ValueError(f"Unknown strategy: {ref!r}")
+    return s.name, s
+
+
+def _matchup_unique_key(a: str, b: str) -> tuple[str, str]:
+    """Order-independent key for a matchup (so we don't run A-vs-B twice)."""
+    return (a, b) if a <= b else (b, a)
+
+
+@dataclass
+class Matchup:
+    a: str
+    b: str
+    games: int
+
+
+def _run_matchup(
+    a_ref: str,
+    b_ref: str,
+    games: int,
+    board_path: str,
+) -> dict:
+    """Play ``games`` games between strategies ``a_ref`` and ``b_ref`` on the
+    given board. Returns a result dict with wins, margins, and turn counts.
+
+    Lives at module level so it can be sent to a ProcessPoolExecutor."""
+    loader = StrategyLoader()
+    a_name, a_strategy = _resolve_strategy(a_ref, loader)
+    b_name, b_strategy = _resolve_strategy(b_ref, loader)
+
+    board_config = load_board(board_path)
+    battle = StrategyBattle(
+        kingdom_cards=board_config.kingdom_cards,
+        board_config=board_config,
+        log_frequency=0,
+    )
+
+    a_wins = 0
+    a_total_score = 0
+    b_total_score = 0
+    total_turns = 0
+
+    for i in range(games):
+        ai_a = GeneticAI(a_strategy)
+        ai_b = GeneticAI(b_strategy)
+        # Alternate first player to remove the seat advantage.
+        if i % 2 == 0:
+            winner, scores, _, turns = battle.run_game(
+                ai_a, ai_b, board_config.kingdom_cards
+            )
+        else:
+            winner, scores, _, turns = battle.run_game(
+                ai_b, ai_a, board_config.kingdom_cards
+            )
+        if winner == ai_a:
+            a_wins += 1
+        a_total_score += scores.get(ai_a.name, 0)
+        b_total_score += scores.get(ai_b.name, 0)
+        total_turns += turns
+
+    return {
+        "a_name": a_name,
+        "b_name": b_name,
+        "games": games,
+        "a_wins": a_wins,
+        "b_wins": games - a_wins,
+        "a_win_rate": a_wins / games * 100,
+        "avg_a_score": a_total_score / games,
+        "avg_b_score": b_total_score / games,
+        "avg_margin": (a_total_score - b_total_score) / games,
+        "avg_turns": total_turns / games,
+    }
+
+
+def _format_matrix(names: list[str], cell: dict[tuple[str, str], str]) -> str:
+    """Format a row=A, col=B matrix where each cell is filled by ``cell[(a, b)]``."""
+    header = "| | " + " | ".join(names) + " |"
+    sep = "|---|" + "|".join(["---"] * len(names)) + "|"
+    rows = [header, sep]
+    for a in names:
+        row = [a]
+        for b in names:
+            if a == b:
+                row.append("—")
+            else:
+                row.append(cell.get((a, b), "?"))
+        rows.append("| " + " | ".join(row) + " |")
+    return "\n".join(rows)
+
+
+def main() -> None:
+    coloredlogs.install(level="INFO", logger=logging.getLogger())
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", help="Path to an island_evolve manifest.json.")
+    parser.add_argument(
+        "--strategies",
+        nargs="+",
+        help="Explicit strategy refs (names or *.py paths). Used if --manifest is omitted.",
+    )
+    parser.add_argument(
+        "--include-seeds",
+        action="store_true",
+        help=(
+            "When using --manifest, also include the original seed names in the "
+            "tournament so champions can be compared against their starting points."
+        ),
+    )
+    parser.add_argument(
+        "--include-panel",
+        action="store_true",
+        help="When using --manifest, also include each panel member as a tournament entrant.",
+    )
+    parser.add_argument("--board", default="boards/lisbon.txt")
+    parser.add_argument("--games", type=int, default=400)
+    parser.add_argument(
+        "--parallel",
+        action="store_true",
+        help="Run matchups in parallel using multiprocessing.",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=0,
+        help="Cap parallel workers. 0 = number of matchups.",
+    )
+    parser.add_argument("--output", help="Write the Markdown report to this path.")
+    args = parser.parse_args()
+
+    refs: list[str] = []
+    if args.manifest:
+        manifest_path = Path(args.manifest)
+        manifest = json.loads(manifest_path.read_text())
+        # Use file paths so we load the actual evolved champions, not the
+        # original named seeds.
+        for island in manifest.get("islands", []):
+            refs.append(island["output_path"])
+        if args.include_seeds:
+            for island in manifest.get("islands", []):
+                refs.append(island["seed_name"])
+        if args.include_panel:
+            refs.extend(manifest.get("panel", []))
+    elif args.strategies:
+        refs = list(args.strategies)
+    else:
+        parser.error("Provide either --manifest or --strategies")
+
+    # Resolve once up-front so misspelled names fail immediately.
+    loader = StrategyLoader()
+    resolved: list[tuple[str, str]] = []  # (display_name, ref-for-subprocess)
+    for ref in refs:
+        name, _ = _resolve_strategy(ref, loader)
+        resolved.append((name, ref))
+
+    names = [n for n, _ in resolved]
+    if len(set(names)) != len(names):
+        logger.warning("Duplicate display names in tournament: %s", names)
+
+    # Build matchup list (one entry per unordered pair).
+    matchups: list[tuple[str, str, str, str]] = []  # (a_name, b_name, a_ref, b_ref)
+    for i, (a_name, a_ref) in enumerate(resolved):
+        for j, (b_name, b_ref) in enumerate(resolved):
+            if j <= i:
+                continue
+            matchups.append((a_name, b_name, a_ref, b_ref))
+
+    logger.info(
+        "Tournament: %d strategies, %d matchups, %d games each",
+        len(resolved),
+        len(matchups),
+        args.games,
+    )
+
+    raw_results: list[dict] = []
+    if args.parallel and len(matchups) > 1:
+        max_workers = args.max_workers or len(matchups)
+        ctx = mp.get_context("spawn")
+        with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as ex:
+            futures = {
+                ex.submit(_run_matchup, a_ref, b_ref, args.games, args.board): (a_name, b_name)
+                for a_name, b_name, a_ref, b_ref in matchups
+            }
+            for fut in as_completed(futures):
+                pair = futures[fut]
+                try:
+                    r = fut.result()
+                    raw_results.append(r)
+                    logger.info(
+                        "%s vs %s: %.1f%% (margin %+.1f)",
+                        r["a_name"], r["b_name"], r["a_win_rate"], r["avg_margin"],
+                    )
+                except Exception:
+                    logger.exception("Matchup %s failed", pair)
+    else:
+        for a_name, b_name, a_ref, b_ref in matchups:
+            r = _run_matchup(a_ref, b_ref, args.games, args.board)
+            raw_results.append(r)
+            logger.info(
+                "%s vs %s: %.1f%% (margin %+.1f)",
+                r["a_name"], r["b_name"], r["a_win_rate"], r["avg_margin"],
+            )
+
+    # Build cell maps. Each result for (a, b) gives us:
+    #   - a_win_rate for cell (a, b)
+    #   - (100 - a_win_rate) for cell (b, a)
+    win_cell: dict[tuple[str, str], str] = {}
+    margin_cell: dict[tuple[str, str], str] = {}
+    for r in raw_results:
+        a, b = r["a_name"], r["b_name"]
+        win_cell[(a, b)] = f"{r['a_win_rate']:.1f}%"
+        win_cell[(b, a)] = f"{100 - r['a_win_rate']:.1f}%"
+        margin_cell[(a, b)] = f"{r['avg_margin']:+.1f}"
+        margin_cell[(b, a)] = f"{-r['avg_margin']:+.1f}"
+
+    # Add an "average win rate" column. For each strategy, average its win
+    # rate across all opponents — the single number that ranks champions.
+    avg_win: dict[str, float] = {}
+    for name in names:
+        rates = []
+        for other in names:
+            if other == name:
+                continue
+            cell = win_cell.get((name, other))
+            if cell:
+                rates.append(float(cell.rstrip("%")))
+        avg_win[name] = sum(rates) / max(1, len(rates))
+
+    lines = []
+    lines.append(f"# Lisbon Island Tournament — {args.games} games / matchup\n")
+    lines.append(f"Board: `{args.board}`\n")
+    lines.append("## Win-rate matrix (row vs column)\n")
+    lines.append(_format_matrix(names, win_cell))
+    lines.append("\n## Average VP margin matrix (row minus column)\n")
+    lines.append(_format_matrix(names, margin_cell))
+    lines.append("\n## Average win rate (ranked)\n")
+    lines.append("| Strategy | Avg win % |")
+    lines.append("|---|---|")
+    for name, rate in sorted(avg_win.items(), key=lambda kv: -kv[1]):
+        lines.append(f"| {name} | {rate:.1f}% |")
+    report = "\n".join(lines) + "\n"
+
+    print(report)
+    if args.output:
+        Path(args.output).write_text(report)
+        logger.info("Wrote report to %s", args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/island_tournament.py
+++ b/scripts/island_tournament.py
@@ -190,7 +190,17 @@ def main() -> None:
         help="When using --manifest, also include each panel member as a tournament entrant.",
     )
     parser.add_argument("--board", default="boards/lisbon.txt")
-    parser.add_argument("--games", type=int, default=400)
+
+    def _positive_int(value: str) -> int:
+        ivalue = int(value)
+        if ivalue <= 0:
+            raise argparse.ArgumentTypeError(f"must be a positive integer, got {value}")
+        return ivalue
+
+    # Validated at parse time: ``_run_matchup`` divides by ``games`` to
+    # compute win rates and averages, so 0/negative would crash or produce
+    # nonsense.
+    parser.add_argument("--games", type=_positive_int, default=400)
     parser.add_argument(
         "--parallel",
         action="store_true",
@@ -232,7 +242,16 @@ def main() -> None:
 
     names = [n for n, _ in resolved]
     if len(set(names)) != len(names):
-        logger.warning("Duplicate display names in tournament: %s", names)
+        # The matrix cells are keyed on (a_name, b_name); duplicate names
+        # would silently overwrite cells and corrupt the report. Reject up
+        # front so the user can rename one of the duplicates rather than
+        # discovering it after the fact in a published table.
+        seen: set[str] = set()
+        dupes = sorted({n for n in names if n in seen or seen.add(n)})
+        parser.error(
+            f"Duplicate display names in tournament entrants: {dupes}. "
+            "Rename or deduplicate before running."
+        )
 
     # Build matchup list (one entry per unordered pair).
     matchups: list[tuple[str, str, str, str]] = []  # (a_name, b_name, a_ref, b_ref)
@@ -250,6 +269,11 @@ def main() -> None:
     )
 
     raw_results: list[dict] = []
+    # A failed matchup means the absent cells get rendered as "?" and the
+    # average-win-rate column is computed from fewer opponents than the
+    # rest, silently biasing the ranking. Track failures and refuse to
+    # publish a partial report.
+    failed_matchups: list[tuple[str, str]] = []
     if args.parallel and len(matchups) > 1:
         max_workers = args.max_workers or len(matchups)
         ctx = mp.get_context("spawn")
@@ -269,14 +293,26 @@ def main() -> None:
                     )
                 except Exception:
                     logger.exception("Matchup %s failed", pair)
+                    failed_matchups.append(pair)
     else:
         for a_name, b_name, a_ref, b_ref in matchups:
-            r = _run_matchup(a_ref, b_ref, args.games, args.board)
-            raw_results.append(r)
-            logger.info(
-                "%s vs %s: %.1f%% (margin %+.1f)",
-                r["a_name"], r["b_name"], r["a_win_rate"], r["avg_margin"],
-            )
+            try:
+                r = _run_matchup(a_ref, b_ref, args.games, args.board)
+                raw_results.append(r)
+                logger.info(
+                    "%s vs %s: %.1f%% (margin %+.1f)",
+                    r["a_name"], r["b_name"], r["a_win_rate"], r["avg_margin"],
+                )
+            except Exception:
+                logger.exception("Matchup (%s, %s) failed", a_name, b_name)
+                failed_matchups.append((a_name, b_name))
+
+    if failed_matchups:
+        logger.error(
+            "Tournament incomplete — %d/%d matchups failed: %s. Not publishing report.",
+            len(failed_matchups), len(matchups), failed_matchups,
+        )
+        sys.exit(1)
 
     # Build cell maps. Each result for (a, b) gives us:
     #   - a_win_rate for cell (a, b)


### PR DESCRIPTION
## Why

The current `LisbonCityEngine` (PR #243) was evolved against a panel that explicitly excluded Big Money — its docstring says "too easy to crush, doesn't drive learning." That removed the speed-test falsifier. A deck that builds slowly should struggle against Big Money; dropping BM stops the GA from finding that out, and the subsequent rounds layered panels of "things this engine already beats." Classic local-optimum trap.

This PR adds infrastructure to escape that trap via the island model: each archetype evolves in isolation with identical hyperparameters and the **same fixed panel** (including Big Money), then champions face off in a deferred round-robin tournament.

## What

**5 new seed archetypes** in `dominion/strategy/strategies/`:
- `lisbon_investment_rush.py` — Investment-detonation Colony rush with Watchtower topdecks
- `lisbon_wv_peddler_engine.py` — Workers' Village / Festival / Peddler draw engine + Expand upgrades
- `lisbon_watchtower_topdeck.py` — Watchtower reaction as the deck-shaping engine
- `lisbon_festival_bigmoney.py` — Big Money chassis with Festival + Collection (the speed-test seed)
- `lisbon_gardens_slog.py` — No-Province slog, Gardens + 3-pile finish

`Lisbon City Engine` from `generated_strategies/` is the 6th seed (control).

**3 runner scripts** in `scripts/`:
- `island_evolve.py` — one `GeneticTrainer` per seed, fixed panel `[Big Money, ClerkCollectionColony]`, parallel via multiprocessing, writes `manifest.json`
- `island_tournament.py` — round-robin matrix output, alternating first player, supports `--include-panel` and `--include-seeds`
- `island_merge.py` — optional final stage: seed all champions into one population, evolve hybrid against the same panel

**Doc**: `scripts/README_island_model.md` — full workflow with compute estimates.

**`.gitignore`**: excludes the new `island_logs/` and `generated_strategies/island_{champions,merged}/` output directories.

## Smoke test

`--smoke` (pop=12, gens=5, games=8) + 30-game tournament ran in ~50s wall time, all six islands in parallel. Pipeline produces a valid manifest, the tournament outputs win-rate and margin matrices, names are readable. Early signal worth noting: at smoke budget, `ClerkCollectionColony` (already-in-tree panel member, not a seed) tied the heavily-evolved `Lisbon City Engine Champion` 50/50 head-to-head — consistent with the local-optimum hypothesis. Real run will say more.

## Test plan

- [x] Smoke test passes (`--smoke --parallel`)
- [x] Tournament runs against the smoke manifest with `--include-panel`
- [x] All 5 new seeds load via `StrategyLoader`
- [ ] Real run (pop=30, gens=60, games-per-eval=30, ~1–2 hours wall time) — kicked off after review
- [ ] Full tournament with 400 games / matchup — kicked off after the real run

## Out of scope

- The real evolution run itself. The results will be a follow-up.
- MAP-Elites / quality-diversity. Discussed as a future upgrade if islands keep converging on similar shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five new Dominion strategies for the Lisbon board with distinct playstyles.
  * Added CLI tools to run island-model optimization: evolve, merge, and tournament workflows.
  * Trainer now snapshots and exposes the champion’s per-opponent evaluation breakdown after training.

* **Documentation**
  * Added a comprehensive island-model README with usage examples and CLI instructions.

* **Chores**
  * Updated .gitignore to exclude generated strategy and log directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/py-overlord/pull/291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->