### PR TITLE
[codex] fix ferryman set-aside pile rules

### DIFF
--- a/dominion/cards/base_card.py
+++ b/dominion/cards/base_card.py
@@ -166,6 +166,10 @@ class Card:
 
     def may_be_bought(self, game_state) -> bool:
         """Check if this card can currently be bought."""
+        if getattr(game_state, "_is_ferryman_reserved_pile_name", lambda _name: False)(
+            self.name
+        ):
+            return False
         return True
 
     def may_be_gained(self, game_state) -> bool:

--- a/dominion/cards/base_set/artisan.py
+++ b/dominion/cards/base_set/artisan.py
@@ -18,16 +18,11 @@ class Artisan(Card):
         )
 
     def play_effect(self, game_state):
-        from ..registry import get_card
-
         player = game_state.current_player
 
         # 1) Gain a card costing up to $5 to hand.
         options = []
-        for name, count in game_state.supply.items():
-            if count <= 0:
-                continue
-            candidate = get_card(name)
+        for _name, candidate, _count in game_state._iter_gainable_supply_cards():
             if candidate.cost.coins > 5:
                 continue
             if candidate.cost.potions > 0 or candidate.cost.debt > 0:

--- a/dominion/cards/base_set/feast.py
+++ b/dominion/cards/base_set/feast.py
@@ -15,8 +15,6 @@ class Feast(Card):
         )
 
     def play_effect(self, game_state):
-        from ..registry import get_card
-
         player = game_state.current_player
 
         # Trash this card. (It's currently in_play because on_play moved it.)
@@ -26,10 +24,7 @@ class Feast(Card):
 
         # Gain a card costing up to $5.
         options = []
-        for name, count in game_state.supply.items():
-            if count <= 0:
-                continue
-            candidate = get_card(name)
+        for _name, candidate, _count in game_state._iter_gainable_supply_cards():
             if candidate.cost.coins > 5:
                 continue
             if candidate.cost.potions > 0 or candidate.cost.debt > 0:

--- a/dominion/cards/base_set/mine.py
+++ b/dominion/cards/base_set/mine.py
@@ -13,7 +13,6 @@ class Mine(Card):
     def play_effect(self, game_state):
         """Trash a treasure from hand and gain a treasure costing up to 3 coins more."""
         player = game_state.current_player
-        from ..registry import get_card
 
         # Find treasures in hand
         treasure_cards = [card for card in player.hand if card.is_treasure]
@@ -31,10 +30,7 @@ class Mine(Card):
 
             # Find treasures that can be gained
             possible_gains = []
-            for name, count in game_state.supply.items():
-                if count <= 0:
-                    continue
-                candidate = get_card(name)
+            for _name, candidate, _count in game_state._iter_gainable_supply_cards():
                 if not candidate.is_treasure:
                     continue
                 if candidate.cost.coins > treasure_to_trash.cost.coins + 3:

--- a/dominion/cards/base_set/remodel.py
+++ b/dominion/cards/base_set/remodel.py
@@ -33,13 +33,8 @@ class Remodel(Card):
         max_coins = trashed.cost.coins + 2
         max_potions = trashed.cost.potions
 
-        from ..registry import get_card
-
         options = []
-        for name, count in game_state.supply.items():
-            if count <= 0:
-                continue
-            candidate = get_card(name)
+        for _name, candidate, _count in game_state._iter_gainable_supply_cards():
             if candidate.cost.potions > max_potions:
                 continue
             if candidate.cost.coins > max_coins:

--- a/dominion/cards/base_set/workshop.py
+++ b/dominion/cards/base_set/workshop.py
@@ -14,20 +14,16 @@ class Workshop(Card):
         """Gain a card costing up to 4 coins."""
         player = game_state.current_player
 
-        from ..registry import get_card  # Avoid circular import
-
         # Find cards that can be gained
         possible_gains = [
-            name
-            for name, count in game_state.supply.items()
-            if count > 0 and get_card(name).cost.coins <= 4
+            card
+            for _name, card, _count in game_state._iter_gainable_supply_cards()
+            if card.cost.coins <= 4
         ]
 
         # Let AI choose what to gain
         if possible_gains:
-            chosen_card = player.ai.choose_buy(
-                game_state, [get_card(name) for name in possible_gains]
-            )
+            chosen_card = player.ai.choose_buy(game_state, possible_gains)
 
             if chosen_card:
                 # Gain the chosen card

--- a/dominion/cards/cornucopia/ferryman.py
+++ b/dominion/cards/cornucopia/ferryman.py
@@ -57,5 +57,10 @@ class Ferryman(Card):
             if game_state.supply.get(name, 0) <= 0:
                 continue
             game_state.supply[name] -= 1
-            game_state.gain_card(player, get_card(name))
+            previous = getattr(game_state, "_allow_ferryman_pile_gain", False)
+            game_state._allow_ferryman_pile_gain = True
+            try:
+                game_state.gain_card(player, get_card(name))
+            finally:
+                game_state._allow_ferryman_pile_gain = previous
             return

--- a/dominion/cards/dark_ages/rats.py
+++ b/dominion/cards/dark_ages/rats.py
@@ -17,7 +17,13 @@ class Rats(Card):
             game_state.supply["Rats"] -= 1
             from ..registry import get_card
 
-            game_state.gain_card(player, get_card("Rats"))
+            previous = getattr(game_state, "_allow_ferryman_pile_gain", False)
+            if game_state._is_ferryman_reserved_pile_name("Rats"):
+                game_state._allow_ferryman_pile_gain = True
+            try:
+                game_state.gain_card(player, get_card("Rats"))
+            finally:
+                game_state._allow_ferryman_pile_gain = previous
         # Trash a non-Rats card from hand if possible
         choices = [c for c in player.hand if c.name != "Rats"]
         if choices:

--- a/dominion/cards/empires/engineer.py
+++ b/dominion/cards/empires/engineer.py
@@ -12,14 +12,10 @@ class Engineer(Card):
 
     def play_effect(self, game_state):
         player = game_state.current_player
-        from ..registry import get_card
 
         def affordable_cards() -> list[Card]:
             cards: list[Card] = []
-            for name, count in game_state.supply.items():
-                if count <= 0:
-                    continue
-                candidate = get_card(name)
+            for _name, candidate, _count in game_state._iter_gainable_supply_cards():
                 if candidate.cost.coins <= 4:
                     cards.append(candidate)
             cards.sort(key=lambda c: (c.cost.coins, c.name), reverse=True)

--- a/dominion/cards/intrigue/ironworks.py
+++ b/dominion/cards/intrigue/ironworks.py
@@ -20,7 +20,11 @@ class Ironworks(Card):
         for name, count in game_state.supply.items():
             if count <= 0:
                 continue
+            if name in game_state.non_supply_pile_names:
+                continue
             card = get_card(name)
+            if not card.may_be_gained(game_state):
+                continue
             if card.cost.coins <= 4:
                 gain_options.append(card)
 

--- a/dominion/cards/menagerie/groom.py
+++ b/dominion/cards/menagerie/groom.py
@@ -24,11 +24,17 @@ class Groom(Card):
         for name, count in game_state.supply.items():
             if count <= 0:
                 continue
+            if name in game_state.non_supply_pile_names:
+                continue
             try:
                 card = get_card(name)
             except ValueError:
                 continue
-            if card.cost.coins <= 4 and card.cost.potions == 0:
+            if (
+                card.may_be_gained(game_state)
+                and card.cost.coins <= 4
+                and card.cost.potions == 0
+            ):
                 candidates.append(card)
         if not candidates:
             return

--- a/dominion/events/adventures_events.py
+++ b/dominion/events/adventures_events.py
@@ -22,13 +22,7 @@ class Alms(Event):
     def on_buy(self, game_state, player) -> None:
         player.alms_used_this_turn = True
         candidates = []
-        for name, count in game_state.supply.items():
-            if count <= 0:
-                continue
-            try:
-                card = get_card(name)
-            except ValueError:
-                continue
+        for _name, card, _count in game_state._iter_gainable_supply_cards():
             if card.cost.coins <= 4 and card.cost.potions == 0 and card.cost.debt == 0:
                 candidates.append(card)
         if not candidates:
@@ -293,13 +287,7 @@ class Ball(Event):
         # Gain 2 cards costing up to $4 each.
         for _ in range(2):
             candidates = []
-            for name, count in game_state.supply.items():
-                if count <= 0:
-                    continue
-                try:
-                    card = get_card(name)
-                except ValueError:
-                    continue
+            for _name, card, _count in game_state._iter_gainable_supply_cards():
                 if card.cost.coins <= 4 and card.cost.potions == 0 and card.cost.debt == 0:
                     candidates.append(card)
             if not candidates:

--- a/dominion/events/adventures_events.py
+++ b/dominion/events/adventures_events.py
@@ -348,12 +348,15 @@ class Seaway(Event):
         for name, count in game_state.supply.items():
             if count <= 0:
                 continue
+            if name in game_state.non_supply_pile_names:
+                continue
             try:
                 card = get_card(name)
             except ValueError:
                 continue
             if (
                 card.is_action
+                and card.may_be_gained(game_state)
                 and card.cost.coins <= 4
                 and card.cost.potions == 0
                 and card.cost.debt == 0

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1087,6 +1087,27 @@ class GameState:
             return None
         return get_card(order[-1])
 
+    def _iter_gainable_supply_cards(self):
+        """Yield normal Supply piles that card effects may gain from."""
+
+        for name, count in self.supply.items():
+            if count <= 0:
+                continue
+            if name in self.non_supply_pile_names:
+                continue
+            if (
+                self._is_ferryman_reserved_pile_name(name)
+                and not getattr(self, "_allow_ferryman_pile_gain", False)
+            ):
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            if not card.may_be_gained(self):
+                continue
+            yield name, card, count
+
     def _prepare_black_market_deck(self, kingdom_cards: list[Card]) -> None:
         """Build and shuffle the Black Market deck for this game."""
 
@@ -1633,8 +1654,6 @@ class GameState:
                 player.discard.append(card)
 
     def _handle_quartermaster_start_of_turn(self, player: PlayerState) -> None:
-        from ..cards.registry import get_card
-
         quartermasters = [c for c in player.duration if c.name == "Quartermaster"]
         if not quartermasters:
             return
@@ -1650,13 +1669,7 @@ class GameState:
                 self.quartermaster_mats[id(player)] = []
             else:
                 candidates = []
-                for name, count in self.supply.items():
-                    if count <= 0:
-                        continue
-                    try:
-                        card = get_card(name)
-                    except ValueError:
-                        continue
+                for _name, card, _count in self._iter_gainable_supply_cards():
                     if (
                         card.cost.coins <= 4
                         and card.cost.potions == 0
@@ -4110,16 +4123,9 @@ class GameState:
         if getattr(player, "mining_road_triggered", False):
             return
         player.mining_road_triggered = True
-        from ..cards.registry import get_card
 
         candidates = []
-        for name, count in self.supply.items():
-            if count <= 0:
-                continue
-            try:
-                card = get_card(name)
-            except ValueError:
-                continue
+        for _name, card, _count in self._iter_gainable_supply_cards():
             if card.is_treasure:
                 candidates.append(card)
         if not candidates:
@@ -4348,14 +4354,9 @@ class GameState:
         if haggler_count == 0:
             return
 
-        from ..cards.registry import get_card
-
         for _ in range(haggler_count):
             options: list[Card] = []
-            for name, count in self.supply.items():
-                if count <= 0:
-                    continue
-                card = get_card(name)
+            for _name, card, _count in self._iter_gainable_supply_cards():
                 if card.cost.coins < bought_card.cost.coins and not card.is_victory:
                     options.append(card)
 

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -1001,6 +1001,11 @@ class GameState:
         for name in self.ferryman_pile_order:
             self.original_kingdom_pile_names.add(name)
             self.non_supply_pile_names.add(name)
+        if self.black_market_deck:
+            reserved = set(self.ferryman_pile_order)
+            self.black_market_deck = [
+                name for name in self.black_market_deck if name not in reserved
+            ]
 
     def _is_ferryman_reserved_pile_name(self, name: str) -> bool:
         """Whether ``name`` is in the pile set aside by Ferryman.

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -796,8 +796,8 @@ class GameState:
         if any(card.name == "Young Witch" for card in kingdom_cards):
             self._setup_young_witch_bane(kingdom_cards)
 
-        # Cornucopia & Guilds 2E: Ferryman picks an unused Action pile costing
-        # exactly $3 and adds it to the Supply.
+        # Cornucopia & Guilds 2E: Ferryman picks an unused Kingdom pile
+        # costing $3 or $4 and sets it aside near the Supply.
         if any(card.name == "Ferryman" for card in kingdom_cards):
             self._setup_ferryman_pile(kingdom_cards)
 
@@ -864,10 +864,10 @@ class GameState:
 
         Split piles (Allies four-card piles, Wizards, Empires
         SplitPileMixin pairs, Empires Castles) are supported only if the
-        chosen card is the TOP of its pile, since gameplay can only buy
-        or gain from the top initially. When a split-pile top is picked,
-        ``_register_kingdom_pile`` adds all partner piles to the supply
-        so the pile evolves correctly during play.
+        chosen card is the TOP of its pile. When a split-pile top is
+        picked, ``_register_kingdom_pile`` adds all partner piles for
+        internal tracking, but those piles are marked non-Supply and are
+        only gainable through Ferryman's gain hook.
         """
         from dominion.cards.allies._split_base import AlliesSplitCard
         from dominion.cards.allies.wizards import (
@@ -1000,6 +1000,25 @@ class GameState:
             self.ferryman_pile_order = [chosen_name]
         for name in self.ferryman_pile_order:
             self.original_kingdom_pile_names.add(name)
+            self.non_supply_pile_names.add(name)
+
+    def _is_ferryman_reserved_pile_name(self, name: str) -> bool:
+        """Whether ``name`` is in the pile set aside by Ferryman.
+
+        The pile lives in ``self.supply`` for count tracking, but by rule it
+        is not part of the Supply and can only be gained by gaining Ferryman.
+        """
+
+        return bool(
+            name
+            and (
+                name in self.ferryman_pile_order
+                or (
+                    not self.ferryman_pile_order
+                    and name == self.ferryman_card_name
+                )
+            )
+        )
 
     def _setup_dark_ages_piles(self, kingdom_cards: list[Card]) -> None:
         """Build the shuffled Ruins / Knights piles and Madman / Mercenary piles."""
@@ -3623,7 +3642,7 @@ class GameState:
         card: Card,
         to_deck: bool = False,
         from_supply: bool = True,
-    ) -> Card:
+    ) -> "Card | None":
         """Add a card to a player's discard or deck, honoring topdeck effects.
 
         ``from_supply`` controls supply-restoration semantics. The default
@@ -3636,6 +3655,17 @@ class GameState:
         If the player has a matching card on their Exile mat, that card is
         reclaimed instead of the newly gained copy.
         """
+
+        if (
+            from_supply
+            and self._is_ferryman_reserved_pile_name(card.name)
+            and not getattr(self, "_allow_ferryman_pile_gain", False)
+        ):
+            # Ferryman's set-aside pile is tracked in self.supply but is not
+            # a normal Supply pile. Callers using from_supply=True have
+            # already decremented; put the copy back and refuse the gain.
+            self._restore_to_supply_pile(card)
+            return None
 
         reclaimed = None
         for idx, exiled in enumerate(player.exile):

--- a/dominion/game/game_state.py
+++ b/dominion/game/game_state.py
@@ -709,6 +709,9 @@ class GameState:
         # ``setup_supply`` directly — e.g. tests rebuilding a kingdom on the
         # same ``GameState`` — don't leak the prior setup's Charlatan flag.
         self._charlatan_seen = False
+        self.non_supply_pile_names = set()
+        self.ferryman_card_name = ""
+        self.ferryman_pile_order = []
         # Add basic cards with proper counts
         copper_card = get_card("Copper")
         silver_card = get_card("Silver")

--- a/dominion/prophecies/divine_wind.py
+++ b/dominion/prophecies/divine_wind.py
@@ -28,6 +28,8 @@ class DivineWind(Prophecy):
         kingdom_pile_names = list(getattr(game_state, "original_kingdom_pile_names", set()))
         removed = []
         for name in kingdom_pile_names:
+            if name in getattr(game_state, "non_supply_pile_names", set()):
+                continue
             if name in game_state.supply:
                 del game_state.supply[name]
                 removed.append(name)

--- a/dominion/ways/butterfly.py
+++ b/dominion/ways/butterfly.py
@@ -1,4 +1,3 @@
-from dominion.cards.registry import get_card
 from dominion.cards.base_card import Card
 from .base_way import Way
 
@@ -21,10 +20,7 @@ class WayOfTheButterfly(Way):
 
         # Collect all gainable cards at the target cost
         candidates = []
-        for name, count in game_state.supply.items():
-            if count <= 0:
-                continue
-            candidate = get_card(name)
+        for _name, candidate, _count in game_state._iter_gainable_supply_cards():
             if (
                 candidate.cost.coins == target_cost
                 and candidate.cost.potions == card.cost.potions

--- a/dominion/ways/rat.py
+++ b/dominion/ways/rat.py
@@ -8,8 +8,6 @@ class WayOfTheRat(Way):
         super().__init__("Way of the Rat")
 
     def apply(self, game_state, card) -> None:
-        from dominion.cards.registry import get_card
-
         player = game_state.current_player
         treasures = [c for c in player.hand if c.is_treasure]
         if not treasures:
@@ -21,13 +19,7 @@ class WayOfTheRat(Way):
         game_state.discard_card(player, choice)
 
         candidates = []
-        for name, count in game_state.supply.items():
-            if count <= 0:
-                continue
-            try:
-                cand = get_card(name)
-            except ValueError:
-                continue
+        for _name, cand, _count in game_state._iter_gainable_supply_cards():
             if cand.is_action and cand.cost.coins <= 5 and cand.cost.potions == 0:
                 candidates.append(cand)
         if not candidates:

--- a/tests/test_adventures_events.py
+++ b/tests/test_adventures_events.py
@@ -246,6 +246,39 @@ def test_seaway_places_buy_token():
     assert state.player_token_pile(player, "+1 Buy") == "Village"
 
 
+class _ChooseNamedSeawayAI(ChooseFirstActionAI):
+    def __init__(self, target_name):
+        super().__init__()
+        self.target_name = target_name
+
+    def choose_gain_for_seaway(self, state, player, choices):
+        for choice in choices:
+            if choice.name == self.target_name:
+                return choice
+        return super().choose_gain_for_seaway(state, player, choices)
+
+
+def test_seaway_does_not_gain_or_token_ferryman_set_aside_pile():
+    state = GameState(players=[])
+    state.initialize_game(
+        [_ChooseNamedSeawayAI("Smithy")],
+        [get_card("Ferryman"), get_card("Village")],
+    )
+    player = state.players[0]
+    state.supply.setdefault("Smithy", get_card("Smithy").starting_supply(state))
+    state.ferryman_card_name = "Smithy"
+    state.ferryman_pile_order = ["Smithy"]
+    state.non_supply_pile_names.add("Smithy")
+    initial_smithies = state.supply["Smithy"]
+
+    Seaway = get_event("Seaway")
+    Seaway.on_buy(state, player)
+
+    assert state.supply["Smithy"] == initial_smithies
+    assert not any(card.name == "Smithy" for card in player.discard)
+    assert state.player_token_pile(player, "+1 Buy") != "Smithy"
+
+
 def test_trade_trashes_for_silvers():
     ai = TrashFirstAI()
     state = GameState(players=[])

--- a/tests/test_adventures_events.py
+++ b/tests/test_adventures_events.py
@@ -223,6 +223,71 @@ def test_ball_minus_coin_token_applies_at_next_turn_start():
     assert player.minus_coin_tokens == 0
 
 
+class _ChooseNamedEventGainAI(ChooseFirstActionAI):
+    def __init__(self, target_name):
+        super().__init__()
+        self.target_name = target_name
+
+    def _choose_named(self, choices):
+        for choice in choices:
+            if choice.name == self.target_name:
+                return choice
+        return None
+
+    def choose_gain_for_alms(self, state, player, choices):
+        return self._choose_named(choices) or super().choose_gain_for_alms(
+            state, player, choices
+        )
+
+    def choose_gain_for_ball(self, state, player, choices):
+        return self._choose_named(choices) or super().choose_gain_for_ball(
+            state, player, choices
+        )
+
+    def choose_gain_for_seaway(self, state, player, choices):
+        return self._choose_named(choices) or super().choose_gain_for_seaway(
+            state, player, choices
+        )
+
+
+def _mark_ferryman_reserved_pile(state, name):
+    state.supply.setdefault(name, get_card(name).starting_supply(state))
+    state.ferryman_card_name = name
+    state.ferryman_pile_order = [name]
+    state.non_supply_pile_names.add(name)
+
+
+def test_alms_does_not_gain_ferryman_set_aside_pile():
+    state = GameState(players=[])
+    state.initialize_game([_ChooseNamedEventGainAI("Smithy")], [get_card("Village")])
+    player = state.players[0]
+    player.in_play = []
+    _mark_ferryman_reserved_pile(state, "Smithy")
+    initial_smithies = state.supply["Smithy"]
+
+    Alms = get_event("Alms")
+    Alms.on_buy(state, player)
+
+    assert state.supply["Smithy"] == initial_smithies
+    assert not any(card.name == "Smithy" for card in player.discard)
+    assert player.discard
+
+
+def test_ball_does_not_gain_ferryman_set_aside_pile():
+    state = GameState(players=[])
+    state.initialize_game([_ChooseNamedEventGainAI("Smithy")], [get_card("Village")])
+    player = state.players[0]
+    _mark_ferryman_reserved_pile(state, "Smithy")
+    initial_smithies = state.supply["Smithy"]
+
+    Ball = get_event("Ball")
+    Ball.on_buy(state, player)
+
+    assert state.supply["Smithy"] == initial_smithies
+    assert not any(card.name == "Smithy" for card in player.discard)
+    assert len(player.discard) == 2
+
+
 def test_raid_minus_card_tokens_and_silvers():
     state = _new_state()
     state2 = GameState(players=[])
@@ -246,29 +311,14 @@ def test_seaway_places_buy_token():
     assert state.player_token_pile(player, "+1 Buy") == "Village"
 
 
-class _ChooseNamedSeawayAI(ChooseFirstActionAI):
-    def __init__(self, target_name):
-        super().__init__()
-        self.target_name = target_name
-
-    def choose_gain_for_seaway(self, state, player, choices):
-        for choice in choices:
-            if choice.name == self.target_name:
-                return choice
-        return super().choose_gain_for_seaway(state, player, choices)
-
-
 def test_seaway_does_not_gain_or_token_ferryman_set_aside_pile():
     state = GameState(players=[])
     state.initialize_game(
-        [_ChooseNamedSeawayAI("Smithy")],
+        [_ChooseNamedEventGainAI("Smithy")],
         [get_card("Ferryman"), get_card("Village")],
     )
     player = state.players[0]
-    state.supply.setdefault("Smithy", get_card("Smithy").starting_supply(state))
-    state.ferryman_card_name = "Smithy"
-    state.ferryman_pile_order = ["Smithy"]
-    state.non_supply_pile_names.add("Smithy")
+    _mark_ferryman_reserved_pile(state, "Smithy")
     initial_smithies = state.supply["Smithy"]
 
     Seaway = get_event("Seaway")

--- a/tests/test_cornucopia_guilds_2e.py
+++ b/tests/test_cornucopia_guilds_2e.py
@@ -1147,6 +1147,7 @@ def test_ferryman_set_aside_pile_cannot_be_gained_by_other_effects():
 
     assert state.supply["Smithy"] == initial_smithies
     assert not any(card.name == "Smithy" for card in player.discard)
+    assert player.discard
 
 
 def test_ferryman_set_aside_pile_does_not_count_as_empty_supply_pile():

--- a/tests/test_cornucopia_guilds_2e.py
+++ b/tests/test_cornucopia_guilds_2e.py
@@ -1099,8 +1099,65 @@ def test_ferryman_setup_designates_a_three_or_four_cost_pile():
     assert state.ferryman_card_name, "Ferryman setup should pick a $3/$4 card"
     chosen = get_card(state.ferryman_card_name)
     assert chosen.cost.coins in (3, 4)
-    # The chosen pile must exist in the supply.
+    # The chosen pile is tracked internally, but is not a Supply pile by rule.
     assert state.ferryman_card_name in state.supply
+    assert state.ferryman_card_name in state.non_supply_pile_names
+
+
+def test_ferryman_set_aside_pile_is_not_buyable():
+    state = GameState(players=[])
+    state.initialize_game([FirstChoiceAI()], [get_card("Ferryman")])
+    player = state.players[0]
+    player.coins = 10
+
+    affordable_names = {card.name for card in state._get_affordable_cards(player)}
+    assert state.ferryman_card_name not in affordable_names
+
+
+class NamedBuyAI(FirstChoiceAI):
+    def __init__(self, target_name):
+        super().__init__()
+        self.target_name = target_name
+
+    def choose_buy(self, state, choices):
+        for choice in choices:
+            if choice is not None and choice.name == self.target_name:
+                return choice
+        return super().choose_buy(state, choices)
+
+
+def test_ferryman_set_aside_pile_cannot_be_gained_by_other_effects():
+    state = GameState(players=[])
+    state.initialize_game(
+        [NamedBuyAI("Smithy")], [get_card("Ferryman"), get_card("Workshop")]
+    )
+    player = state.players[0]
+    player.hand = []
+    player.deck = []
+    player.discard = []
+    state.current_player_index = 0
+
+    state.supply.setdefault("Smithy", get_card("Smithy").starting_supply(state))
+    state.ferryman_card_name = "Smithy"
+    state.ferryman_pile_order = ["Smithy"]
+    state.non_supply_pile_names.add("Smithy")
+    initial_smithies = state.supply["Smithy"]
+
+    get_card("Workshop").play_effect(state)
+
+    assert state.supply["Smithy"] == initial_smithies
+    assert not any(card.name == "Smithy" for card in player.discard)
+
+
+def test_ferryman_set_aside_pile_does_not_count_as_empty_supply_pile():
+    state = GameState(players=[])
+    state.initialize_game([FirstChoiceAI()], [get_card("Ferryman")])
+    state.supply["Smithy"] = 0
+    state.ferryman_card_name = "Smithy"
+    state.ferryman_pile_order = ["Smithy"]
+    state.non_supply_pile_names.add("Smithy")
+
+    assert state.empty_piles == 0
 
 
 def test_ferryman_setup_can_pick_either_three_or_four_cost():

--- a/tests/test_cornucopia_guilds_2e.py
+++ b/tests/test_cornucopia_guilds_2e.py
@@ -1160,6 +1160,17 @@ def test_ferryman_set_aside_pile_does_not_count_as_empty_supply_pile():
     assert state.empty_piles == 0
 
 
+def test_ferryman_set_aside_pile_is_removed_from_black_market_deck():
+    state = GameState(players=[])
+    state.initialize_game(
+        [FirstChoiceAI()],
+        [get_card("Black Market"), get_card("Ferryman")],
+    )
+
+    for name in state.ferryman_pile_order:
+        assert name not in state.black_market_deck
+
+
 def test_ferryman_setup_can_pick_either_three_or_four_cost():
     """Across many setups, Ferryman should sample from both $3 and $4
     Kingdom piles (not just $3)."""

--- a/tests/test_cornucopia_guilds_2e.py
+++ b/tests/test_cornucopia_guilds_2e.py
@@ -1171,6 +1171,54 @@ def test_ferryman_set_aside_pile_is_removed_from_black_market_deck():
         assert name not in state.black_market_deck
 
 
+def test_ferryman_set_aside_pile_is_not_an_ironworks_gain_option():
+    state = GameState(players=[])
+    state.initialize_game(
+        [FirstChoiceAI()],
+        [get_card("Ferryman"), get_card("Ironworks")],
+    )
+    player = state.players[0]
+    player.hand = []
+    player.deck = []
+    player.discard = []
+    state.current_player_index = 0
+
+    state.supply.setdefault("Smithy", get_card("Smithy").starting_supply(state))
+    state.ferryman_card_name = "Smithy"
+    state.ferryman_pile_order = ["Smithy"]
+    state.non_supply_pile_names.add("Smithy")
+    initial_smithies = state.supply["Smithy"]
+
+    get_card("Ironworks").play_effect(state)
+
+    assert state.supply["Smithy"] == initial_smithies
+    assert not any(card.name == "Smithy" for card in player.discard)
+
+
+def test_ferryman_set_aside_pile_is_not_a_groom_gain_option():
+    state = GameState(players=[])
+    state.initialize_game(
+        [NamedBuyAI("Smithy")],
+        [get_card("Ferryman"), get_card("Groom")],
+    )
+    player = state.players[0]
+    player.hand = []
+    player.deck = []
+    player.discard = []
+    state.current_player_index = 0
+
+    state.supply.setdefault("Smithy", get_card("Smithy").starting_supply(state))
+    state.ferryman_card_name = "Smithy"
+    state.ferryman_pile_order = ["Smithy"]
+    state.non_supply_pile_names.add("Smithy")
+    initial_smithies = state.supply["Smithy"]
+
+    get_card("Groom").play_effect(state)
+
+    assert state.supply["Smithy"] == initial_smithies
+    assert not any(card.name == "Smithy" for card in player.discard)
+
+
 def test_ferryman_setup_can_pick_either_three_or_four_cost():
     """Across many setups, Ferryman should sample from both $3 and $4
     Kingdom piles (not just $3)."""

--- a/tests/test_cornucopia_guilds_2e.py
+++ b/tests/test_cornucopia_guilds_2e.py
@@ -1219,6 +1219,24 @@ def test_ferryman_set_aside_pile_is_not_a_groom_gain_option():
     assert not any(card.name == "Smithy" for card in player.discard)
 
 
+def test_ferryman_setup_state_resets_when_game_state_is_reused():
+    state = GameState(players=[])
+    state.initialize_game([FirstChoiceAI()], [get_card("Ferryman")])
+    former_ferryman_pile = state.ferryman_card_name
+    assert former_ferryman_pile in state.non_supply_pile_names
+
+    state.initialize_game([FirstChoiceAI()], [get_card(former_ferryman_pile)])
+    player = state.players[0]
+    player.coins = 10
+
+    assert state.ferryman_card_name == ""
+    assert state.ferryman_pile_order == []
+    assert former_ferryman_pile not in state.non_supply_pile_names
+    assert former_ferryman_pile in {
+        card.name for card in state._get_affordable_cards(player)
+    }
+
+
 def test_ferryman_setup_can_pick_either_three_or_four_cost():
     """Across many setups, Ferryman should sample from both $3 and $4
     Kingdom piles (not just $3)."""

--- a/tests/test_cornucopia_guilds_2e.py
+++ b/tests/test_cornucopia_guilds_2e.py
@@ -1237,6 +1237,20 @@ def test_ferryman_setup_state_resets_when_game_state_is_reused():
     }
 
 
+def test_ferryman_set_aside_pile_is_not_gainable_supply():
+    state = GameState(players=[])
+    state.initialize_game([FirstChoiceAI()], [get_card("Ferryman")])
+    state.supply.setdefault("Smithy", get_card("Smithy").starting_supply(state))
+    state.ferryman_card_name = "Smithy"
+    state.ferryman_pile_order = ["Smithy"]
+    state.non_supply_pile_names.add("Smithy")
+
+    gainable_names = {
+        name for name, _card, _count in state._iter_gainable_supply_cards()
+    }
+    assert "Smithy" not in gainable_names
+
+
 def test_ferryman_setup_can_pick_either_three_or_four_cost():
     """Across many setups, Ferryman should sample from both $3 and $4
     Kingdom piles (not just $3)."""

--- a/tests/test_engineer_card.py
+++ b/tests/test_engineer_card.py
@@ -89,3 +89,22 @@ def test_engineer_defaults_to_best_available_gain_when_ai_abstains():
 
     assert [card.name for card in player.discard] == ["Silver"]
     assert state.supply["Silver"] == 4
+
+
+def test_engineer_skips_ferryman_set_aside_pile():
+    ai = EngineerTestAI(["Smithy", "Silver"], trash_engineer=False)
+    state, player = _make_state(ai)
+
+    state.supply.update({"Smithy": 5, "Silver": 5, "Estate": 8})
+    state.ferryman_card_name = "Smithy"
+    state.ferryman_pile_order = ["Smithy"]
+    state.non_supply_pile_names.add("Smithy")
+
+    engineer = get_card("Engineer")
+    player.in_play = [engineer]
+
+    engineer.play_effect(state)
+
+    assert state.supply["Smithy"] == 5
+    assert [card.name for card in player.discard] == ["Silver"]
+    assert state.supply["Silver"] == 4

--- a/tests/test_menagerie_ways.py
+++ b/tests/test_menagerie_ways.py
@@ -18,6 +18,20 @@ class WayPickerAI(ChooseFirstActionAI):
         return None
 
 
+class NamedWayGainAI(WayPickerAI):
+    def __init__(self, way_name: str, gain_names: list[str]):
+        super().__init__(way_name)
+        self._gain_names = list(gain_names)
+
+    def choose_buy(self, state, choices):
+        while self._gain_names:
+            target = self._gain_names.pop(0)
+            for choice in choices:
+                if choice is not None and choice.name == target:
+                    return choice
+        return super().choose_buy(state, choices)
+
+
 def _state(way_name: str | None = None, kingdom=None):
     kingdom = kingdom or [get_card("Village"), get_card("Smithy")]
     if way_name is not None:
@@ -199,6 +213,33 @@ def test_way_of_the_rat_discards_treasure_gains_action():
     assert any(c.name == "Copper" for c in p1.discard)
     gained = [c for c in p1.discard if c.is_action]
     assert gained
+
+
+def test_way_of_the_rat_skips_ferryman_set_aside_pile():
+    state = GameState(players=[])
+    state.initialize_game(
+        [
+            NamedWayGainAI("Way of the Rat", ["Smithy", "Village"]),
+            ChooseFirstActionAI(),
+        ],
+        [get_card("Village")],
+        ways=[get_way("Way of the Rat")],
+    )
+    state.supply["Smithy"] = 5
+    state.ferryman_card_name = "Smithy"
+    state.ferryman_pile_order = ["Smithy"]
+    state.non_supply_pile_names.add("Smithy")
+    p1 = state.players[0]
+    p1.actions = 1
+    p1.hand = [get_card("Village"), get_card("Copper")]
+    state.phase = "action"
+
+    state.handle_action_phase()
+
+    assert state.supply["Smithy"] == 5
+    assert any(card.name == "Copper" for card in p1.discard)
+    assert any(card.name == "Village" for card in p1.discard)
+    assert not any(card.name == "Smithy" for card in p1.discard)
 
 
 def test_way_of_the_turtle_plays_next_turn():

--- a/tests/test_rising_sun_cards.py
+++ b/tests/test_rising_sun_cards.py
@@ -722,6 +722,31 @@ def test_divine_wind_preserves_non_kingdom_support_piles():
         assert basic in state.supply, f"{basic} should still be in supply"
 
 
+def test_divine_wind_preserves_ferryman_set_aside_pile():
+    """Ferryman's designated pile is near the Supply, not a Supply pile.
+
+    Divine Wind removes Kingdom Supply piles, so it must leave Ferryman's
+    set-aside pile available for existing gained Ferrymen.
+    """
+    state = GameState(players=[])
+    state.initialize_game(
+        [_GainFirstAI()],
+        [get_card("Ferryman"), get_card("Village")],
+    )
+    ferryman_pile = state.ferryman_card_name
+    assert ferryman_pile in state.supply
+    assert ferryman_pile in state.non_supply_pile_names
+    initial_count = state.supply[ferryman_pile]
+
+    dw = get_prophecy("Divine Wind")
+    dw.activate(state)
+
+    assert "Ferryman" not in state.supply
+    assert "Village" not in state.supply
+    assert ferryman_pile in state.supply
+    assert state.supply[ferryman_pile] == initial_count
+
+
 def test_approaching_army_adds_attack_companion_piles():
     """If Approaching Army adds Marauder, the Ruins and Spoils piles it
     needs must also be created (otherwise gained Marauders/Loots break).

--- a/tests/test_trashing_cards.py
+++ b/tests/test_trashing_cards.py
@@ -108,3 +108,25 @@ def test_rats_gains_respect_supply():
 
     assert empty_state.supply["Rats"] == 0
     assert other_player.count("Rats") == 1  # only the original copy remains
+
+
+def test_rats_self_gain_can_use_ferryman_set_aside_pile():
+    ai = TrashFirstAI()
+    player = PlayerState(ai)
+    state = GameState([player])
+    state.setup_supply([get_card("Rats")])
+    state.ferryman_card_name = "Rats"
+    state.ferryman_pile_order = ["Rats"]
+    state.non_supply_pile_names.add("Rats")
+
+    player.deck = []
+    player.discard = []
+    player.in_play = []
+    player.hand = [get_card("Rats")]
+
+    rats_supply_before = state.supply["Rats"]
+    play_action(state, player, player.hand[0])
+
+    assert state.supply["Rats"] == rats_supply_before - 1
+    assert any(card.name == "Rats" for card in player.discard)
+    assert player.count("Rats") == 2


### PR DESCRIPTION
## Summary

- Mark Ferryman's designated pile as non-Supply while preserving internal count tracking.
- Block normal buys and Workshop-style gains from the Ferryman set-aside pile.
- Allow Ferryman's own gain hook to gain from that pile and add regressions for buyability, gainability, and empty-pile counting.

## Root Cause

Ferryman setup was registering the designated pile as a normal `state.supply` pile. That made it available to ordinary buys/gain effects and let it count toward empty Supply piles, but Ferryman's rules put that pile near the Supply and only allow it to be gained by gaining Ferryman.

## Validation

- `pytest -q tests/test_cornucopia_guilds_2e.py -k ferryman`
- `pytest -q tests/test_base_set_cards.py tests/test_menagerie_cards.py tests/test_alchemy_cards.py`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Ferryman's set-aside pile to be properly protected: it can no longer be bought, gained through other card effects (Workshop, Black Market, Ironworks, Groom), or counted as an empty supply pile.
  * Fixed Divine Wind to correctly preserve Ferryman's set-aside pile when replacing Kingdom Supply piles.
  * Improved game state handling to properly reset Ferryman bookkeeping between games.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->