### PR TITLE
Reset best_eval_breakdown at the top of train()

### DIFF
--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -853,6 +853,10 @@ class GeneticTrainer:
             # Track raw mean win rate of the best individual separately from
             # shaped fitness so metrics['win_rate'] stays a real win rate.
             best_win_rate = 0.0
+            # Reset the champion's panel breakdown so a second train() call on
+            # the same trainer that fails to establish a new best can't leak
+            # stale per-opponent data from the previous run.
+            self.best_eval_breakdown = []
 
             # Start training progress tracking
             self.logger.start_training(self.generations)

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -903,3 +903,29 @@ class TestMutationProducesCallableConditions:
                 assert rule.condition is None or callable(rule.condition), (
                     f"After mutation, condition for {rule.card_name} is {type(rule.condition)}"
                 )
+
+
+class TestTrainResetsBestEvalBreakdown:
+    """A second ``train()`` call on the same trainer must not leak the previous
+    run's champion panel breakdown. If the second run fails to establish a new
+    best (e.g. every candidate scores ``-inf``), ``best_eval_breakdown`` must
+    reflect the failed run (empty), not the prior successful one."""
+
+    def test_second_train_run_does_not_leak_prior_breakdown(self, monkeypatch):
+        trainer = GeneticTrainer(
+            ["Village"], population_size=2, generations=1, games_per_eval=2
+        )
+        # Simulate state left behind by a successful prior run.
+        trainer.best_eval_breakdown = [("PriorOpp", 75.0)]
+
+        # Every candidate this run scores -inf, so no new best is found and the
+        # snapshot at the "new best" branch in train() never fires.
+        monkeypatch.setattr(trainer, "evaluate_strategy", lambda s: float("-inf"))
+
+        best, _ = trainer.train()
+
+        assert best is None, "Sanity: no candidate should beat -inf seed"
+        assert trainer.best_eval_breakdown == [], (
+            "best_eval_breakdown should be reset at the top of train(); "
+            f"got stale value {trainer.best_eval_breakdown!r}"
+        )


### PR DESCRIPTION
## Summary

Follow-up to #291 addressing coderabbitai feedback that landed ~18s before merge ([discussion](https://github.com/jss367/py-overlord/pull/291#discussion_r3321259475)).

`GeneticTrainer.best_eval_breakdown` is instance state set in `__init__` and snapshotted inside `train()` whenever a new champion is found. The other "best" trackers (`best_strategy`, `best_fitness`, `best_win_rate`) are local variables re-initialized at the top of `train()`. If the same trainer is reused for a second `train()` call and that run fails to establish a new best (e.g. every candidate scores `-inf`), callers reading `best_eval_breakdown` got the prior run's panel data instead of an empty list.

Fix is one line at the top of `train()`, matching the existing pattern. Added a regression test that pre-populates `best_eval_breakdown`, runs `train()` with `evaluate_strategy` monkey-patched to return `-inf`, and asserts the attribute is empty afterwards (the test fails on the pre-fix code).

## Test plan

- [x] `PYTHONPATH=. python -m pytest -x -q` (1619 passed)
- [x] `PYTHONPATH=. python scripts/island_evolve.py --smoke --only "Lisbon Investment Rush"` (fitness=73.22, win_rate=87.5%)
- [x] Regression test fails without the fix and passes with it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Genetic trainer now properly resets evaluation breakdown metrics at the beginning of each training run, ensuring stale performance data from previous training attempts does not persist into subsequent sessions.

* **Tests**
  * Added test coverage to validate that evaluation breakdown data is correctly cleared when starting new training sessions on the same trainer instance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jss367/py-overlord/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->