### PR TITLE
Make GA fitness evaluation trustworthy: racing, common random numbers, hall of fame

### DIFF
--- a/dominion/runner.py
+++ b/dominion/runner.py
@@ -123,7 +123,10 @@ def main():
     parser.add_argument("--generations", type=int, default=40, help="Number of generations to run (default: 40)")
     parser.add_argument("--mutation-rate", type=float, default=0.1, help="Mutation rate (default: 0.1)")
     parser.add_argument(
-        "--games-per-eval", type=int, default=10, help="Number of games to play per strategy evaluation (default: 10)"
+        "--games-per-eval",
+        type=int,
+        default=None,
+        help="Number of games to play per strategy evaluation (default: config value, else 30)",
     )
     parser.add_argument("--board", help="Board definition file containing kingdom cards and landscapes")
     parser.add_argument(

--- a/dominion/runner.py
+++ b/dominion/runner.py
@@ -221,7 +221,9 @@ def main():
     population_size = args.population_size or training_params.get('population_size', 5)
     generations = args.generations or training_params.get('generations', 10)
     mutation_rate = args.mutation_rate or training_params.get('mutation_rate', 0.1)
-    games_per_eval = args.games_per_eval or training_params.get('games_per_eval', 10)
+    # 10-game screens were pure noise (win-rate sd ~15pp); 30 is the floor at
+    # which racing's refine/confirm stages can rescue the comparisons.
+    games_per_eval = args.games_per_eval or training_params.get('games_per_eval', 30)
 
     # Create trainer with parameters
     trainer = GeneticTrainer(

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -15,6 +15,17 @@ log = logging.getLogger(__name__)
 coloredlogs.install(level="INFO", logger=log)
 
 
+# Seed-context phase tags. Each evaluation phase draws its game seeds from a
+# distinct block so screening, refinement, and confirmation never reuse the
+# same shuffles (which would let a candidate overfit one set of deck orders),
+# while every candidate evaluated *within* a phase shares the same seeds
+# (common random numbers — deck luck cancels out of comparisons).
+_SEED_PHASE_SCREEN = 0
+_SEED_PHASE_REFINE = 1
+_SEED_PHASE_CONFIRM = 2
+_SEED_PHASE_REBASE = 3
+
+
 def _distribute_games(total_budget: int, n_opponents: int) -> list[int]:
     """Distribute ``total_budget`` games across ``n_opponents``, preserving the
     budget exactly when feasible. Each opponent gets ``base`` games and the
@@ -50,6 +61,15 @@ class GeneticTrainer:
         prune_warmup_generations: int = 3,
         prune_min_rules: int = 3,
         default_baseline_panel: bool = False,
+        racing: bool = True,
+        refine_games: Optional[int] = None,
+        confirm_games: Optional[int] = None,
+        race_top_fraction: float = 0.2,
+        confirm_slack: float = 5.0,
+        common_random_numbers: bool = True,
+        eval_seed: Optional[int] = None,
+        hall_of_fame_size: int = 3,
+        hall_of_fame_interval: int = 10,
     ):
         if kingdom_cards is None:
             if board_config is None:
@@ -71,6 +91,36 @@ class GeneticTrainer:
         self.prune_warmup_generations = prune_warmup_generations
         self.prune_min_rules = prune_min_rules
         self.default_baseline_panel = default_baseline_panel
+
+        # --- Evaluation-integrity knobs (racing + variance reduction) ---
+        # ``games_per_eval`` is the cheap *screening* budget every individual
+        # gets. With ``racing`` on, the top ``race_top_fraction`` of each
+        # generation is re-evaluated with ``refine_games`` extra games, and a
+        # would-be champion only replaces the incumbent after both are scored
+        # on the same ``confirm_games`` seeded games. This prevents the
+        # winner's-curse failure mode where the returned champion is whichever
+        # mediocre candidate got the luckiest single evaluation.
+        self.racing = racing
+        self.refine_games = refine_games if refine_games is not None else 2 * games_per_eval
+        self.confirm_games = confirm_games if confirm_games is not None else 4 * games_per_eval
+        self.race_top_fraction = race_top_fraction
+        self.confirm_slack = confirm_slack
+        # Common random numbers: every candidate in the same evaluation phase
+        # plays the same seeded shuffles, so candidate-vs-candidate comparisons
+        # cancel deck luck instead of compounding it.
+        self.common_random_numbers = common_random_numbers
+        self._eval_seed_base = eval_seed if eval_seed is not None else random.randrange(2**31)
+        # When not None, evaluate_strategy seeds each game from this
+        # (phase, generation) context. None = legacy unseeded behavior.
+        self._eval_seed_context: Optional[tuple] = None
+
+        # Hall of fame: past champions appended to the opponent panel so the
+        # fitness gradient doesn't saturate once the population beats the
+        # static baselines. Size 0 disables.
+        self.hall_of_fame_size = hall_of_fame_size
+        self.hall_of_fame_interval = hall_of_fame_interval
+        self.hall_of_fame: list[BaseStrategy] = []
+
         self.battle_system = StrategyBattle(kingdom_cards, log_folder, board_config=board_config)
         if not self.kingdom_cards:
             raise ValueError("kingdom_cards cannot be empty")
@@ -86,6 +136,12 @@ class GeneticTrainer:
         # (not a dict) so multiple panel members sharing a name (e.g. two
         # BigMoneySmithy variants) each contribute independently.
         self.last_eval_breakdown: list[tuple] = []
+        # Champion bookkeeping. ``_best_confirmed`` is the champion's fitness
+        # from its most recent confirmation eval (racing mode) or its single
+        # screening eval (legacy mode).
+        self._best_strategy: Optional[BaseStrategy] = None
+        self._best_confirmed: float = float("-inf")
+        self._best_win_rate: float = 0.0
         # Breakdown captured at the moment the best individual was found.
         # ``last_eval_breakdown`` is overwritten by every evaluation, so by the
         # time ``train()`` returns it reflects whichever candidate was scored
@@ -427,9 +483,18 @@ class GeneticTrainer:
         mean per-opponent win rate (0-100). With ``shape_rewards=True``
         (the default), returns ``0.8 * win_rate + 0.2 * margin_score`` per
         opponent and averages those — see :meth:`_shape_fitness`.
+
+        When ``_eval_seed_context`` is set (train() sets it per evaluation
+        phase), each seat-swapped pair of games is seeded from the context so
+        all candidates evaluated in that phase play identical shuffles
+        (common random numbers). The global RNG state is restored afterward so
+        seeding can't make the GA's own mutation stream deterministic.
         """
+        seeding = self._eval_seed_context is not None
+        rng_snapshot = random.getstate() if seeding else None
         try:
-            panel = self._resolve_panel()
+            panel = list(self._resolve_panel())
+            panel.extend(self.hall_of_fame)
             from dominion.ai.genetic_ai import GeneticAI
             from dominion.strategy.rule_pruning import reset_fire_flags
 
@@ -460,6 +525,8 @@ class GeneticTrainer:
                 wins = 0
                 margin_total = 0.0
                 for game_num in range(games_per_opp):
+                    if seeding:
+                        random.seed(self._game_seed(i, game_num))
                     ai1 = GeneticAI(strategy)
                     ai2 = GeneticAI(opponent)
                     if game_num % 2 == 0:
@@ -504,6 +571,155 @@ class GeneticTrainer:
             # shaped fitness in best-strategy tracking.
             self.last_eval_breakdown = []
             return float("-inf")
+        finally:
+            if rng_snapshot is not None:
+                random.setstate(rng_snapshot)
+
+    def _game_seed(self, opponent_index: int, game_num: int) -> int:
+        """Derive the RNG seed for one game of a seeded evaluation.
+
+        Consecutive seat-swapped games (game_num 2k and 2k+1) share a seed so
+        each shuffle sequence is played from both seats. The seed depends only
+        on (base, phase context, opponent, pair index) — never on the candidate
+        — which is what makes the random numbers *common* across candidates.
+        The context contains only ints, so the hash (and therefore the seeds)
+        is reproducible across processes for a fixed ``eval_seed``.
+        """
+        pair_index = game_num // 2
+        return hash((self._eval_seed_base, self._eval_seed_context, opponent_index, pair_index)) & 0x7FFFFFFF
+
+    def _eval_with_budget(self, strategy: BaseStrategy, games: int, context: Optional[tuple]) -> float:
+        """Run evaluate_strategy with a temporary games budget and seed context."""
+        saved_games = self.games_per_eval
+        saved_context = self._eval_seed_context
+        self.games_per_eval = games
+        self._eval_seed_context = context if self.common_random_numbers else None
+        try:
+            return self.evaluate_strategy(strategy)
+        finally:
+            self.games_per_eval = saved_games
+            self._eval_seed_context = saved_context
+
+    @staticmethod
+    def _genome_signature(strategy: BaseStrategy) -> tuple:
+        """Structural fingerprint of a genome: every rule's card and condition
+        source, in order. Used to skip re-confirming the elite when it is the
+        generation's best again (it usually is), saving the confirmation
+        budget for genuinely new challengers."""
+
+        def rule_sig(rules) -> tuple:
+            return tuple(
+                (r.card_name, getattr(getattr(r, "condition", None), "_source", None))
+                for r in rules
+            )
+
+        way_sig = tuple(
+            (r.card_name, r.way_name, getattr(getattr(r, "condition", None), "_source", None))
+            for r in getattr(strategy, "way_policy", []) or []
+        )
+        return (
+            rule_sig(strategy.gain_priority),
+            rule_sig(strategy.action_priority),
+            rule_sig(strategy.treasure_priority),
+            rule_sig(strategy.trash_priority),
+            way_sig,
+        )
+
+    def _record_champion_result(self, fitness: float, breakdown: list[tuple]) -> None:
+        """Update the champion's confirmed fitness, breakdown, and win rate."""
+        self._best_confirmed = fitness
+        self.best_eval_breakdown = list(breakdown)
+        if breakdown:
+            self._best_win_rate = sum(entry[1] for entry in breakdown) / len(breakdown)
+
+    def _set_champion(self, strategy: BaseStrategy, fitness: float, breakdown: list[tuple]) -> None:
+        self._best_strategy = deepcopy(strategy)
+        self._record_champion_result(fitness, breakdown)
+
+    def _consider_challenger(self, challenger: BaseStrategy, screen_fitness: float, gen: int) -> None:
+        """Decide whether ``challenger`` (this generation's best) should
+        replace the incumbent champion.
+
+        The incumbent and challenger are both evaluated on the same
+        ``confirm_games`` seeded games, so the comparison is paired: deck luck
+        cancels and the better strategy wins the head-to-head. Re-evaluating
+        the incumbent every time also keeps its confirmed fitness current as
+        the hall-of-fame panel evolves. A champion is never crowned from a
+        single screening eval — that is the winner's-curse path this method
+        exists to close."""
+        if self._best_strategy is not None and self._genome_signature(challenger) == self._genome_signature(
+            self._best_strategy
+        ):
+            return
+
+        context = (_SEED_PHASE_CONFIRM, gen)
+
+        if self._best_strategy is None:
+            confirmed = self._eval_with_budget(challenger, self.confirm_games, context)
+            if confirmed == float("-inf"):
+                return
+            self._set_champion(challenger, confirmed, self.last_eval_breakdown)
+            log.info(
+                "Champion confirmed at %.2f (screen estimate was %.2f)",
+                confirmed,
+                screen_fitness,
+            )
+            return
+
+        # Don't spend the confirmation budget on challengers whose screening
+        # estimate isn't even close to the incumbent.
+        if screen_fitness < self._best_confirmed - self.confirm_slack:
+            return
+
+        incumbent_fitness = self._eval_with_budget(self._best_strategy, self.confirm_games, context)
+        incumbent_breakdown = list(self.last_eval_breakdown)
+        challenger_fitness = self._eval_with_budget(challenger, self.confirm_games, context)
+        challenger_breakdown = list(self.last_eval_breakdown)
+
+        if challenger_fitness > incumbent_fitness:
+            self._set_champion(challenger, challenger_fitness, challenger_breakdown)
+            log.info(
+                "Champion replaced: challenger %.2f beat incumbent %.2f (confirmation, %d games)",
+                challenger_fitness,
+                incumbent_fitness,
+                self.confirm_games,
+            )
+        else:
+            if incumbent_fitness != float("-inf"):
+                self._record_champion_result(incumbent_fitness, incumbent_breakdown)
+            log.info(
+                "Champion retained: incumbent %.2f vs challenger %.2f (confirmation, %d games)",
+                incumbent_fitness,
+                challenger_fitness,
+                self.confirm_games,
+            )
+
+    def _update_hall_of_fame(self, gen: int) -> None:
+        """Add the current champion to the opponent hall of fame (if novel)
+        and rebase the champion's confirmed fitness on the new, harder panel."""
+        champion = self._best_strategy
+        if champion is None:
+            return
+        sig = self._genome_signature(champion)
+        if any(self._genome_signature(member) == sig for member in self.hall_of_fame):
+            return
+
+        member = deepcopy(champion)
+        member.name = f"HallOfFame-g{gen + 1}"
+        self.hall_of_fame.append(member)
+        if len(self.hall_of_fame) > self.hall_of_fame_size:
+            self.hall_of_fame = self.hall_of_fame[-self.hall_of_fame_size :]
+        log.info(
+            "Hall of fame updated (%d member%s) — champion joins the opponent panel",
+            len(self.hall_of_fame),
+            "s" if len(self.hall_of_fame) != 1 else "",
+        )
+
+        # The panel just changed, so the incumbent's confirmed fitness is on
+        # the old scale; re-measure it so future challenger gating is fair.
+        rebased = self._eval_with_budget(champion, self.confirm_games, (_SEED_PHASE_REBASE, gen))
+        if rebased != float("-inf"):
+            self._record_champion_result(rebased, self.last_eval_breakdown)
 
     def _crossover(self, parent1: BaseStrategy, parent2: BaseStrategy) -> BaseStrategy:
         """Create a new strategy by combining two parent strategies"""
@@ -845,18 +1061,15 @@ class GeneticTrainer:
                     population[slot] = strategy
                 self._strategies_to_inject = []
 
-            best_strategy = None
-            # Shaped fitness can be negative, so seed below any possible value
-            # — otherwise a panel where every candidate scores <= 0 would leave
-            # best_strategy = None and train() would return (None, metrics).
-            best_fitness = float("-inf")
-            # Track raw mean win rate of the best individual separately from
-            # shaped fitness so metrics['win_rate'] stays a real win rate.
-            best_win_rate = 0.0
-            # Reset the champion's panel breakdown so a second train() call on
-            # the same trainer that fails to establish a new best can't leak
-            # stale per-opponent data from the previous run.
+            # Reset champion bookkeeping so a second train() call on the same
+            # trainer can't leak state (strategy, fitness, breakdown, hall of
+            # fame) from the previous run. Shaped fitness can be negative, so
+            # seed the confirmed fitness below any possible value.
+            self._best_strategy = None
+            self._best_confirmed = float("-inf")
+            self._best_win_rate = 0.0
             self.best_eval_breakdown = []
+            self.hall_of_fame = []
 
             # Start training progress tracking
             self.logger.start_training(self.generations)
@@ -873,40 +1086,90 @@ class GeneticTrainer:
                     )
                     population = [simplify_strategy(s) for s in population]
 
-                # Evaluate population
+                # --- Screen: every individual gets the cheap budget. With
+                # common random numbers, the whole generation plays the same
+                # seeded shuffles so comparisons cancel deck luck.
+                if self.common_random_numbers:
+                    self._eval_seed_context = (_SEED_PHASE_SCREEN, gen)
                 fitness_scores = []
-                for i, strategy in enumerate(population):
-                    fitness = self.evaluate_strategy(strategy)
-                    fitness_scores.append(fitness)
+                try:
+                    for strategy in population:
+                        fitness = self.evaluate_strategy(strategy)
+                        fitness_scores.append(fitness)
 
-                    if fitness > best_fitness:
-                        best_fitness = fitness
-                        best_strategy = deepcopy(strategy)
-                        # Snapshot the breakdown now -- ``last_eval_breakdown``
-                        # will be overwritten by the next candidate, so without
-                        # this copy callers reading it after train() returns
-                        # would see the last-evaluated candidate's breakdown,
-                        # not the champion's.
-                        self.best_eval_breakdown = list(self.last_eval_breakdown)
-                        if self.last_eval_breakdown:
-                            # Entry[1] is always the per-opponent win rate,
-                            # whether the breakdown is 2-tuple or 4-tuple.
-                            best_win_rate = sum(
-                                entry[1] for entry in self.last_eval_breakdown
-                            ) / len(self.last_eval_breakdown)
-                        log.info("New best fitness: %.2f", best_fitness)
-                        if len(self.last_eval_breakdown) > 1:
-                            parts = ", ".join(
-                                f"{entry[0]}: {entry[1]:.1f}%"
-                                for entry in self.last_eval_breakdown
-                            )
-                            log.info("  panel breakdown — %s", parts)
+                        if not self.racing and fitness > self._best_confirmed:
+                            # Legacy mode: champion = best single eval ever
+                            # seen. Kept behind racing=False for comparison;
+                            # subject to the winner's curse on noisy evals.
+                            self._set_champion(strategy, fitness, self.last_eval_breakdown)
+                            log.info("New best fitness: %.2f", fitness)
+                            if len(self.last_eval_breakdown) > 1:
+                                parts = ", ".join(
+                                    f"{entry[0]}: {entry[1]:.1f}%"
+                                    for entry in self.last_eval_breakdown
+                                )
+                                log.info("  panel breakdown — %s", parts)
+                finally:
+                    self._eval_seed_context = None
+
+                # --- Refine: re-evaluate the top slice with a bigger budget so
+                # elitism and the challenger pick aren't decided by screening
+                # noise. The refined estimate pools screen + refine games.
+                refined_indices: list[int] = []
+                if self.racing and self.refine_games > 0 and len(population) > 1:
+                    top_k = max(1, int(round(len(population) * self.race_top_fraction)))
+                    ranked = sorted(
+                        range(len(population)),
+                        key=lambda idx: fitness_scores[idx],
+                        reverse=True,
+                    )
+                    for idx in ranked[:top_k]:
+                        if fitness_scores[idx] == float("-inf"):
+                            continue
+                        extra = self._eval_with_budget(
+                            population[idx], self.refine_games, (_SEED_PHASE_REFINE, gen)
+                        )
+                        if extra == float("-inf"):
+                            fitness_scores[idx] = extra
+                            continue
+                        total_games = self.games_per_eval + self.refine_games
+                        fitness_scores[idx] = (
+                            fitness_scores[idx] * self.games_per_eval + extra * self.refine_games
+                        ) / total_games
+                        refined_indices.append(idx)
+
+                # --- Confirm: the generation's best challenges the incumbent
+                # champion on a shared block of confirmation games. When a
+                # refine pass ran, the challenger is picked among the refined
+                # candidates only — a refined (more accurate, lower) estimate
+                # must not be compared against unrefined screens, whose max is
+                # inflated by noise.
+                if self.racing and fitness_scores:
+                    challenger_pool = refined_indices or range(len(population))
+                    gen_best_idx = max(
+                        challenger_pool, key=lambda idx: fitness_scores[idx]
+                    )
+                    if fitness_scores[gen_best_idx] != float("-inf"):
+                        self._consider_challenger(
+                            population[gen_best_idx], fitness_scores[gen_best_idx], gen
+                        )
+
+                # --- Hall of fame: periodically promote the champion into the
+                # opponent panel so the fitness gradient doesn't saturate once
+                # the population beats the static baselines.
+                if (
+                    self.hall_of_fame_size > 0
+                    and self._best_strategy is not None
+                    and (gen + 1) % self.hall_of_fame_interval == 0
+                    and gen + 1 < self.generations
+                ):
+                    self._update_hall_of_fame(gen)
 
                 # Calculate generation statistics
                 avg_fitness = sum(fitness_scores) / len(fitness_scores)
 
                 # Update progress
-                self.logger.update_training(gen, best_fitness, avg_fitness)
+                self.logger.update_training(gen, self._best_confirmed, avg_fitness)
 
                 # Diversity pressure: shared fitness for selection, random immigrants
                 shared_fitness = self._apply_fitness_sharing(
@@ -930,16 +1193,16 @@ class GeneticTrainer:
             # If no candidate was ever evaluated (e.g. empty population),
             # surface the shaped fitness as -inf-equivalent 0.0 so callers
             # don't see a sentinel value.
-            reported_fitness = best_fitness if best_strategy is not None else 0.0
+            reported_fitness = self._best_confirmed if self._best_strategy is not None else 0.0
 
             metrics = {
-                "win_rate": best_win_rate,
+                "win_rate": self._best_win_rate,
                 "fitness": reported_fitness,
                 "generations": self.generations,
                 "final_generation": self.generations,
             }
 
-            return best_strategy, metrics
+            return self._best_strategy, metrics
 
         except Exception as exc:
             log.exception("Error during training")

--- a/dominion/simulation/strategy_battle.py
+++ b/dominion/simulation/strategy_battle.py
@@ -510,6 +510,17 @@ class StrategyBattle:
 
         return results
 
+    @staticmethod
+    def _select_winner(players):
+        """Pick the winner per the official Dominion tie-break: highest VP,
+        and on equal VP the player who took fewer turns. A full tie (equal VP
+        and equal turns) falls back to seat order, which callers neutralize by
+        alternating seats across games."""
+        return max(
+            players,
+            key=lambda p: (p.get_victory_points(), -p.turns_taken),
+        )
+
     def run_game(
         self,
         ai1: GeneticAI,
@@ -563,7 +574,7 @@ class StrategyBattle:
         # Get results
         final_turns = game_state.turn_number
         scores = {p.ai.name: p.get_victory_points() for p in game_state.players}
-        winner = max(game_state.players, key=lambda p: p.get_victory_points()).ai
+        winner = self._select_winner(game_state.players).ai
 
         # End game logging and capture log path if any
         log_path = self.logger.end_game(winner.name, scores, game_state.supply, game_state.players)

--- a/tests/test_eval_overhaul.py
+++ b/tests/test_eval_overhaul.py
@@ -1,0 +1,408 @@
+"""Tests for the evaluation-integrity overhaul.
+
+Covers the three mechanisms added to make fitness trustworthy:
+
+1. Common random numbers — seeded, seat-swapped game pairs so every candidate
+   in an evaluation phase plays identical shuffles.
+2. Racing — cheap screening for all, refinement for the top slice, and
+   champion replacement only after a paired confirmation eval (closes the
+   winner's-curse path where the returned champion was the luckiest single
+   eval out of thousands).
+3. Hall of fame — past champions join the opponent panel so the fitness
+   gradient doesn't saturate once the population beats the static baselines.
+
+Plus the official-rules tie-break in StrategyBattle (fewer turns wins ties).
+"""
+
+from __future__ import annotations
+
+import random
+import types
+
+import pytest
+
+from dominion.simulation.genetic_trainer import (
+    _SEED_PHASE_CONFIRM,
+    _SEED_PHASE_SCREEN,
+    GeneticTrainer,
+)
+from dominion.simulation.strategy_battle import StrategyBattle
+from dominion.strategy.enhanced_strategy import PriorityRule
+from dominion.strategy.strategies.base_strategy import BaseStrategy
+
+
+def _make_strategy(name: str, *gain_cards: str) -> BaseStrategy:
+    s = BaseStrategy()
+    s.name = name
+    s.gain_priority = [PriorityRule(c) for c in (gain_cards or ("Province",))]
+    s.treasure_priority = [
+        PriorityRule("Gold"),
+        PriorityRule("Silver"),
+        PriorityRule("Copper"),
+    ]
+    return s
+
+
+def _make_trainer(**kwargs) -> GeneticTrainer:
+    defaults = dict(
+        kingdom_cards=["Village", "Smithy"],
+        population_size=4,
+        generations=1,
+        games_per_eval=2,
+        eval_seed=1234,
+    )
+    defaults.update(kwargs)
+    return GeneticTrainer(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Tie-break: fewer turns wins on equal VP
+# ---------------------------------------------------------------------------
+
+
+class TestSelectWinner:
+    @staticmethod
+    def _player(vp: int, turns: int):
+        return types.SimpleNamespace(
+            get_victory_points=lambda _vp=vp: _vp,
+            turns_taken=turns,
+            ai=object(),
+        )
+
+    def test_higher_vp_wins_regardless_of_turns(self):
+        a = self._player(vp=20, turns=18)
+        b = self._player(vp=15, turns=15)
+        assert StrategyBattle._select_winner([a, b]) is a
+
+    def test_equal_vp_fewer_turns_wins(self):
+        a = self._player(vp=20, turns=18)
+        b = self._player(vp=20, turns=17)
+        assert StrategyBattle._select_winner([a, b]) is b
+
+    def test_full_tie_falls_back_to_seat_order(self):
+        a = self._player(vp=20, turns=18)
+        b = self._player(vp=20, turns=18)
+        assert StrategyBattle._select_winner([a, b]) is a
+
+
+# ---------------------------------------------------------------------------
+# Common random numbers
+# ---------------------------------------------------------------------------
+
+
+class TestGameSeeds:
+    def test_seat_swapped_pairs_share_a_seed(self):
+        trainer = _make_trainer()
+        trainer._eval_seed_context = (_SEED_PHASE_SCREEN, 0)
+        assert trainer._game_seed(0, 0) == trainer._game_seed(0, 1)
+        assert trainer._game_seed(0, 2) == trainer._game_seed(0, 3)
+        assert trainer._game_seed(0, 0) != trainer._game_seed(0, 2)
+
+    def test_seeds_differ_across_opponents_and_contexts(self):
+        trainer = _make_trainer()
+        trainer._eval_seed_context = (_SEED_PHASE_SCREEN, 0)
+        seed_a = trainer._game_seed(0, 0)
+        seed_b = trainer._game_seed(1, 0)
+        trainer._eval_seed_context = (_SEED_PHASE_SCREEN, 1)
+        seed_c = trainer._game_seed(0, 0)
+        assert seed_a != seed_b
+        assert seed_a != seed_c
+
+    def test_seeds_do_not_depend_on_candidate(self):
+        """The seed is a function of (base, context, opponent, pair) only —
+        that's what makes the random numbers common across candidates."""
+        t1 = _make_trainer(eval_seed=42)
+        t2 = _make_trainer(eval_seed=42)
+        t1._eval_seed_context = t2._eval_seed_context = (_SEED_PHASE_CONFIRM, 7)
+        assert [t1._game_seed(0, g) for g in range(6)] == [t2._game_seed(0, g) for g in range(6)]
+
+
+class TestSeededEvaluationDeterminism:
+    def test_same_context_same_fitness(self):
+        """Two seeded evals of the same strategy in the same context play the
+        exact same games and must return identical fitness and breakdown."""
+        trainer = _make_trainer(games_per_eval=12)
+        strategy = _make_strategy("Det", "Province", "Gold", "Silver")
+
+        trainer._eval_seed_context = (_SEED_PHASE_SCREEN, 0)
+        first = trainer.evaluate_strategy(strategy)
+        first_breakdown = list(trainer.last_eval_breakdown)
+        second = trainer.evaluate_strategy(strategy)
+        second_breakdown = list(trainer.last_eval_breakdown)
+
+        assert first == second
+        assert first_breakdown == second_breakdown
+
+    def test_seeded_eval_restores_global_rng_state(self):
+        """Seeding games must not make the GA's own mutation stream
+        deterministic: the global RNG state is restored after the eval."""
+        trainer = _make_trainer(games_per_eval=2)
+        strategy = _make_strategy("RngGuard", "Province")
+
+        random.seed(987)
+        expected_next = random.Random()
+        expected_next.seed(987)
+        expected_values = [expected_next.random() for _ in range(3)]
+
+        trainer._eval_seed_context = (_SEED_PHASE_SCREEN, 0)
+        trainer.evaluate_strategy(strategy)
+
+        assert [random.random() for _ in range(3)] == expected_values
+
+    def test_unseeded_eval_keeps_legacy_stochastic_behavior(self):
+        """With no seed context, evals consume global randomness exactly as
+        before — two evals must NOT replay the same RNG stream."""
+        trainer = _make_trainer(games_per_eval=2)
+        strategy = _make_strategy("Legacy", "Province")
+
+        random.seed(555)
+        state_before = random.getstate()
+        assert trainer._eval_seed_context is None
+        trainer.evaluate_strategy(strategy)
+        assert random.getstate() != state_before
+
+
+# ---------------------------------------------------------------------------
+# _eval_with_budget
+# ---------------------------------------------------------------------------
+
+
+class TestEvalWithBudget:
+    def test_budget_and_context_are_temporary(self, monkeypatch):
+        trainer = _make_trainer(games_per_eval=2)
+        seen = {}
+
+        def fake(strategy):
+            seen["games"] = trainer.games_per_eval
+            seen["context"] = trainer._eval_seed_context
+            return 42.0
+
+        monkeypatch.setattr(trainer, "evaluate_strategy", fake)
+        result = trainer._eval_with_budget(_make_strategy("X"), 16, (_SEED_PHASE_CONFIRM, 3))
+
+        assert result == 42.0
+        assert seen["games"] == 16
+        assert seen["context"] == (_SEED_PHASE_CONFIRM, 3)
+        assert trainer.games_per_eval == 2
+        assert trainer._eval_seed_context is None
+
+    def test_crn_disabled_means_no_seed_context(self, monkeypatch):
+        trainer = _make_trainer(common_random_numbers=False)
+        seen = {}
+
+        def fake(strategy):
+            seen["context"] = trainer._eval_seed_context
+            return 0.0
+
+        monkeypatch.setattr(trainer, "evaluate_strategy", fake)
+        trainer._eval_with_budget(_make_strategy("X"), 8, (_SEED_PHASE_CONFIRM, 0))
+        assert seen["context"] is None
+
+
+# ---------------------------------------------------------------------------
+# Champion confirmation (racing)
+# ---------------------------------------------------------------------------
+
+
+class TestConsiderChallenger:
+    def _patch_budget(self, monkeypatch, trainer, results_by_name, calls):
+        def fake(strategy, games, context):
+            calls.append((strategy.name, games, context))
+            fitness, win_rate = results_by_name[strategy.name]
+            trainer.last_eval_breakdown = [("Opp", win_rate)]
+            return fitness
+
+        monkeypatch.setattr(trainer, "_eval_with_budget", fake)
+
+    def test_first_champion_is_crowned_at_confirmed_fitness(self, monkeypatch):
+        trainer = _make_trainer(confirm_games=8)
+        calls: list = []
+        self._patch_budget(monkeypatch, trainer, {"A": (55.0, 60.0)}, calls)
+
+        trainer._consider_challenger(_make_strategy("A"), screen_fitness=90.0, gen=0)
+
+        assert trainer._best_strategy.name == "A"
+        # Confirmed fitness, not the lucky screen estimate, is what's kept.
+        assert trainer._best_confirmed == 55.0
+        assert trainer._best_win_rate == 60.0
+        assert calls == [("A", 8, (_SEED_PHASE_CONFIRM, 0))]
+
+    def test_identical_genome_skips_confirmation(self, monkeypatch):
+        trainer = _make_trainer()
+        incumbent = _make_strategy("Champ", "Province", "Gold")
+        trainer._best_strategy = incumbent
+        trainer._best_confirmed = 60.0
+        calls: list = []
+        self._patch_budget(monkeypatch, trainer, {}, calls)
+
+        clone = _make_strategy("Champ-clone", "Province", "Gold")
+        trainer._consider_challenger(clone, screen_fitness=95.0, gen=1)
+
+        assert calls == []
+        assert trainer._best_strategy is incumbent
+
+    def test_weak_screen_is_gated_without_spending_budget(self, monkeypatch):
+        trainer = _make_trainer(confirm_slack=5.0)
+        trainer._best_strategy = _make_strategy("Champ", "Province", "Gold")
+        trainer._best_confirmed = 60.0
+        calls: list = []
+        self._patch_budget(monkeypatch, trainer, {}, calls)
+
+        challenger = _make_strategy("Weak", "Duchy")
+        trainer._consider_challenger(challenger, screen_fitness=40.0, gen=1)
+
+        assert calls == []
+        assert trainer._best_strategy.name == "Champ"
+
+    def test_challenger_replaces_incumbent_when_confirmed_better(self, monkeypatch):
+        trainer = _make_trainer(confirm_games=8)
+        trainer._best_strategy = _make_strategy("Champ", "Province", "Gold")
+        trainer._best_confirmed = 60.0
+        calls: list = []
+        self._patch_budget(
+            monkeypatch, trainer,
+            {"Champ": (58.0, 62.0), "New": (66.0, 70.0)},
+            calls,
+        )
+
+        trainer._consider_challenger(_make_strategy("New", "Province", "Witch"), 65.0, gen=2)
+
+        assert trainer._best_strategy.name == "New"
+        assert trainer._best_confirmed == 66.0
+        assert trainer._best_win_rate == 70.0
+        # Both were measured, on the same confirmation context (paired games).
+        assert calls == [
+            ("Champ", 8, (_SEED_PHASE_CONFIRM, 2)),
+            ("New", 8, (_SEED_PHASE_CONFIRM, 2)),
+        ]
+
+    def test_incumbent_retained_and_its_estimate_refreshed(self, monkeypatch):
+        trainer = _make_trainer(confirm_games=8)
+        trainer._best_strategy = _make_strategy("Champ", "Province", "Gold")
+        trainer._best_confirmed = 60.0
+        calls: list = []
+        self._patch_budget(
+            monkeypatch, trainer,
+            {"Champ": (57.0, 61.0), "Lucky": (45.0, 50.0)},
+            calls,
+        )
+
+        trainer._consider_challenger(_make_strategy("Lucky", "Province", "Witch"), 80.0, gen=3)
+
+        assert trainer._best_strategy.name == "Champ"
+        # The incumbent's confirmed fitness was re-measured, not left stale.
+        assert trainer._best_confirmed == 57.0
+        assert trainer._best_win_rate == 61.0
+
+
+# ---------------------------------------------------------------------------
+# Hall of fame
+# ---------------------------------------------------------------------------
+
+
+class TestHallOfFame:
+    def _patch_budget(self, monkeypatch, trainer, fitness=50.0):
+        def fake(strategy, games, context):
+            trainer.last_eval_breakdown = [("Opp", fitness)]
+            return fitness
+
+        monkeypatch.setattr(trainer, "_eval_with_budget", fake)
+
+    def test_champion_joins_panel_and_fitness_is_rebased(self, monkeypatch):
+        trainer = _make_trainer(hall_of_fame_size=3)
+        trainer._best_strategy = _make_strategy("Champ", "Province", "Gold")
+        trainer._best_confirmed = 80.0
+        self._patch_budget(monkeypatch, trainer, fitness=52.0)
+
+        trainer._update_hall_of_fame(gen=9)
+
+        assert len(trainer.hall_of_fame) == 1
+        assert trainer.hall_of_fame[0].name == "HallOfFame-g10"
+        # Confirmed fitness re-measured on the new (harder) panel.
+        assert trainer._best_confirmed == 52.0
+
+    def test_duplicate_champion_not_added_twice(self, monkeypatch):
+        trainer = _make_trainer(hall_of_fame_size=3)
+        trainer._best_strategy = _make_strategy("Champ", "Province", "Gold")
+        trainer._best_confirmed = 80.0
+        self._patch_budget(monkeypatch, trainer)
+
+        trainer._update_hall_of_fame(gen=9)
+        trainer._update_hall_of_fame(gen=19)
+
+        assert len(trainer.hall_of_fame) == 1
+
+    def test_hall_is_capped_dropping_oldest(self, monkeypatch):
+        trainer = _make_trainer(hall_of_fame_size=2)
+        self._patch_budget(monkeypatch, trainer)
+
+        for gen, cards in enumerate([("Province",), ("Province", "Gold"), ("Province", "Witch")]):
+            trainer._best_strategy = _make_strategy(f"Champ{gen}", *cards)
+            trainer._best_confirmed = 80.0
+            trainer._update_hall_of_fame(gen=gen)
+
+        assert len(trainer.hall_of_fame) == 2
+        assert [m.name for m in trainer.hall_of_fame] == ["HallOfFame-g2", "HallOfFame-g3"]
+
+    def test_hall_members_are_added_to_the_eval_panel(self, monkeypatch):
+        trainer = _make_trainer(games_per_eval=4)
+        opp = _make_strategy("Baseline", "Province")
+        trainer.set_baseline_panel([opp])
+        hof_member = _make_strategy("HallOfFame-g10", "Province", "Gold")
+        trainer.hall_of_fame = [hof_member]
+
+        games_against: dict[str, int] = {"Baseline": 0, "HallOfFame-g10": 0}
+
+        def fake_run_game(first_ai, second_ai, kingdom):
+            for ai in (first_ai, second_ai):
+                if ai.strategy.name in games_against:
+                    games_against[ai.strategy.name] += 1
+            return first_ai, {}, None, 0
+
+        monkeypatch.setattr(trainer.battle_system, "run_game", fake_run_game)
+        trainer.evaluate_strategy(_make_strategy("Candidate", "Province"))
+
+        # 4 games split across baseline + hall member
+        assert games_against == {"Baseline": 2, "HallOfFame-g10": 2}
+
+
+# ---------------------------------------------------------------------------
+# train() integration: racing end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestTrainWithRacing:
+    def test_champion_fitness_comes_from_confirmation_not_screen(self, monkeypatch):
+        """Screens report an inflated 80; the confirmation eval reports 65.
+        The returned metrics must carry the confirmed value."""
+        trainer = _make_trainer(
+            population_size=4,
+            generations=1,
+            games_per_eval=2,
+            refine_games=4,
+            confirm_games=8,
+            hall_of_fame_size=0,
+        )
+
+        def fake(strategy):
+            by_budget = {2: 80.0, 4: 70.0, 8: 65.0}
+            fitness = by_budget[trainer.games_per_eval]
+            trainer.last_eval_breakdown = [("Opp", fitness)]
+            return fitness
+
+        monkeypatch.setattr(trainer, "evaluate_strategy", fake)
+
+        best, metrics = trainer.train()
+
+        assert best is not None
+        assert metrics["fitness"] == pytest.approx(65.0)
+        assert metrics["win_rate"] == pytest.approx(65.0)
+
+    def test_train_resets_hall_of_fame_between_runs(self, monkeypatch):
+        trainer = _make_trainer(hall_of_fame_size=3)
+        trainer.hall_of_fame = [_make_strategy("Stale", "Province")]
+
+        monkeypatch.setattr(trainer, "evaluate_strategy", lambda s: float("-inf"))
+        trainer.train()
+
+        assert trainer.hall_of_fame == []

--- a/tests/test_reward_shaping.py
+++ b/tests/test_reward_shaping.py
@@ -244,6 +244,8 @@ class TestTrainHandlesNegativeShapedFitness:
     them all and return None."""
 
     def test_returns_best_strategy_when_all_fitness_negative(self, monkeypatch):
+        # racing=False: this test pins the legacy best-single-eval champion
+        # semantics (the iterators below feed exactly one eval per candidate).
         trainer = GeneticTrainer(
             ["Village"],
             population_size=4,
@@ -251,6 +253,7 @@ class TestTrainHandlesNegativeShapedFitness:
             games_per_eval=2,
             immigrant_fraction=0.0,
             shape_rewards=True,
+            racing=False,
         )
 
         scores = iter([-10.0, -5.0, -20.0, -8.0])
@@ -281,6 +284,8 @@ class TestTrainMetricsDistinguishWinRateFromShapedFitness:
     100%-winning strategy."""
 
     def test_metrics_reports_raw_win_rate_alongside_shaped_fitness(self, monkeypatch):
+        # racing=False: iterators below feed exactly one eval per candidate,
+        # which is the legacy single-eval champion path.
         trainer = GeneticTrainer(
             ["Village"],
             population_size=2,
@@ -288,6 +293,7 @@ class TestTrainMetricsDistinguishWinRateFromShapedFitness:
             games_per_eval=2,
             immigrant_fraction=0.0,
             shape_rewards=True,
+            racing=False,
         )
 
         # First evaluation: shaped fitness 86 backed by a true 100% win rate.


### PR DESCRIPTION
## Why

The repo has been bad at turning a board into a great strategy, and the diagnosis (see below) points at the evaluation statistics, not the game engine:

- **Eval noise exceeds the signal.** Evaluating the *same* strategy 12 times with the trainer's own `evaluate_strategy` at 100 games/eval produced win rates from **69% to 84%** (sd ≈ 4.6pp). The gap between a decent and a great strategy is the same size, so selection between close candidates was a coin flip.
- **Winner's curse.** `train()` kept the best *single* eval ever seen across ~2000 evals — expected ~3.5σ above truth — so the returned "champion" was typically a mediocre strategy that got hot dice, with inflated reported fitness.
- **Saturated objective.** Fitness was win rate vs one fixed weak baseline (Big Money / best seed); once the population cleared "decent" there was no gradient left toward "great."

## What changed

**`GeneticTrainer`:**
- **Common random numbers** — evals are seeded per `(phase, generation, opponent, game-pair)`: every candidate in a phase plays identical shuffles, so comparisons cancel deck luck. Seat-swapped game pairs share a seed. Global RNG state is restored after seeded evals so the GA's own mutation stream stays stochastic. (`common_random_numbers=False` to opt out, `eval_seed=` for reproducibility.)
- **Racing evaluation** — `games_per_eval` is now a cheap screen for everyone; the top `race_top_fraction` get `refine_games` more games (pooled estimate); the champion is only replaced after incumbent and challenger are both scored on the **same** `confirm_games` seeded block. Incumbent's confirmed fitness refreshes on every confirmation; a genome-identical elite skips re-confirmation. `racing=False` preserves legacy behavior.
- **Hall of fame** — every `hall_of_fame_interval` generations the champion joins the opponent panel (capped, genome-deduped), keeping a gradient alive past the static baselines; champion fitness is rebased when the panel changes.

**Smaller fixes:**
- `StrategyBattle` now applies the official Dominion tie-break (equal VP → fewer turns wins) instead of seat order.
- `runner.py` default `games_per_eval` 10 → 30 (10-game screens have ~15pp sd — pure noise).

## Validation

- Full suite: **1656 passed** (22 new tests: seed derivation, deterministic seeded evals, RNG restoration, confirmation paths, hall-of-fame, `train()` end-to-end with racing).
- Smoke evolution on `boards/siege_engine.txt` (pop 8, 10 gens): champion now reports a *confirmed* fitness with per-opponent breakdown (85% vs Big Money, ~50% vs its own hall-of-fame ancestors — self-play pressure visible), and a tied challenger correctly fails to displace the incumbent.

## Follow-ups (not in this PR)

- Constrain the genome toward Provincial-style structured buy menus (mutation hit-rate).
- Wire trick-scanner seeds into `runner.py` defaults; de-hardcode the island pipeline's Lisbon seeds.
- Define winner semantics for the 100-turn cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-phase racing genetic training with optional seeded evaluations for fairer comparisons.
  * Hall-of-fame that preserves and reuses top strategies during training.
  * Evaluation budget now defaults to 30 games (configurable; CLI flag defers to config when not given).

* **Bug Fixes**
  * Improved game outcome tie-breaking: higher victory points, then fewer turns, then seat order.

* **Tests**
  * Added comprehensive tests covering evaluation determinism, racing/confirmation, seeding, and hall-of-fame behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->