### PR TITLE
Structured buy-menu genome: constrain the GA search space to coherent menus

### DIFF
--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -128,8 +128,10 @@ class GeneticTrainer:
         # rewrites where almost every edit is noise. structured_genome=False
         # restores the legacy free-form operators for comparison.
         self.structured_genome = structured_genome
-        from dominion.simulation.structured_genome import KingdomInfo
-        self._kingdom_info = KingdomInfo.from_kingdom(kingdom_cards or [])
+        self._kingdom_info = None
+        if self.structured_genome:
+            from dominion.simulation.structured_genome import KingdomInfo
+            self._kingdom_info = KingdomInfo.from_kingdom(kingdom_cards or [])
 
         self.battle_system = StrategyBattle(kingdom_cards, log_folder, board_config=board_config)
         if not self.kingdom_cards:

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -70,6 +70,7 @@ class GeneticTrainer:
         eval_seed: Optional[int] = None,
         hall_of_fame_size: int = 3,
         hall_of_fame_interval: int = 10,
+        structured_genome: bool = True,
     ):
         if kingdom_cards is None:
             if board_config is None:
@@ -120,6 +121,15 @@ class GeneticTrainer:
         self.hall_of_fame_size = hall_of_fame_size
         self.hall_of_fame_interval = hall_of_fame_interval
         self.hall_of_fame: list[BaseStrategy] = []
+
+        # Structured "buy menu" genome: random init builds coherent menus
+        # (greening block + capped kingdom picks) and mutation applies menu
+        # edits from a curated gate vocabulary, instead of free-form condition
+        # rewrites where almost every edit is noise. structured_genome=False
+        # restores the legacy free-form operators for comparison.
+        self.structured_genome = structured_genome
+        from dominion.simulation.structured_genome import KingdomInfo
+        self._kingdom_info = KingdomInfo.from_kingdom(kingdom_cards or [])
 
         self.battle_system = StrategyBattle(kingdom_cards, log_folder, board_config=board_config)
         if not self.kingdom_cards:
@@ -352,7 +362,18 @@ class GeneticTrainer:
         return WayRule(card, way, condition)
 
     def create_random_strategy(self) -> BaseStrategy:
-        """Create a random strategy"""
+        """Create a random strategy.
+
+        With ``structured_genome`` (the default) this builds a coherent buy
+        menu via :mod:`dominion.simulation.structured_genome`; the legacy
+        free-form path shuffles all cards into an arbitrary gain order."""
+        if self.structured_genome:
+            from dominion.simulation.structured_genome import random_menu_strategy
+            strategy = random_menu_strategy(self._kingdom_info)
+            strategy.name = f"gen{self.current_generation}-{id(strategy)}"
+            self._seed_way_policy(strategy)
+            return self._normalize(strategy)
+
         strategy = BaseStrategy()
         strategy.name = f"gen{self.current_generation}-{id(strategy)}"
 
@@ -407,17 +428,21 @@ class GeneticTrainer:
             PriorityRule("Copper", PriorityRule.has_cards(["Silver", "Gold"], 3)),
         ]
 
-        # Seed a small number of way_policy rules when the board has ways.
-        # Without seeding, no individual would ever try a non-default Way and
-        # the mutation-only path would discover them only by chance.
+        self._seed_way_policy(strategy)
+
+        return self._normalize(strategy)
+
+    def _seed_way_policy(self, strategy: BaseStrategy) -> None:
+        """Seed a small number of way_policy rules when the board has ways.
+
+        Without seeding, no individual would ever try a non-default Way and
+        the mutation-only path would discover them only by chance."""
         strategy.way_policy = []
         if self._kingdom_ways:
             for _ in range(random.randint(0, 2)):
                 rule = self._random_way_rule()
                 if rule is not None:
                     strategy.way_policy.append(rule)
-
-        return self._normalize(strategy)
 
     def set_baseline_strategy(self, strategy: BaseStrategy):
         """Set a custom baseline strategy to evaluate against instead of Big Money."""
@@ -755,7 +780,18 @@ class GeneticTrainer:
         return child
 
     def _mutate(self, strategy: BaseStrategy) -> BaseStrategy:
-        """Mutate a strategy"""
+        """Mutate a strategy.
+
+        With ``structured_genome`` (the default), mutations are menu edits —
+        reorder, cap nudges, curated re-gating, pick add/drop — applied by
+        :func:`dominion.simulation.structured_genome.mutate_menu`. The legacy
+        free-form condition rewrites remain behind ``structured_genome=False``."""
+        if self.structured_genome:
+            from dominion.simulation.structured_genome import mutate_menu
+            mutate_menu(strategy, self._kingdom_info, self.mutation_rate)
+            self._mutate_way_policy(strategy)
+            return strategy
+
         # --- Mutate gain priorities ---
         # Condition mutations: drop, replace, or fresh-from-none
         for priority in strategy.gain_priority:
@@ -868,9 +904,15 @@ class GeneticTrainer:
                             min_treasures = random.randint(2, 4)
                             priority.condition = PriorityRule.has_cards(["Silver", "Gold"], min_treasures)
 
-        # --- Mutate way_policy ---
-        # Only meaningful when the board has Ways. Skipped otherwise so the
-        # mutator can't grow way_policy on boards where the rules can never fire.
+        self._mutate_way_policy(strategy)
+
+        return strategy
+
+    def _mutate_way_policy(self, strategy: BaseStrategy) -> None:
+        """Mutate way_policy in place.
+
+        Only meaningful when the board has Ways. Skipped otherwise so the
+        mutator can't grow way_policy on boards where the rules can never fire."""
         if getattr(strategy, "way_policy", None) is None:
             strategy.way_policy = []
 
@@ -911,22 +953,27 @@ class GeneticTrainer:
                 i = random.randint(0, len(strategy.way_policy) - 1)
                 strategy.way_policy.pop(i)
 
-        return strategy
-
     @staticmethod
     def _apply_fitness_sharing(
         population: list[BaseStrategy],
         raw_fitness: list[float],
         threshold: float = 0.8,
+        similarity=None,
     ) -> list[float]:
         """Divide each individual's fitness by its niche count (members within
         ``threshold`` similarity, including itself). Clones lose to unique
-        strategies at the same skill level."""
+        strategies at the same skill level.
+
+        ``similarity`` defaults to the raw top-5 gain overlap; structured-menu
+        runs pass :func:`kingdom_similarity` instead so the shared greening
+        skeleton doesn't put the whole population in one niche."""
+        if similarity is None:
+            similarity = GeneticTrainer._strategy_similarity
         shared: list[float] = []
         for i, individual in enumerate(population):
             niche = sum(
                 1 for other in population
-                if GeneticTrainer._strategy_similarity(individual, other) >= threshold
+                if similarity(individual, other) >= threshold
             )
             shared.append(raw_fitness[i] / max(1, niche))
         return shared
@@ -964,6 +1011,9 @@ class GeneticTrainer:
 
     def _normalize(self, strategy: BaseStrategy) -> BaseStrategy:
         """Normalize all priority lists to remove unreachable rules."""
+        if self.structured_genome:
+            from dominion.simulation.structured_genome import normalize_menu
+            normalize_menu(strategy, self._kingdom_info)
         strategy.gain_priority = self._normalize_priority_list(strategy.gain_priority)
         strategy.action_priority = self._normalize_priority_list(strategy.action_priority)
         strategy.treasure_priority = self._normalize_priority_list(strategy.treasure_priority)
@@ -1172,8 +1222,13 @@ class GeneticTrainer:
                 self.logger.update_training(gen, self._best_confirmed, avg_fitness)
 
                 # Diversity pressure: shared fitness for selection, random immigrants
+                similarity = None
+                if self.structured_genome:
+                    from dominion.simulation.structured_genome import kingdom_similarity
+                    similarity = kingdom_similarity
                 shared_fitness = self._apply_fitness_sharing(
-                    population, fitness_scores, threshold=self.sharing_threshold
+                    population, fitness_scores, threshold=self.sharing_threshold,
+                    similarity=similarity,
                 )
                 if self.population_size < 4 or self.immigrant_fraction <= 0:
                     immigrants = 0

--- a/dominion/simulation/structured_genome.py
+++ b/dominion/simulation/structured_genome.py
@@ -1,0 +1,375 @@
+"""Structured "buy menu" genome operators for the genetic trainer.
+
+The free-form genome let mutation draw arbitrary conditions from a large
+vocabulary and assemble gain lists in any order — so random individuals
+opened with Copper above Province, champions accumulated duplicate rules,
+and almost every mutation was noise. These operators constrain the search
+space the way a strong player thinks about a kingdom:
+
+- a gain list is a *menu*: a greening block (Province / Duchy / Estate with
+  pile-count gates) over an economy backbone (Gold / Silver) interleaved
+  with a handful of kingdom picks, each capped with ``max_in_deck``;
+- mutations are menu edits — reorder entries, nudge a cap, swap a gate from
+  a small curated vocabulary, add or drop a pick — instead of arbitrary
+  condition rewrites;
+- normalization enforces invariants every viable strategy needs (a Province
+  rule exists, no duplicate rules, basic treasures are playable).
+
+The phenotype is still a plain :class:`EnhancedStrategy` rule list, so
+seeds, serialization, pruning, and simplification all keep working; only
+how the GA *moves through* strategy space changes.
+"""
+
+from __future__ import annotations
+
+import random as _random_module
+import re
+from dataclasses import dataclass, field
+
+from dominion.cards.registry import get_card
+from dominion.strategy.enhanced_strategy import PriorityRule
+from dominion.strategy.strategies.base_strategy import BaseStrategy
+
+# Cards handled by the menu skeleton rather than treated as kingdom picks.
+BASIC_CARDS = {"Copper", "Silver", "Gold", "Estate", "Duchy", "Province", "Curse"}
+
+_MAX_IN_DECK_RE = re.compile(r"PriorityRule\.max_in_deck\('([^']+)', (\d+)\)")
+
+
+@dataclass
+class KingdomInfo:
+    """Card-role classification for one kingdom, used to build sane menus."""
+
+    kingdom_cards: list[str]
+    gainable: list[str] = field(default_factory=list)  # kingdom cards worth a menu slot
+    action_cards: list[str] = field(default_factory=list)
+    treasure_cards: list[str] = field(default_factory=list)
+    villages: list[str] = field(default_factory=list)      # +2 or more actions
+    cantrips: list[str] = field(default_factory=list)      # exactly +1 action
+    terminal_draw: list[str] = field(default_factory=list)  # 0 actions, +2 or more cards
+    other_terminals: list[str] = field(default_factory=list)
+    costs: dict[str, int] = field(default_factory=dict)
+
+    @classmethod
+    def from_kingdom(cls, kingdom_cards: list[str]) -> "KingdomInfo":
+        info = cls(kingdom_cards=list(kingdom_cards))
+        for name in kingdom_cards:
+            if name in BASIC_CARDS:
+                continue
+            try:
+                card = get_card(name)
+            except ValueError:
+                continue
+            info.costs[name] = card.cost.coins
+            info.gainable.append(name)
+            if card.is_action:
+                info.action_cards.append(name)
+                if card.stats.actions >= 2:
+                    info.villages.append(name)
+                elif card.stats.actions == 1:
+                    info.cantrips.append(name)
+                elif card.stats.cards >= 2:
+                    info.terminal_draw.append(name)
+                else:
+                    info.other_terminals.append(name)
+            if card.is_treasure:
+                info.treasure_cards.append(name)
+        return info
+
+    def default_cap(self, card: str, rng) -> int:
+        """A sensible max-in-deck cap range per card role."""
+        if card in self.villages:
+            return rng.randint(2, 4)
+        if card in self.terminal_draw:
+            return rng.randint(1, 3)
+        if card in self.other_terminals:
+            return rng.randint(1, 2)
+        if card in self.cantrips:
+            return rng.randint(2, 5)
+        if card in self.treasure_cards:
+            return rng.randint(1, 3)
+        # Victory/other kingdom cards (Gardens, Mill, ...) — wide range.
+        return rng.randint(1, 8)
+
+
+# ---------------------------------------------------------------------------
+# Curated gate vocabulary
+# ---------------------------------------------------------------------------
+
+
+def _greening_gate(card: str, rng):
+    if card == "Duchy":
+        return PriorityRule.provinces_left("<=", rng.randint(3, 6))
+    if card == "Estate":
+        return PriorityRule.provinces_left("<=", rng.randint(1, 3))
+    # Province: usually unconditional; occasionally an endgame-only gate.
+    if rng.random() < 0.85:
+        return None
+    return PriorityRule.provinces_left("<=", rng.randint(4, 8))
+
+
+def _silver_gate(rng):
+    roll = rng.random()
+    if roll < 0.4:
+        return None
+    if roll < 0.7:
+        return PriorityRule.turn_number("<=", rng.randint(5, 12))
+    return PriorityRule.provinces_left(">", rng.randint(2, 4))
+
+
+def _pick_gate(card: str, info: KingdomInfo, rng):
+    """Cap + optional extra gate for a kingdom menu pick."""
+    cap = PriorityRule.max_in_deck(card, info.default_cap(card, rng))
+    if rng.random() >= 0.3:
+        return cap
+    roll = rng.random()
+    if roll < 0.5:
+        extra = PriorityRule.turn_number("<=", rng.randint(6, 16))
+    elif roll < 0.8 and len(info.gainable) >= 2:
+        anchor = rng.choice([c for c in info.gainable if c != card] or [card])
+        extra = PriorityRule.has_cards([anchor], rng.randint(1, 2))
+    else:
+        extra = PriorityRule.provinces_left(">", rng.randint(2, 4))
+    return PriorityRule.and_(cap, extra)
+
+
+def _gate_for(card: str, info: KingdomInfo, rng):
+    """Re-gate vocabulary used by mutation, dispatched on the card's role."""
+    if card in ("Province", "Duchy", "Estate"):
+        return _greening_gate(card, rng)
+    if card == "Silver":
+        return _silver_gate(rng)
+    if card == "Gold":
+        return None if rng.random() < 0.8 else PriorityRule.max_in_deck("Gold", rng.randint(2, 6))
+    if card == "Copper":
+        # Copper is only ever bought deliberately (e.g. Gardens piles) —
+        # always keep it gated so it can't become an unconditional junk buy.
+        return PriorityRule.has_cards(["Gardens"], 1) if "Gardens" in info.gainable else PriorityRule.provinces_left("<=", 1)
+    return _pick_gate(card, info, rng)
+
+
+# ---------------------------------------------------------------------------
+# Random initialization
+# ---------------------------------------------------------------------------
+
+
+def random_menu_strategy(info: KingdomInfo, rng=_random_module) -> BaseStrategy:
+    """Build a random but *coherent* strategy: greening block on top, an
+    economy backbone, and a few capped kingdom picks ordered roughly by cost."""
+    strategy = BaseStrategy()
+
+    gain: list[PriorityRule] = [PriorityRule("Province")]
+    if rng.random() < 0.9:
+        gain.append(PriorityRule("Duchy", _greening_gate("Duchy", rng)))
+    if rng.random() < 0.4:
+        gain.append(PriorityRule("Estate", _greening_gate("Estate", rng)))
+
+    picks: list[str] = []
+    if info.gainable:
+        hi = min(6, len(info.gainable))
+        n_picks = rng.randint(min(2, hi), hi)
+        picks = rng.sample(info.gainable, n_picks)
+
+    # Merge picks with the treasure backbone, ordered by cost with jitter so
+    # adjacent-cost cards can swap order between individuals.
+    entries: list[tuple[float, PriorityRule]] = [
+        (info.costs.get(card, 0) + rng.uniform(-1.5, 1.5), PriorityRule(card, _pick_gate(card, info, rng)))
+        for card in picks
+    ]
+    entries.append((6 + rng.uniform(-1.5, 1.5), PriorityRule("Gold")))
+    entries.append((3 + rng.uniform(-1.5, 1.5), PriorityRule("Silver", _silver_gate(rng))))
+    entries.sort(key=lambda pair: pair[0], reverse=True)
+    gain.extend(rule for _, rule in entries)
+    strategy.gain_priority = gain
+
+    # Action play order: villages first, then cantrips, then terminal draw,
+    # then remaining terminals. Within each role group the order is shuffled.
+    action: list[PriorityRule] = []
+    for group in (info.villages, info.cantrips, info.terminal_draw, info.other_terminals):
+        group = list(group)
+        rng.shuffle(group)
+        action.extend(PriorityRule(card) for card in group)
+    strategy.action_priority = action
+
+    # Treasures: Gold, kingdom treasures (cost order), Silver, Copper.
+    kingdom_treasures = sorted(info.treasure_cards, key=lambda c: -info.costs.get(c, 0))
+    strategy.treasure_priority = (
+        [PriorityRule("Gold")]
+        + [PriorityRule(c) for c in kingdom_treasures]
+        + [PriorityRule("Silver"), PriorityRule("Copper")]
+    )
+
+    strategy.trash_priority = [
+        PriorityRule("Curse"),
+        PriorityRule("Estate", PriorityRule.provinces_left(">", rng.randint(2, 6))),
+        PriorityRule("Copper", PriorityRule.has_cards(["Silver", "Gold"], rng.randint(2, 4))),
+    ]
+
+    strategy.way_policy = []
+    return strategy
+
+
+# ---------------------------------------------------------------------------
+# Menu-aware mutation
+# ---------------------------------------------------------------------------
+
+
+def _adjust_cap(rule: PriorityRule, rng) -> bool:
+    """Nudge a max_in_deck cap on this rule by ±1. Returns True if adjusted."""
+    source = getattr(rule.condition, "_source", "") if rule.condition else ""
+    match = _MAX_IN_DECK_RE.search(source)
+    if not match:
+        return False
+    card, cap = match.group(1), int(match.group(2))
+    new_cap = max(1, min(10, cap + rng.choice([-1, 1])))
+    if new_cap == cap:
+        return False
+    new_inner = PriorityRule.max_in_deck(card, new_cap)
+    # Preserve a compound gate's other condition by rebuilding the and_ with
+    # the new cap source spliced in is not worth the complexity — the curated
+    # vocabulary is small, so replacing the whole condition keeps genomes lean.
+    rule.condition = new_inner
+    return True
+
+
+def mutate_menu(strategy: BaseStrategy, info: KingdomInfo, rate: float, rng=_random_module) -> BaseStrategy:
+    """Apply menu-edit mutations in place and return the strategy."""
+    gain = strategy.gain_priority
+
+    # Reorder: swap adjacent entries.
+    if rng.random() < rate and len(gain) >= 2:
+        i = rng.randint(0, len(gain) - 2)
+        gain[i], gain[i + 1] = gain[i + 1], gain[i]
+
+    # Relocate one entry.
+    if rng.random() < rate * 0.5 and len(gain) >= 2:
+        i = rng.randint(0, len(gain) - 1)
+        rule = gain.pop(i)
+        gain.insert(rng.randint(0, len(gain)), rule)
+
+    # Nudge a cap.
+    if rng.random() < rate and gain:
+        capped = [r for r in gain if _MAX_IN_DECK_RE.search(getattr(r.condition, "_source", "") if r.condition else "")]
+        if capped:
+            _adjust_cap(rng.choice(capped), rng)
+
+    # Add a missing kingdom pick.
+    if rng.random() < rate * 0.4:
+        existing = {r.card_name for r in gain}
+        missing = [c for c in info.gainable if c not in existing]
+        if missing:
+            card = rng.choice(missing)
+            gain.insert(rng.randint(0, len(gain)), PriorityRule(card, _pick_gate(card, info, rng)))
+
+    # Drop an entry (never Province; keep a minimum menu).
+    if rng.random() < rate * 0.25 and len(gain) > 4:
+        droppable = [i for i, r in enumerate(gain) if r.card_name != "Province"]
+        if droppable:
+            gain.pop(rng.choice(droppable))
+
+    # Re-gate one entry from the curated vocabulary for its role.
+    if rng.random() < rate and gain:
+        rule = rng.choice(gain)
+        rule.condition = _gate_for(rule.card_name, info, rng)
+
+    # Action play order: swap adjacent; occasionally add/remove.
+    action = strategy.action_priority
+    if rng.random() < rate and len(action) >= 2:
+        i = rng.randint(0, len(action) - 2)
+        action[i], action[i + 1] = action[i + 1], action[i]
+    if rng.random() < rate * 0.3:
+        existing = {r.card_name for r in action}
+        missing = [c for c in info.action_cards if c not in existing]
+        if missing:
+            card = rng.choice(missing)
+            action.insert(rng.randint(0, len(action)), PriorityRule(card))
+    if rng.random() < rate * 0.2 and len(action) > 1:
+        action.pop(rng.randint(0, len(action) - 1))
+
+    # Treasure order: swap adjacent.
+    treasure = strategy.treasure_priority
+    if rng.random() < rate * 0.5 and len(treasure) >= 2:
+        i = rng.randint(0, len(treasure) - 2)
+        treasure[i], treasure[i + 1] = treasure[i + 1], treasure[i]
+
+    # Trash thresholds.
+    if rng.random() < rate:
+        for rule in strategy.trash_priority:
+            if rng.random() >= 0.3:
+                continue
+            if rule.card_name == "Estate":
+                rule.condition = PriorityRule.provinces_left(">", rng.randint(2, 6))
+            elif rule.card_name == "Copper":
+                rule.condition = PriorityRule.has_cards(["Silver", "Gold"], rng.randint(2, 4))
+
+    return strategy
+
+
+# ---------------------------------------------------------------------------
+# Normalization invariants
+# ---------------------------------------------------------------------------
+
+
+def normalize_menu(strategy: BaseStrategy, info: KingdomInfo) -> BaseStrategy:
+    """Enforce the invariants every viable menu needs.
+
+    - exactly no duplicate (card, gate) rules — crossover splices can clone;
+    - a Province gain rule exists (without one the strategy cannot win);
+    - never an unconditional Copper/Curse gain rule (pure junk buys);
+    - Gold/Silver/Copper present in treasure_priority so coins get played.
+    """
+    seen: set[tuple] = set()
+    deduped: list[PriorityRule] = []
+    for rule in strategy.gain_priority:
+        if rule.card_name == "Curse":
+            continue
+        if rule.card_name == "Copper" and rule.condition is None:
+            continue
+        key = (rule.card_name, getattr(rule.condition, "_source", None) if rule.condition else None)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(rule)
+    strategy.gain_priority = deduped
+
+    if not any(r.card_name == "Province" for r in strategy.gain_priority):
+        strategy.gain_priority.insert(0, PriorityRule("Province"))
+
+    treasure_names = {r.card_name for r in strategy.treasure_priority}
+    for name in ("Gold", "Silver", "Copper"):
+        if name not in treasure_names:
+            strategy.treasure_priority.append(PriorityRule(name))
+
+    return strategy
+
+
+# ---------------------------------------------------------------------------
+# Kingdom-aware similarity (for fitness sharing)
+# ---------------------------------------------------------------------------
+
+
+def _top_kingdom_picks(strategy: BaseStrategy, n: int = 5) -> set[str]:
+    picks: list[str] = []
+    for rule in strategy.gain_priority:
+        if rule.card_name in BASIC_CARDS or rule.card_name in picks:
+            continue
+        picks.append(rule.card_name)
+        if len(picks) == n:
+            break
+    return set(picks)
+
+
+def kingdom_similarity(a: BaseStrategy, b: BaseStrategy) -> float:
+    """Top-5 overlap of *kingdom* gain picks, ignoring the shared skeleton.
+
+    Structured menus all contain Province/Duchy/Gold/Silver, so similarity
+    computed over raw top-5 entries would put nearly every individual in one
+    niche and fitness sharing would punish the whole population uniformly.
+    What distinguishes strategies is which kingdom cards they pick, in
+    priority order."""
+    top_a = _top_kingdom_picks(a)
+    top_b = _top_kingdom_picks(b)
+    if not top_a and not top_b:
+        return 1.0
+    denom = max(1, min(5, max(len(top_a), len(top_b))))
+    return len(top_a & top_b) / denom

--- a/dominion/simulation/structured_genome.py
+++ b/dominion/simulation/structured_genome.py
@@ -337,9 +337,11 @@ def normalize_menu(strategy: BaseStrategy, info: KingdomInfo) -> BaseStrategy:
     - on Colony boards, a Colony gain rule exists;
     - Province/Colony are never shadowed by an *unconditional* basic-treasure
       rule (an uncapped Gold above Province means $8 always buys Gold, so the
-      strategy can never green). Their position relative to gated rules stays
-      free — orderings like "first 3 Torturers before greening" are legitimate
-      strategy space the GA should explore;
+      strategy can never green), and Colony is never shadowed by an
+      unconditional Province rule (Province matches whenever Colony does, so
+      $11+ would always buy Province). Their position relative to gated rules
+      stays free — orderings like "first 3 Torturers before greening" are
+      legitimate strategy space the GA should explore;
     - never an unconditional Copper/Curse gain rule (pure junk buys);
     - Gold/Silver/Copper (and Platinum, when on the board) present in
       treasure_priority so coins get played.
@@ -379,6 +381,19 @@ def normalize_menu(strategy: BaseStrategy, info: KingdomInfo) -> BaseStrategy:
         green_idx = next((i for i, r in enumerate(gain) if r.card_name == green), None)
         if green_idx is not None and green_idx > shadow_idx:
             gain.insert(shadow_idx, gain.pop(green_idx))
+
+    # On Colony boards an *unconditional* Province rule above Colony shadows
+    # it the same way: Province matches whenever Colony is affordable, so
+    # $11+ hands always buy Province. Move the first Colony rule directly
+    # above such a Province rule; a gated Province above Colony stays legal.
+    if info.has_colony:
+        province_idx = next(
+            (i for i, r in enumerate(gain) if r.card_name == "Province" and r.condition is None),
+            None,
+        )
+        colony_idx = next((i for i, r in enumerate(gain) if r.card_name == "Colony"), None)
+        if province_idx is not None and colony_idx is not None and colony_idx > province_idx:
+            gain.insert(province_idx, gain.pop(colony_idx))
 
     treasure_names = {r.card_name for r in strategy.treasure_priority}
     if info.has_platinum and "Platinum" not in treasure_names:

--- a/dominion/simulation/structured_genome.py
+++ b/dominion/simulation/structured_genome.py
@@ -31,7 +31,11 @@ from dominion.strategy.enhanced_strategy import PriorityRule
 from dominion.strategy.strategies.base_strategy import BaseStrategy
 
 # Cards handled by the menu skeleton rather than treated as kingdom picks.
-BASIC_CARDS = {"Copper", "Silver", "Gold", "Estate", "Duchy", "Province", "Curse"}
+BASIC_CARDS = {"Copper", "Silver", "Gold", "Platinum", "Estate", "Duchy", "Province", "Colony", "Curse"}
+
+# Unconditional rules for these shadow every cheaper buy below them, so the
+# greening block must always sort above them (see normalize_menu).
+_BASIC_TREASURES = ("Gold", "Silver", "Platinum")
 
 _MAX_IN_DECK_RE = re.compile(r"PriorityRule\.max_in_deck\('([^']+)', (\d+)\)")
 
@@ -49,11 +53,17 @@ class KingdomInfo:
     terminal_draw: list[str] = field(default_factory=list)  # 0 actions, +2 or more cards
     other_terminals: list[str] = field(default_factory=list)
     costs: dict[str, int] = field(default_factory=dict)
+    has_colony: bool = False
+    has_platinum: bool = False
 
     @classmethod
     def from_kingdom(cls, kingdom_cards: list[str]) -> "KingdomInfo":
         info = cls(kingdom_cards=list(kingdom_cards))
         for name in kingdom_cards:
+            if name == "Colony":
+                info.has_colony = True
+            elif name == "Platinum":
+                info.has_platinum = True
             if name in BASIC_CARDS:
                 continue
             try:
@@ -137,10 +147,13 @@ def _gate_for(card: str, info: KingdomInfo, rng):
     """Re-gate vocabulary used by mutation, dispatched on the card's role."""
     if card in ("Province", "Duchy", "Estate"):
         return _greening_gate(card, rng)
+    if card == "Colony":
+        # Colony is the win condition on Colony boards — keep it ungated.
+        return None
     if card == "Silver":
         return _silver_gate(rng)
-    if card == "Gold":
-        return None if rng.random() < 0.8 else PriorityRule.max_in_deck("Gold", rng.randint(2, 6))
+    if card in ("Gold", "Platinum"):
+        return None if rng.random() < 0.8 else PriorityRule.max_in_deck(card, rng.randint(2, 6))
     if card == "Copper":
         # Copper is only ever bought deliberately (e.g. Gardens piles) —
         # always keep it gated so it can't become an unconditional junk buy.
@@ -158,7 +171,10 @@ def random_menu_strategy(info: KingdomInfo, rng=_random_module) -> BaseStrategy:
     economy backbone, and a few capped kingdom picks ordered roughly by cost."""
     strategy = BaseStrategy()
 
-    gain: list[PriorityRule] = [PriorityRule("Province")]
+    gain: list[PriorityRule] = []
+    if info.has_colony:
+        gain.append(PriorityRule("Colony"))
+    gain.append(PriorityRule("Province"))
     if rng.random() < 0.9:
         gain.append(PriorityRule("Duchy", _greening_gate("Duchy", rng)))
     if rng.random() < 0.4:
@@ -176,6 +192,8 @@ def random_menu_strategy(info: KingdomInfo, rng=_random_module) -> BaseStrategy:
         (info.costs.get(card, 0) + rng.uniform(-1.5, 1.5), PriorityRule(card, _pick_gate(card, info, rng)))
         for card in picks
     ]
+    if info.has_platinum:
+        entries.append((9 + rng.uniform(-1.5, 1.5), PriorityRule("Platinum")))
     entries.append((6 + rng.uniform(-1.5, 1.5), PriorityRule("Gold")))
     entries.append((3 + rng.uniform(-1.5, 1.5), PriorityRule("Silver", _silver_gate(rng))))
     entries.sort(key=lambda pair: pair[0], reverse=True)
@@ -191,10 +209,11 @@ def random_menu_strategy(info: KingdomInfo, rng=_random_module) -> BaseStrategy:
         action.extend(PriorityRule(card) for card in group)
     strategy.action_priority = action
 
-    # Treasures: Gold, kingdom treasures (cost order), Silver, Copper.
+    # Treasures: Platinum, Gold, kingdom treasures (cost order), Silver, Copper.
     kingdom_treasures = sorted(info.treasure_cards, key=lambda c: -info.costs.get(c, 0))
     strategy.treasure_priority = (
-        [PriorityRule("Gold")]
+        ([PriorityRule("Platinum")] if info.has_platinum else [])
+        + [PriorityRule("Gold")]
         + [PriorityRule(c) for c in kingdom_treasures]
         + [PriorityRule("Silver"), PriorityRule("Copper")]
     )
@@ -315,8 +334,15 @@ def normalize_menu(strategy: BaseStrategy, info: KingdomInfo) -> BaseStrategy:
 
     - exactly no duplicate (card, gate) rules — crossover splices can clone;
     - a Province gain rule exists (without one the strategy cannot win);
+    - on Colony boards, a Colony gain rule exists;
+    - Province/Colony are never shadowed by an *unconditional* basic-treasure
+      rule (an uncapped Gold above Province means $8 always buys Gold, so the
+      strategy can never green). Their position relative to gated rules stays
+      free — orderings like "first 3 Torturers before greening" are legitimate
+      strategy space the GA should explore;
     - never an unconditional Copper/Curse gain rule (pure junk buys);
-    - Gold/Silver/Copper present in treasure_priority so coins get played.
+    - Gold/Silver/Copper (and Platinum, when on the board) present in
+      treasure_priority so coins get played.
     """
     seen: set[tuple] = set()
     deduped: list[PriorityRule] = []
@@ -334,8 +360,29 @@ def normalize_menu(strategy: BaseStrategy, info: KingdomInfo) -> BaseStrategy:
 
     if not any(r.card_name == "Province" for r in strategy.gain_priority):
         strategy.gain_priority.insert(0, PriorityRule("Province"))
+    if info.has_colony and not any(r.card_name == "Colony" for r in strategy.gain_priority):
+        strategy.gain_priority.insert(0, PriorityRule("Colony"))
+
+    # Non-shadowing: an unconditional Gold/Silver/Platinum rule above the
+    # greening cards would absorb every $6+/$8+ buy forever. Move each
+    # greening card directly above the first such rule; gated rules above
+    # Province/Colony are left alone (deliberately evolvable ordering).
+    gain = strategy.gain_priority
+    greens = ["Province"] + (["Colony"] if info.has_colony else [])
+    for green in greens:
+        shadow_idx = next(
+            (i for i, r in enumerate(gain) if r.card_name in _BASIC_TREASURES and r.condition is None),
+            None,
+        )
+        if shadow_idx is None:
+            break
+        green_idx = next((i for i, r in enumerate(gain) if r.card_name == green), None)
+        if green_idx is not None and green_idx > shadow_idx:
+            gain.insert(shadow_idx, gain.pop(green_idx))
 
     treasure_names = {r.card_name for r in strategy.treasure_priority}
+    if info.has_platinum and "Platinum" not in treasure_names:
+        strategy.treasure_priority.insert(0, PriorityRule("Platinum"))
     for name in ("Gold", "Silver", "Copper"):
         if name not in treasure_names:
             strategy.treasure_priority.append(PriorityRule(name))

--- a/tests/test_compound_mutation.py
+++ b/tests/test_compound_mutation.py
@@ -161,9 +161,13 @@ class TestCompoundSerializationRoundTrip:
 class TestMutateCanProduceCompound:
     def test_mutation_eventually_produces_compound_condition(self):
         from copy import deepcopy
+        # structured_genome=False: this test pins the legacy free-form
+        # mutator, whose vocabulary includes card_in_play compounds. The
+        # structured menu mutator uses a curated gate vocabulary instead.
         trainer = GeneticTrainer(
             ["Village", "Smithy", "Market", "Laboratory", "Witch"],
             population_size=1, generations=1, mutation_rate=1.0,
+            structured_genome=False,
         )
         seed = BaseStrategy()
         seed.name = "seed"

--- a/tests/test_structured_genome.py
+++ b/tests/test_structured_genome.py
@@ -1,0 +1,312 @@
+"""Tests for the structured "buy menu" genome operators.
+
+The structured genome constrains the GA's search space: random individuals
+are coherent menus (greening block + capped kingdom picks over a treasure
+backbone), mutations are menu edits from a curated gate vocabulary, and
+normalization enforces the invariants every viable strategy needs.
+"""
+
+from __future__ import annotations
+
+import random
+import types
+
+from dominion.simulation.genetic_trainer import GeneticTrainer
+from dominion.simulation.structured_genome import (
+    KingdomInfo,
+    kingdom_similarity,
+    mutate_menu,
+    normalize_menu,
+    random_menu_strategy,
+)
+from dominion.strategy.enhanced_strategy import PriorityRule
+from dominion.strategy.strategies.base_strategy import BaseStrategy
+
+KINGDOM = ["Village", "Smithy", "Market", "Festival", "Laboratory", "Witch", "Chapel", "Moat"]
+
+
+def _info() -> KingdomInfo:
+    return KingdomInfo.from_kingdom(KINGDOM)
+
+
+def _mock_state(turn_number=5, provinces_left=8):
+    state = types.SimpleNamespace()
+    state.turn_number = turn_number
+    state.supply = {"Province": provinces_left}
+    state.empty_piles = 0
+    state.players = []
+    return state
+
+
+def _mock_player():
+    player = types.SimpleNamespace()
+    player.coins = 3
+    player.actions = 1
+    player.buys = 1
+    player.hand = []
+    player.in_play = []
+    player.count_in_deck = lambda _c: 0
+    player.all_cards = lambda: []
+    player.get_victory_points = lambda _g=None: 3
+    player.actions_gained_this_turn = 0
+    player.cards_gained_this_turn = 0
+    return player
+
+
+class TestKingdomInfo:
+    def test_role_classification(self):
+        info = _info()
+        assert "Village" in info.villages          # +2 actions
+        assert "Festival" in info.villages         # +2 actions
+        assert "Market" in info.cantrips           # +1 action
+        assert "Laboratory" in info.cantrips       # +1 action
+        assert "Smithy" in info.terminal_draw      # 0 actions, +3 cards
+        assert "Witch" in info.terminal_draw       # 0 actions, +2 cards
+        assert "Chapel" in info.other_terminals
+        assert set(info.gainable) == set(KINGDOM)
+
+    def test_basic_cards_are_not_picks(self):
+        info = KingdomInfo.from_kingdom(["Village", "Copper", "Province"])
+        assert info.gainable == ["Village"]
+
+    def test_unknown_cards_are_skipped(self):
+        info = KingdomInfo.from_kingdom(["Village", "NotACard"])
+        assert info.gainable == ["Village"]
+
+
+class TestRandomMenuStrategy:
+    def test_menus_are_coherent(self):
+        random.seed(3)
+        info = _info()
+        for _ in range(30):
+            s = random_menu_strategy(info)
+            names = [r.card_name for r in s.gain_priority]
+            # Province exists and leads the menu.
+            assert names[0] == "Province"
+            # The economy backbone is present.
+            assert "Gold" in names and "Silver" in names
+            # No junk buys.
+            assert "Copper" not in names and "Curse" not in names
+            # Picks are kingdom cards.
+            assert all(n in set(KINGDOM) | {"Province", "Duchy", "Estate", "Gold", "Silver"} for n in names)
+
+    def test_kingdom_picks_are_capped(self):
+        random.seed(4)
+        info = _info()
+        s = random_menu_strategy(info)
+        for rule in s.gain_priority:
+            if rule.card_name in KINGDOM:
+                source = getattr(rule.condition, "_source", "")
+                assert "max_in_deck" in source, (
+                    f"{rule.card_name} has no deck cap: {source!r}"
+                )
+
+    def test_action_priority_orders_villages_first(self):
+        random.seed(5)
+        info = _info()
+        s = random_menu_strategy(info)
+        names = [r.card_name for r in s.action_priority]
+        assert set(names) == set(info.action_cards)
+        village_idx = [names.index(c) for c in info.villages]
+        terminal_idx = [names.index(c) for c in info.terminal_draw + info.other_terminals]
+        assert max(village_idx) < min(terminal_idx)
+
+    def test_conditions_are_callable_and_evaluate(self):
+        random.seed(6)
+        info = _info()
+        state, player = _mock_state(), _mock_player()
+        for _ in range(20):
+            s = random_menu_strategy(info)
+            for rule_list in (s.gain_priority, s.action_priority, s.trash_priority):
+                for rule in rule_list:
+                    if rule.condition is not None:
+                        assert callable(rule.condition)
+                        assert isinstance(rule.condition(state, player), bool)
+                        assert hasattr(rule.condition, "_source")
+
+    def test_treasure_priority_plays_gold_before_copper(self):
+        random.seed(7)
+        s = random_menu_strategy(_info())
+        names = [r.card_name for r in s.treasure_priority]
+        assert names.index("Gold") < names.index("Silver") < names.index("Copper")
+
+
+class TestMutateMenu:
+    def test_invariants_survive_heavy_mutation(self):
+        random.seed(8)
+        info = _info()
+        s = random_menu_strategy(info)
+        state, player = _mock_state(), _mock_player()
+        for _ in range(200):
+            s = mutate_menu(s, info, rate=1.0)
+            s = normalize_menu(s, info)
+            names = [r.card_name for r in s.gain_priority]
+            assert "Province" in names
+            assert "Curse" not in names
+            for rule in s.gain_priority:
+                if rule.condition is not None:
+                    assert isinstance(bool(rule.condition(state, player)), bool)
+
+    def test_cap_adjustment_changes_cap_value(self):
+        random.seed(9)
+        info = _info()
+        s = BaseStrategy()
+        s.gain_priority = [
+            PriorityRule("Province"),
+            PriorityRule("Smithy", PriorityRule.max_in_deck("Smithy", 2)),
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+        ]
+        s.action_priority = [PriorityRule("Smithy")]
+        s.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
+        s.trash_priority = []
+
+        seen_caps = set()
+        for _ in range(120):
+            mutate_menu(s, info, rate=1.0)
+            for rule in s.gain_priority:
+                if rule.card_name == "Smithy" and rule.condition is not None:
+                    src = getattr(rule.condition, "_source", "")
+                    if "max_in_deck" in src:
+                        seen_caps.add(src)
+        assert len(seen_caps) > 1, f"cap never changed: {seen_caps}"
+
+    def test_mutation_can_add_missing_kingdom_pick(self):
+        random.seed(10)
+        info = _info()
+        s = BaseStrategy()
+        s.gain_priority = [PriorityRule("Province"), PriorityRule("Gold"), PriorityRule("Silver")]
+        s.action_priority = []
+        s.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
+        s.trash_priority = []
+
+        for _ in range(100):
+            mutate_menu(s, info, rate=1.0)
+            if any(r.card_name in KINGDOM for r in s.gain_priority):
+                break
+        assert any(r.card_name in KINGDOM for r in s.gain_priority)
+
+
+class TestNormalizeMenu:
+    def test_reinserts_province(self):
+        info = _info()
+        s = BaseStrategy()
+        s.gain_priority = [PriorityRule("Gold"), PriorityRule("Silver")]
+        s.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
+        normalize_menu(s, info)
+        assert s.gain_priority[0].card_name == "Province"
+
+    def test_dedupes_identical_rules(self):
+        info = _info()
+        cond = PriorityRule.max_in_deck("Smithy", 2)
+        s = BaseStrategy()
+        s.gain_priority = [
+            PriorityRule("Province"),
+            PriorityRule("Smithy", cond),
+            PriorityRule("Smithy", cond),
+            PriorityRule("Gold"),
+            PriorityRule("Gold"),
+        ]
+        s.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
+        normalize_menu(s, info)
+        names = [(r.card_name, getattr(r.condition, "_source", None)) for r in s.gain_priority]
+        assert len(names) == len(set(names))
+
+    def test_drops_curse_and_unconditional_copper(self):
+        info = _info()
+        s = BaseStrategy()
+        s.gain_priority = [
+            PriorityRule("Province"),
+            PriorityRule("Curse"),
+            PriorityRule("Copper"),
+            PriorityRule("Copper", PriorityRule.provinces_left("<=", 1)),
+        ]
+        s.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
+        normalize_menu(s, info)
+        names = [r.card_name for r in s.gain_priority]
+        assert "Curse" not in names
+        # The gated Copper rule survives; the unconditional one is dropped.
+        coppers = [r for r in s.gain_priority if r.card_name == "Copper"]
+        assert len(coppers) == 1 and coppers[0].condition is not None
+
+    def test_ensures_basic_treasures_playable(self):
+        info = _info()
+        s = BaseStrategy()
+        s.gain_priority = [PriorityRule("Province")]
+        s.treasure_priority = [PriorityRule("Gold")]
+        normalize_menu(s, info)
+        names = [r.card_name for r in s.treasure_priority]
+        assert "Silver" in names and "Copper" in names
+
+
+class TestKingdomSimilarity:
+    def _menu(self, *kingdom_picks: str) -> BaseStrategy:
+        s = BaseStrategy()
+        s.gain_priority = (
+            [PriorityRule("Province"), PriorityRule("Duchy"), PriorityRule("Gold")]
+            + [PriorityRule(c) for c in kingdom_picks]
+            + [PriorityRule("Silver")]
+        )
+        return s
+
+    def test_shared_skeleton_does_not_count(self):
+        a = self._menu("Witch", "Chapel")
+        b = self._menu("Smithy", "Village")
+        assert kingdom_similarity(a, b) == 0.0
+
+    def test_identical_picks_score_one(self):
+        a = self._menu("Witch", "Chapel")
+        b = self._menu("Witch", "Chapel")
+        assert kingdom_similarity(a, b) == 1.0
+
+    def test_pure_big_money_menus_share_a_niche(self):
+        a = self._menu()
+        b = self._menu()
+        assert kingdom_similarity(a, b) == 1.0
+
+
+class TestTrainerIntegration:
+    def test_structured_is_default_and_produces_menus(self):
+        trainer = GeneticTrainer(KINGDOM, population_size=1, generations=1)
+        assert trainer.structured_genome is True
+        random.seed(11)
+        s = trainer.create_random_strategy()
+        names = [r.card_name for r in s.gain_priority]
+        assert names[0] == "Province"
+        assert "Copper" not in names
+
+    def test_legacy_flag_restores_freeform_init(self):
+        trainer = GeneticTrainer(
+            KINGDOM, population_size=1, generations=1, structured_genome=False
+        )
+        random.seed(12)
+        # Legacy init shuffles all cards including Copper into the gain list.
+        seen_copper = any(
+            any(r.card_name == "Copper" for r in trainer.create_random_strategy().gain_priority)
+            for _ in range(20)
+        )
+        assert seen_copper
+
+    def test_structured_mutation_preserves_invariants(self):
+        trainer = GeneticTrainer(KINGDOM, population_size=1, generations=1, mutation_rate=1.0)
+        random.seed(13)
+        s = trainer.create_random_strategy()
+        for _ in range(50):
+            s = trainer._mutate(s)
+            s = trainer._normalize(s)
+        names = [r.card_name for r in s.gain_priority]
+        assert "Province" in names
+        assert "Curse" not in names
+
+    def test_structured_crossover_children_are_normalized(self):
+        trainer = GeneticTrainer(KINGDOM, population_size=4, generations=1)
+        random.seed(14)
+        pop = [trainer.create_random_strategy() for _ in range(4)]
+        next_pop = trainer.create_next_generation(pop, [50.0, 40.0, 30.0, 20.0])
+        for s in next_pop:
+            keys = [
+                (r.card_name, getattr(r.condition, "_source", None) if r.condition else None)
+                for r in s.gain_priority
+            ]
+            assert len(keys) == len(set(keys)), f"duplicate rules survived: {keys}"
+            assert any(r.card_name == "Province" for r in s.gain_priority)

--- a/tests/test_structured_genome.py
+++ b/tests/test_structured_genome.py
@@ -300,8 +300,32 @@ class TestNormalizeMenu:
         s.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
         normalize_menu(s, info)
         names = [r.card_name for r in s.gain_priority]
-        assert names.index("Province") < names.index("Gold")
-        assert names.index("Colony") < names.index("Gold")
+        # Composition: Colony must lead — an unconditional Province above it
+        # would shadow Colony at $11+ just like the Gold shadowed both.
+        assert names == ["Colony", "Province", "Gold"]
+
+    def test_moves_colony_above_unconditional_province(self):
+        info = _colony_info()
+        s = BaseStrategy()
+        s.gain_priority = [
+            PriorityRule("Province"),
+            PriorityRule("Colony"),
+        ]
+        s.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
+        normalize_menu(s, info)
+        names = [r.card_name for r in s.gain_priority]
+        assert names == ["Colony", "Province"]
+
+    def test_leaves_gated_province_above_colony(self):
+        info = _colony_info()
+        gated_province = PriorityRule("Province", PriorityRule.provinces_left("<=", 4))
+        s = BaseStrategy()
+        s.gain_priority = [gated_province, PriorityRule("Colony")]
+        s.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
+        normalize_menu(s, info)
+        names = [(r.card_name, r.condition is not None) for r in s.gain_priority]
+        # A gated Province above Colony is legitimate strategy space — untouched.
+        assert names == [("Province", True), ("Colony", False)]
 
     def test_leaves_capped_pick_and_gated_gold_above_province(self):
         info = _info()

--- a/tests/test_structured_genome.py
+++ b/tests/test_structured_genome.py
@@ -23,10 +23,15 @@ from dominion.strategy.enhanced_strategy import PriorityRule
 from dominion.strategy.strategies.base_strategy import BaseStrategy
 
 KINGDOM = ["Village", "Smithy", "Market", "Festival", "Laboratory", "Witch", "Chapel", "Moat"]
+COLONY_KINGDOM = KINGDOM + ["Colony", "Platinum"]
 
 
 def _info() -> KingdomInfo:
     return KingdomInfo.from_kingdom(KINGDOM)
+
+
+def _colony_info() -> KingdomInfo:
+    return KingdomInfo.from_kingdom(COLONY_KINGDOM)
 
 
 def _mock_state(turn_number=5, provinces_left=8):
@@ -72,6 +77,17 @@ class TestKingdomInfo:
     def test_unknown_cards_are_skipped(self):
         info = KingdomInfo.from_kingdom(["Village", "NotACard"])
         assert info.gainable == ["Village"]
+
+    def test_colony_and_platinum_are_basic_not_picks(self):
+        info = KingdomInfo.from_kingdom(["Village", "Colony", "Platinum"])
+        assert info.gainable == ["Village"]
+        assert info.has_colony is True
+        assert info.has_platinum is True
+
+    def test_colony_flags_default_off(self):
+        info = _info()
+        assert info.has_colony is False
+        assert info.has_platinum is False
 
 
 class TestRandomMenuStrategy:
@@ -129,6 +145,26 @@ class TestRandomMenuStrategy:
         s = random_menu_strategy(_info())
         names = [r.card_name for r in s.treasure_priority]
         assert names.index("Gold") < names.index("Silver") < names.index("Copper")
+
+    def test_colony_board_menus(self):
+        random.seed(15)
+        info = _colony_info()
+        for _ in range(30):
+            s = random_menu_strategy(info)
+            names = [r.card_name for r in s.gain_priority]
+            # Colony leads the greening block, unconditionally; Province follows.
+            assert names[0] == "Colony"
+            assert s.gain_priority[0].condition is None
+            assert "Province" in names
+            # Platinum joins the backbone above Gold, never as a capped pick.
+            assert names.index("Platinum") < names.index("Gold")
+            for rule in s.gain_priority:
+                if rule.card_name in ("Colony", "Platinum"):
+                    source = getattr(rule.condition, "_source", "") if rule.condition else ""
+                    assert "max_in_deck" not in source
+            # Platinum is played before Gold.
+            treasures = [r.card_name for r in s.treasure_priority]
+            assert treasures.index("Platinum") < treasures.index("Gold")
 
 
 class TestMutateMenu:
@@ -229,6 +265,56 @@ class TestNormalizeMenu:
         coppers = [r for r in s.gain_priority if r.card_name == "Copper"]
         assert len(coppers) == 1 and coppers[0].condition is not None
 
+    def test_reinserts_colony_on_colony_boards(self):
+        info = _colony_info()
+        s = BaseStrategy()
+        s.gain_priority = [PriorityRule("Province"), PriorityRule("Gold"), PriorityRule("Silver")]
+        s.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
+        normalize_menu(s, info)
+        assert s.gain_priority[0].card_name == "Colony"
+        # Platinum is restored to treasure_priority, ahead of Gold.
+        treasures = [r.card_name for r in s.treasure_priority]
+        assert treasures.index("Platinum") < treasures.index("Gold")
+
+    def test_moves_province_above_unconditional_gold(self):
+        info = _info()
+        s = BaseStrategy()
+        s.gain_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Province"),
+        ]
+        s.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
+        normalize_menu(s, info)
+        names = [r.card_name for r in s.gain_priority]
+        assert names.index("Province") < names.index("Gold")
+
+    def test_moves_colony_and_province_above_unconditional_treasures(self):
+        info = _colony_info()
+        s = BaseStrategy()
+        s.gain_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Province"),
+            PriorityRule("Colony"),
+        ]
+        s.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
+        normalize_menu(s, info)
+        names = [r.card_name for r in s.gain_priority]
+        assert names.index("Province") < names.index("Gold")
+        assert names.index("Colony") < names.index("Gold")
+
+    def test_leaves_capped_pick_and_gated_gold_above_province(self):
+        info = _info()
+        capped_pick = PriorityRule("Smithy", PriorityRule.max_in_deck("Smithy", 3))
+        gated_gold = PriorityRule("Gold", PriorityRule.max_in_deck("Gold", 4))
+        s = BaseStrategy()
+        s.gain_priority = [capped_pick, gated_gold, PriorityRule("Province"), PriorityRule("Silver", PriorityRule.turn_number("<=", 10))]
+        s.treasure_priority = [PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")]
+        normalize_menu(s, info)
+        names = [r.card_name for r in s.gain_priority]
+        # Gated rules above Province are legitimate strategy space — untouched.
+        assert names == ["Smithy", "Gold", "Province", "Silver"]
+
     def test_ensures_basic_treasures_playable(self):
         info = _info()
         s = BaseStrategy()
@@ -279,6 +365,8 @@ class TestTrainerIntegration:
         trainer = GeneticTrainer(
             KINGDOM, population_size=1, generations=1, structured_genome=False
         )
+        # Legacy mode skips structured-genome setup entirely.
+        assert trainer._kingdom_info is None
         random.seed(12)
         # Legacy init shuffles all cards including Copper into the gain list.
         seen_copper = any(


### PR DESCRIPTION
## Why

Follow-up to #294. With evaluation fixed, the binding constraint on strategy quality was the genome: free-form mutation drew arbitrary conditions from a 17-primitive vocabulary and assembled gain lists in any order, so random individuals opened with Copper above Province, champions accumulated duplicate rules, and almost every mutation was noise.

## What changed

New module `dominion/simulation/structured_genome.py`; `GeneticTrainer(structured_genome=True)` is the default, `False` restores the legacy operators. The phenotype is still a plain `EnhancedStrategy` rule list — seeds, serialization, pruning, and simplification are untouched. Only how the GA *moves through* strategy space changes:

- **Coherent random init** — every individual is a real menu: greening block (Province lead, pile-gated Duchy/Estate) over a Gold/Silver backbone, interleaved by cost with 2–6 kingdom picks that each carry a role-appropriate `max_in_deck` cap; villages-first action ordering.
- **Menu-edit mutations** — adjacent swaps, entry relocation, cap nudges (±1), pick add/drop, and re-gating from a small curated vocabulary dispatched on card role (greening gates, Silver gates, capped engine gates).
- **Normalization invariants** — dedup `(card, gate)` rules, a Province rule always exists, never Curse / unconditional Copper gains, basic treasures always playable.
- **Kingdom-aware fitness sharing** — similarity counts top-5 *kingdom picks*, not the shared greening skeleton (which would put the whole population in one niche).

## Validation (matched ~39k-game budgets, cold start — no seed injection, `boards/siege_engine.txt`, both arms on the #294 evaluator)

| Matchup | Result |
|---|---|
| **Structured champion vs free-form champion** | **94.1%** (2,000 games) |
| Structured champion vs Big Money | 88.5% |
| Free-form champion vs Big Money | 33.7% (loses) |
| Structured champion vs best prior evolved strategy (v22 seed) | **97.1%** |
| Free-form champion vs same | 38.1% (loses) |

From a cold start the structured pipeline now produces a champion that crushes everything previously evolved on this board. The champion genome is 7 readable rules (Province → gated Duchy/Estate → Gold → capped Torturer ×3 → gated Silver) instead of the old 18-rule duplicate-laden lists.

Combined with #294: handing the system a board with *no* hand-written seeds now yields a strategy at 88.5% vs Big Money, where the pre-#294 pipeline's seeded champion measured ~79% and its cold-start output lost outright.

## Tests

22 new tests in `tests/test_structured_genome.py` (role classification, menu coherence, cap mutation, invariants under heavy mutation, crossover-child normalization, kingdom similarity, trainer integration). One legacy-vocabulary test pinned to `structured_genome=False`. Full suite: **1,678 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced structured genome mode for genetic strategy evolution, now enabled by default.
  * Added refined strategy construction, mutation, and normalization operators.
  * Implemented kingdom-based similarity metrics for improved genetic diversity management.

* **Tests**
  * Comprehensive test coverage for structured genome operators and trainer integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->