### PR TITLE
Board-derived island seeds; trick-scanner seeds and reuse on by default

### DIFF
--- a/dominion/analysis/island_seeds.py
+++ b/dominion/analysis/island_seeds.py
@@ -168,6 +168,27 @@ def augment_panel_with_compatible(
     return names
 
 
+def resolve_library_spec(board: BoardConfig, spec_key: str) -> EnhancedStrategy:
+    """Rebuild the library strategy whose entry ``spec`` equals ``spec_key``.
+
+    ``spec_key`` is a library entry *spec* (its ``module:function`` reference),
+    the canonical strategy identifier the ``"library"`` island kind keys on.
+
+    The candidate list must be a superset of whatever ``derive_island_specs``
+    could have produced: derive selects with the unbounded ``--reuse-top-k``,
+    so a fixed bound here would silently miss specs ranked beyond it. Use an
+    effectively-unbounded ``top_k`` and ``min_overlap=1`` (always <= derive's
+    ``reuse_min_overlap``) so the superset holds. Raises ``ValueError`` if no
+    entry matches, so a misconfigured island fails loudly.
+    """
+
+    entries = find_compatible_strategies(board.kingdom_cards, top_k=10_000, min_overlap=1)
+    for entry in entries:
+        if entry.spec == spec_key:
+            return entry.factory()
+    raise ValueError(f"Island seed not found in strategy library: {spec_key!r}")
+
+
 def resolve_island_seed(
     spec: IslandSpec,
     board: BoardConfig,
@@ -196,21 +217,7 @@ def resolve_island_seed(
         # not the display name: two library strategies can share a display name
         # but their specs are unique, so matching on the spec guarantees each
         # island resolves to its OWN strategy.
-        #
-        # The resolution lookup must be able to find any library spec that
-        # ``derive_island_specs`` could have produced. derive selects with
-        # ``top_k=reuse_top_k`` (the ``--reuse-top-k`` CLI flag is unbounded),
-        # so a fixed bound here would silently miss specs ranked beyond it and
-        # crash the island. Use an effectively-unbounded ``top_k`` so resolve's
-        # candidate list is a superset of derive's, and keep ``min_overlap=1``
-        # (always <= derive's ``reuse_min_overlap``, so the superset holds).
-        entries = find_compatible_strategies(
-            board.kingdom_cards, top_k=10_000, min_overlap=1
-        )
-        for entry in entries:
-            if entry.spec == spec.key:
-                return entry.factory()
-        raise ValueError(f"Island seed not found in strategy library: {spec.key!r}")
+        return resolve_library_spec(board, spec.key)
 
     if spec.kind == "trick":
         seeds = build_seed_genomes(board)

--- a/dominion/analysis/island_seeds.py
+++ b/dominion/analysis/island_seeds.py
@@ -84,6 +84,43 @@ def derive_island_specs(
     return specs[:max_islands]
 
 
+def augment_panel_with_compatible(
+    board: BoardConfig,
+    baseline_names: list[str],
+    strategy_loader,
+    *,
+    top_k: int = 3,
+    min_overlap: int = 2,
+) -> list[str]:
+    """Build the default opponent panel: baselines + board-compatible strategies.
+
+    The built-in baseline panel can collapse to just Big Money on boards whose
+    kingdom excludes the engine opponents (e.g. Lisbon), making default runs
+    silently weaker. The board-general fix is to fold in the board's compatible
+    library strategies, so every board trains against a panel stronger than
+    Big-Money-alone, derived from the board.
+
+    Panel names are re-resolved by name (via ``StrategyLoader.get_strategy``) in
+    both the island workers and ``scripts/island_merge.py``, so only names that
+    round-trip through the loader are kept. Compatible library entries that are
+    generated strategies the loader cannot resolve by name are skipped silently.
+    Order is preserved (baselines first, then compatible) and names are deduped.
+    """
+
+    names: list[str] = list(baseline_names)
+    seen = set(names)
+    for entry in find_compatible_strategies(
+        board.kingdom_cards, top_k=top_k, min_overlap=min_overlap
+    ):
+        if entry.name in seen:
+            continue
+        if strategy_loader.get_strategy(entry.name) is None:
+            continue
+        names.append(entry.name)
+        seen.add(entry.name)
+    return names
+
+
 def resolve_island_seed(
     spec: IslandSpec,
     board: BoardConfig,
@@ -108,8 +145,15 @@ def resolve_island_seed(
         return strategy
 
     if spec.kind == "library":
+        # The resolution lookup must be able to find any library spec that
+        # ``derive_island_specs`` could have produced. derive selects with
+        # ``top_k=reuse_top_k`` (the ``--reuse-top-k`` CLI flag is unbounded),
+        # so a fixed bound here would silently miss specs ranked beyond it and
+        # crash the island. Use an effectively-unbounded ``top_k`` so resolve's
+        # candidate list is a superset of derive's, and keep ``min_overlap=1``
+        # (always <= derive's ``reuse_min_overlap``, so the superset holds).
         entries = find_compatible_strategies(
-            board.kingdom_cards, top_k=10, min_overlap=1
+            board.kingdom_cards, top_k=10_000, min_overlap=1
         )
         for entry in entries:
             if entry.name == spec.key:

--- a/dominion/analysis/island_seeds.py
+++ b/dominion/analysis/island_seeds.py
@@ -58,30 +58,43 @@ def derive_island_specs(
 
     Library and trick islands come first (they carry the most board-specific
     information), then the Big Money archetype, then random islands pad the
-    roster to ``max_islands``. If the informed islands alone exceed
-    ``max_islands``, the roster is truncated — library entries are ranked by
-    overlap score and trick seeds follow scanner order, so the cut keeps the
-    strongest candidates.
+    roster to ``max_islands``. The Big Money archetype is *always* present in
+    the returned roster (assuming ``max_islands >= 1``): it is the speed-test
+    baseline every board should be measured against. When the informed islands
+    (library + trick) alone would fill or overflow the roster, Big Money's slot
+    is reserved — the informed specs are truncated to ``max_islands - 1`` and
+    Big Money takes the final slot. Library entries are ranked by overlap score
+    and trick seeds follow scanner order, so the cut keeps the strongest
+    candidates while preserving their ranked order.
     """
 
-    specs: list[IslandSpec] = []
+    informed: list[IslandSpec] = []
 
     for entry in find_compatible_strategies(
         board.kingdom_cards, top_k=reuse_top_k, min_overlap=reuse_min_overlap
     ):
-        specs.append(IslandSpec("library", entry.name, f"Reuse {entry.name}"))
+        informed.append(IslandSpec("library", entry.name, f"Reuse {entry.name}"))
 
     for index, (name, _strategy) in enumerate(build_seed_genomes(board)):
-        specs.append(IslandSpec("trick", str(index), name))
+        informed.append(IslandSpec("trick", str(index), name))
 
-    specs.append(IslandSpec("loader", "Big Money", "Big Money Island"))
+    if max_islands <= 0:
+        return []
+
+    big_money = IslandSpec("loader", "Big Money", "Big Money Island")
+
+    # Always reserve the final slot for the Big Money baseline. When the
+    # informed specs would fill or overflow the roster, keep the strongest
+    # ``max_islands - 1`` of them (ranked order preserved) and append Big Money.
+    informed = informed[: max_islands - 1]
+    specs: list[IslandSpec] = informed + [big_money]
 
     random_index = 0
     while len(specs) < max_islands:
         random_index += 1
         specs.append(IslandSpec("random", str(random_index), f"Random Island {random_index}"))
 
-    return specs[:max_islands]
+    return specs
 
 
 def augment_panel_with_compatible(

--- a/dominion/analysis/island_seeds.py
+++ b/dominion/analysis/island_seeds.py
@@ -1,0 +1,128 @@
+"""Board-derived island seeds for the island-model evolution pipeline.
+
+The island model runs one GeneticTrainer per *seed* — each seed a distinct
+theory of the kingdom — so the run escapes shared local optima. The original
+pipeline hardcoded six hand-written Lisbon strategies, which meant a new
+board required writing six seed strategies before islands could run at all.
+
+This module derives the island roster from the board itself:
+
+1. **Library reuse** — existing strategies whose referenced cards overlap
+   this kingdom (:func:`find_compatible_strategies`), each as its own island.
+2. **Trick seeds** — one island per mechanical interaction surfaced by the
+   trick scanner (:func:`build_seed_genomes`).
+3. **Big Money** — the archetype baseline island, always available.
+4. **Random islands** — unseeded lineages (the structured-genome random init
+   produces coherent menus, so these are real hypotheses, not noise) filling
+   the roster up to ``max_islands``.
+
+Island specs are plain dataclasses of strings: the pipeline runs each island
+in a spawned subprocess, and strategy objects (lambda conditions) cannot be
+serialized across that boundary. Workers rebuild the actual seed strategy
+from the spec via :func:`resolve_island_seed`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from dominion.analysis.seed_genomes import build_seed_genomes
+from dominion.analysis.strategy_library import find_compatible_strategies
+from dominion.boards.loader import BoardConfig
+from dominion.strategy.enhanced_strategy import EnhancedStrategy
+
+
+@dataclass(frozen=True)
+class IslandSpec:
+    """A subprocess-safe description of one island's starting point.
+
+    ``kind`` is one of ``"loader"`` (a registered strategy name), ``"library"``
+    (a compatible strategy from the reuse library, keyed by entry name),
+    ``"trick"`` (an index into ``build_seed_genomes(board)``), or ``"random"``
+    (no seed — the island starts from random structured menus).
+    """
+
+    kind: str
+    key: str
+    name: str
+
+
+def derive_island_specs(
+    board: BoardConfig,
+    max_islands: int = 6,
+    reuse_top_k: int = 3,
+    reuse_min_overlap: int = 2,
+) -> list[IslandSpec]:
+    """Derive an island roster for ``board``.
+
+    Library and trick islands come first (they carry the most board-specific
+    information), then the Big Money archetype, then random islands pad the
+    roster to ``max_islands``. If the informed islands alone exceed
+    ``max_islands``, the roster is truncated — library entries are ranked by
+    overlap score and trick seeds follow scanner order, so the cut keeps the
+    strongest candidates.
+    """
+
+    specs: list[IslandSpec] = []
+
+    for entry in find_compatible_strategies(
+        board.kingdom_cards, top_k=reuse_top_k, min_overlap=reuse_min_overlap
+    ):
+        specs.append(IslandSpec("library", entry.name, f"Reuse {entry.name}"))
+
+    for index, (name, _strategy) in enumerate(build_seed_genomes(board)):
+        specs.append(IslandSpec("trick", str(index), name))
+
+    specs.append(IslandSpec("loader", "Big Money", "Big Money Island"))
+
+    random_index = 0
+    while len(specs) < max_islands:
+        random_index += 1
+        specs.append(IslandSpec("random", str(random_index), f"Random Island {random_index}"))
+
+    return specs[:max_islands]
+
+
+def resolve_island_seed(
+    spec: IslandSpec,
+    board: BoardConfig,
+    strategy_loader,
+) -> Optional[EnhancedStrategy]:
+    """Rebuild the seed strategy for ``spec`` (inside the island subprocess).
+
+    Returns ``None`` for ``"random"`` islands — the caller simply skips seed
+    injection and lets the trainer start from random structured menus.
+    Raises ``ValueError`` if a named seed can no longer be found, so a
+    misconfigured island fails loudly instead of silently devolving into a
+    random island with a misleading name.
+    """
+
+    if spec.kind == "random":
+        return None
+
+    if spec.kind == "loader":
+        strategy = strategy_loader.get_strategy(spec.key)
+        if strategy is None:
+            raise ValueError(f"Island seed not found in strategy loader: {spec.key!r}")
+        return strategy
+
+    if spec.kind == "library":
+        entries = find_compatible_strategies(
+            board.kingdom_cards, top_k=10, min_overlap=1
+        )
+        for entry in entries:
+            if entry.name == spec.key:
+                return entry.factory()
+        raise ValueError(f"Island seed not found in strategy library: {spec.key!r}")
+
+    if spec.kind == "trick":
+        seeds = build_seed_genomes(board)
+        index = int(spec.key)
+        if index >= len(seeds):
+            raise ValueError(
+                f"Trick seed index {index} out of range ({len(seeds)} seeds on this board)"
+            )
+        return seeds[index][1]
+
+    raise ValueError(f"Unknown island spec kind: {spec.kind!r}")

--- a/dominion/analysis/island_seeds.py
+++ b/dominion/analysis/island_seeds.py
@@ -38,14 +38,44 @@ class IslandSpec:
     """A subprocess-safe description of one island's starting point.
 
     ``kind`` is one of ``"loader"`` (a registered strategy name), ``"library"``
-    (a compatible strategy from the reuse library, keyed by entry name),
+    (a compatible strategy from the reuse library, keyed by the entry *spec* —
+    its ``module:function`` reference, the canonical strategy identifier — so
+    two library strategies that share a display name never collide on the key),
     ``"trick"`` (an index into ``build_seed_genomes(board)``), or ``"random"``
     (no seed — the island starts from random structured menus).
+
+    ``name`` is the island's human-readable identity: it becomes the GA
+    champion name, the output filename, and the log prefix. The roster returned
+    by :func:`derive_island_specs` guarantees every ``name`` is unique, since a
+    collision would corrupt those outputs regardless of island kind.
     """
 
     kind: str
     key: str
     name: str
+
+
+def _dedupe_names(specs: list[IslandSpec]) -> list[IslandSpec]:
+    """Return ``specs`` with every ``IslandSpec.name`` made unique.
+
+    Two islands sharing a display name collide on output filenames and log
+    identification (the name becomes the champion name / saved ``.py`` file /
+    log prefix in ``scripts/island_evolve.py``), so the roster must guarantee
+    uniqueness across all kinds. When a name repeats, later occurrences get a
+    deterministic ``" (2)"``, ``" (3)"`` suffix — stable for a given board and
+    readable in logs. Keys are left untouched (a library spec keyed by its
+    unique ``module:function`` spec already resolves correctly)."""
+
+    seen: dict[str, int] = {}
+    out: list[IslandSpec] = []
+    for spec in specs:
+        count = seen.get(spec.name, 0) + 1
+        seen[spec.name] = count
+        if count == 1:
+            out.append(spec)
+        else:
+            out.append(IslandSpec(spec.kind, spec.key, f"{spec.name} ({count})"))
+    return out
 
 
 def derive_island_specs(
@@ -73,7 +103,7 @@ def derive_island_specs(
     for entry in find_compatible_strategies(
         board.kingdom_cards, top_k=reuse_top_k, min_overlap=reuse_min_overlap
     ):
-        informed.append(IslandSpec("library", entry.name, f"Reuse {entry.name}"))
+        informed.append(IslandSpec("library", entry.spec, f"Reuse {entry.name}"))
 
     for index, (name, _strategy) in enumerate(build_seed_genomes(board)):
         informed.append(IslandSpec("trick", str(index), name))
@@ -94,7 +124,11 @@ def derive_island_specs(
         random_index += 1
         specs.append(IslandSpec("random", str(random_index), f"Random Island {random_index}"))
 
-    return specs
+    # Two library strategies can share a display name (distinct module:function
+    # specs, same ``strategy.name``), and a library name can in principle clash
+    # with a trick/loader name. Names drive output filenames and log identity,
+    # so dedupe across the whole roster before returning.
+    return _dedupe_names(specs)
 
 
 def augment_panel_with_compatible(
@@ -158,6 +192,11 @@ def resolve_island_seed(
         return strategy
 
     if spec.kind == "library":
+        # ``spec.key`` is the entry *spec* (its ``module:function`` reference),
+        # not the display name: two library strategies can share a display name
+        # but their specs are unique, so matching on the spec guarantees each
+        # island resolves to its OWN strategy.
+        #
         # The resolution lookup must be able to find any library spec that
         # ``derive_island_specs`` could have produced. derive selects with
         # ``top_k=reuse_top_k`` (the ``--reuse-top-k`` CLI flag is unbounded),
@@ -169,7 +208,7 @@ def resolve_island_seed(
             board.kingdom_cards, top_k=10_000, min_overlap=1
         )
         for entry in entries:
-            if entry.name == spec.key:
+            if entry.spec == spec.key:
                 return entry.factory()
         raise ValueError(f"Island seed not found in strategy library: {spec.key!r}")
 

--- a/dominion/runner.py
+++ b/dominion/runner.py
@@ -141,9 +141,19 @@ def main():
     )
     parser.add_argument(
         "--reuse-compatible-strategies",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=True,
         help="Automatically reuse existing strategies whose referenced cards overlap this board. "
-        "Selected strategies are injected as seeds and added to the baseline panel.",
+        "Selected strategies are injected as seeds and added to the baseline panel. "
+        "On by default; disable with --no-reuse-compatible-strategies.",
+    )
+    parser.add_argument(
+        "--trick-seeds",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Seed the population with trick-scanner-derived strategies when --board is given "
+        "(one seed per surfaced mechanical interaction). On by default; disable with "
+        "--no-trick-seeds.",
     )
     parser.add_argument(
         "--reuse-top-k",
@@ -265,8 +275,10 @@ def main():
             else:
                 logger.info("No reusable strategies met the compatibility threshold")
         except Exception as exc:
-            logger.error("Failed to discover reusable strategies: %s", exc)
-            sys.exit(1)
+            # Reuse is a default-on enrichment, not a precondition — a broken
+            # strategy file in the library must not kill the training run.
+            logger.warning("Skipping strategy reuse — discovery failed: %s", exc)
+            reusable_entries = []
 
     # Inject seed strategies if provided or discovered
     seed_specs = []
@@ -288,6 +300,26 @@ def main():
         except Exception as exc:
             logger.error("Failed to load seed strategy %s: %s", spec, exc)
             sys.exit(1)
+
+    # Trick-scanner seeds: one strategy per mechanical interaction surfaced
+    # on this board, so the GA starts with the trick encoded instead of
+    # having to rediscover it by random mutation. Mirrors evolve.py.
+    if args.trick_seeds and board_config is not None:
+        from dominion.analysis.seed_genomes import build_seed_genomes
+
+        try:
+            trick_seeds = build_seed_genomes(board_config)
+        except Exception as exc:
+            logger.warning("Skipping trick seeds — scanner failed: %s", exc)
+            trick_seeds = []
+        if trick_seeds:
+            trainer.inject_strategies([strategy for _, strategy in trick_seeds])
+            logger.info(
+                "Injected trick-scanner seeds: %s",
+                ", ".join(name for name, _ in trick_seeds),
+            )
+        else:
+            logger.info("Trick scanner surfaced no interactions for this board")
 
     # Set baseline panel (preferred) or single baseline
     panel: list = []

--- a/dominion/runner.py
+++ b/dominion/runner.py
@@ -112,6 +112,26 @@ def save_strategy_as_python(strategy: EnhancedStrategy, path: Path, class_name: 
     path.write_text("\n".join(lines), encoding="utf-8")
 
 
+def merge_baseline_panel(base_panel: list, reused: list) -> list:
+    """Return ``base_panel`` followed by the ``reused`` strategies not already
+    present (dedup by ``strategy.name``).
+
+    Pulled out of ``main()`` so the reuse-augments-default-baselines invariant
+    is unit-testable without standing up an argparse/training run: with reuse on
+    and no explicit baseline, the resolved panel must contain the default
+    baselines (Big Money etc.) ALONGSIDE the reused strategies, never the reused
+    strategies alone.
+    """
+    panel = list(base_panel)
+    existing_names = {strategy.name for strategy in panel}
+    for strategy in reused:
+        if strategy.name in existing_names:
+            continue
+        existing_names.add(strategy.name)
+        panel.append(strategy)
+    return panel
+
+
 def main():
     # Set up argument parser
     parser = argparse.ArgumentParser(description="Train a Dominion strategy using genetic algorithms")
@@ -321,25 +341,29 @@ def main():
         else:
             logger.info("Trick scanner surfaced no interactions for this board")
 
-    # Set baseline panel (preferred) or single baseline
+    # Establish the baseline panel BEFORE folding in reused strategies, so
+    # reuse ADDS TO the panel instead of replacing it. Precedence for the base
+    # panel: explicit --baseline-panel > explicit --baseline-strategy > the
+    # trainer's default baseline panel (Big Money + compatible built-ins).
     panel: list = []
     if args.baseline_panel:
         try:
             panel = [_load_strategy(spec) for spec in args.baseline_panel]
-            trainer.set_baseline_panel(panel)
             logger.info("Evaluating against panel: %s", ", ".join(p.name for p in panel))
         except Exception as exc:
             logger.error("Failed to load baseline panel: %s", exc)
             sys.exit(1)
     elif args.baseline_strategy:
         try:
-            baseline = _load_strategy(args.baseline_strategy)
-            trainer.set_baseline_strategy(baseline)
-            panel = [baseline]
-            logger.info("Evaluating against baseline: %s", baseline.name)
+            panel = [_load_strategy(args.baseline_strategy)]
+            logger.info("Evaluating against baseline: %s", panel[0].name)
         except Exception as exc:
             logger.error("Failed to load baseline strategy: %s", exc)
             sys.exit(1)
+    elif trainer.default_baseline_panel:
+        panel = trainer.build_default_baseline_panel()
+        if panel:
+            logger.info("Using default baseline panel: %s", ", ".join(p.name for p in panel))
 
     if reusable_entries:
         reused_panel_specs = [
@@ -352,22 +376,23 @@ def main():
         except Exception as exc:
             logger.error("Failed to load reusable baseline strategy: %s", exc)
             sys.exit(1)
-        if reused_panel:
-            panel.extend(reused_panel)
-            trainer.set_baseline_panel(panel)
+        # Dedup by name so a strategy that is both a default baseline and a
+        # reuse entry is not doubled into the panel.
+        before_names = {strategy.name for strategy in panel}
+        panel = merge_baseline_panel(panel, reused_panel)
+        added = [strategy for strategy in panel if strategy.name not in before_names]
+        if added:
             logger.info(
                 "Added reusable strategies to baseline panel: %s",
-                ", ".join(strategy.name for strategy in reused_panel),
+                ", ".join(strategy.name for strategy in added),
             )
 
-    if not panel and trainer.default_baseline_panel:
-        panel = trainer.build_default_baseline_panel()
-        if len(panel) > 1:
-            trainer.set_baseline_panel(panel)
-            logger.info("Using default baseline panel: %s", ", ".join(p.name for p in panel))
-        elif panel:
-            trainer.set_baseline_strategy(panel[0])
-            logger.info("Using default baseline: %s", panel[0].name)
+    # Commit the assembled panel to the trainer. Mirror the historical
+    # len(panel) > 1 split: a lone member becomes the single baseline.
+    if len(panel) > 1:
+        trainer.set_baseline_panel(panel)
+    elif panel:
+        trainer.set_baseline_strategy(panel[0])
 
     logger.info("Training parameters:")
     logger.info("  Population size: %d", population_size)

--- a/scripts/island_evolve.py
+++ b/scripts/island_evolve.py
@@ -56,6 +56,7 @@ import coloredlogs
 
 from dominion.analysis.island_seeds import (
     IslandSpec,
+    augment_panel_with_compatible,
     derive_island_specs,
     resolve_island_seed,
 )
@@ -179,7 +180,9 @@ def _resolve_panel_names(board_config, explicit: list[str] | None) -> list[str]:
 
     With ``--panel``, the user's names are used verbatim (they must resolve
     via StrategyLoader, both here and later in island_merge). Otherwise the
-    default is the built-in baseline panel compatible with this kingdom —
+    default is the built-in baseline panel PLUS the board's compatible library
+    strategies — so every board trains against a panel stronger than
+    Big-Money-alone, derived from the board rather than hardcoded. It is
     deterministic for a given board, so every island sees the same panel.
     """
     if explicit:
@@ -194,12 +197,14 @@ def _resolve_panel_names(board_config, explicit: list[str] | None) -> list[str]:
     )
     panel = probe.build_default_baseline_panel()
     loader = StrategyLoader()
-    names = []
+    baseline_names = []
     for strategy in panel:
         # Manifest panel names must round-trip through StrategyLoader (the
         # merge stage re-resolves them), so verify before recording.
         if loader.get_strategy(strategy.name) is not None:
-            names.append(strategy.name)
+            baseline_names.append(strategy.name)
+
+    names = augment_panel_with_compatible(board_config, baseline_names, loader)
     return names or ["Big Money"]
 
 

--- a/scripts/island_evolve.py
+++ b/scripts/island_evolve.py
@@ -1,28 +1,42 @@
-"""Island-model evolution for the Lisbon board.
+"""Island-model evolution for any board.
 
-Runs one ``GeneticTrainer`` per seed strategy. Each trainer uses identical
-hyperparameters and the same fixed opponent panel, so fitness numbers are
-comparable across islands. The champions are saved as importable Python
-files for the tournament stage.
+Runs one ``GeneticTrainer`` per island seed. Each trainer uses identical
+hyperparameters and the same fixed opponent panel, so runs are comparable
+across islands. The champions are saved as importable Python files for the
+tournament stage.
 
-The whole point of the island model is to escape local optima: each seed
-represents a distinct theory of the kingdom (Investment Rush, WV/Peddler
-Engine, Watchtower Topdeck, Festival BigMoney, Gardens Slog, City Pile
-Engine). After every island has had equal optimization budget against a
-neutral panel, the champions face each other in
-``scripts/island_tournament.py``.
+The whole point of the island model is to escape local optima: each island
+starts from a distinct theory of the kingdom. By default the roster is
+**derived from the board** (see :mod:`dominion.analysis.island_seeds`):
+compatible strategies from the reuse library, one island per trick-scanner
+interaction, a Big Money archetype island, and random structured-menu
+islands to fill the roster. ``--seeds`` overrides the roster with explicit
+registered strategy names (the original hand-curated workflow).
+
+After every island has had equal optimization budget, the champions face
+each other in ``scripts/island_tournament.py`` (and optionally merge in
+``scripts/island_merge.py``).
+
+Note on fitness comparability: each island's trainer maintains its own hall
+of fame, so late-run fitness numbers are scored partly against the island's
+own ancestors. Treat manifest fitness as a within-island signal; the
+tournament is the cross-island ranking.
 
 Usage
 -----
     # Smoke test (sequential, small budget):
-    python scripts/island_evolve.py --smoke
+    python scripts/island_evolve.py --board boards/lisbon.txt --smoke
 
-    # Real run, parallel across islands:
-    python scripts/island_evolve.py \
+    # Real run, parallel across islands, board-derived roster:
+    python scripts/island_evolve.py --board boards/lisbon.txt \
         --population 30 --generations 60 --games-per-eval 30 --parallel
 
+    # Explicit seed roster (original workflow):
+    python scripts/island_evolve.py --board boards/lisbon.txt \
+        --seeds "Lisbon Investment Rush" "Lisbon City Engine"
+
     # Single island for debugging:
-    python scripts/island_evolve.py --only "Lisbon Investment Rush"
+    python scripts/island_evolve.py --board boards/lisbon.txt --only "Big Money Island"
 """
 
 from __future__ import annotations
@@ -37,37 +51,18 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, asdict
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 import coloredlogs
 
+from dominion.analysis.island_seeds import (
+    IslandSpec,
+    derive_island_specs,
+    resolve_island_seed,
+)
 from dominion.boards.loader import load_board
 from dominion.runner import save_strategy_as_python
 from dominion.simulation.genetic_trainer import GeneticTrainer
 from dominion.strategy.strategy_loader import StrategyLoader
-
-
-# Seeds the islands start from. Each is a distinct theory of the kingdom.
-# Order matters only for log readability — every island gets the same panel
-# and the same budget regardless of position in this list.
-LISBON_SEEDS = [
-    "Lisbon Investment Rush",
-    "Lisbon WV Peddler Engine",
-    "Lisbon Watchtower Topdeck",
-    "Lisbon Festival BigMoney",
-    "Lisbon Gardens Slog",
-    "Lisbon City Engine",
-]
-
-# Fixed panel for every island. Big Money is the non-negotiable speed-test
-# (a deck that builds slowly should win less vs BM than a deck that builds
-# fast — that's the signal previous panels filtered out). ClerkCollection-
-# Colony is the existing engine baseline. Neither is one of the seeds.
-LISBON_PANEL = [
-    "Big Money",
-    "ClerkCollectionColony",
-]
-
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +87,9 @@ def _safe_filename(name: str) -> str:
 
 
 def run_one_island(
-    seed_name: str,
+    spec_kind: str,
+    spec_key: str,
+    island_name: str,
     board_path: str,
     panel_names: list[str],
     population: int,
@@ -103,20 +100,23 @@ def run_one_island(
     run_id: str,
 ) -> IslandResult:
     """Run a single island. Designed to be called in a subprocess: takes only
-    picklable arguments and constructs the trainer + loader inside."""
+    plain-string arguments and rebuilds the seed strategy + panel inside
+    (strategy objects hold lambda conditions and don't survive the spawn
+    boundary)."""
 
     # Configure logging in the subprocess. Each island prefixes its logs with
-    # its seed name so a parallel run is still readable.
+    # its island name so a parallel run is still readable.
     coloredlogs.install(
         level="INFO",
         logger=logging.getLogger(),
-        fmt=f"%(asctime)s [{seed_name}] %(message)s",
+        fmt=f"%(asctime)s [{island_name}] %(message)s",
     )
 
+    board_config = load_board(board_path)
     loader = StrategyLoader()
-    seed = loader.get_strategy(seed_name)
-    if seed is None:
-        raise ValueError(f"Seed strategy not found: {seed_name!r}")
+
+    spec = IslandSpec(spec_kind, spec_key, island_name)
+    seed = resolve_island_seed(spec, board_config, loader)
 
     panel = []
     for name in panel_names:
@@ -125,8 +125,6 @@ def run_one_island(
             raise ValueError(f"Panel strategy not found: {name!r}")
         panel.append(opp)
 
-    board_config = load_board(board_path)
-
     trainer = GeneticTrainer(
         kingdom_cards=board_config.kingdom_cards,
         population_size=population,
@@ -134,9 +132,10 @@ def run_one_island(
         mutation_rate=mutation_rate,
         games_per_eval=games_per_eval,
         board_config=board_config,
-        log_folder=f"island_logs/{run_id}/{_safe_filename(seed_name)}",
+        log_folder=f"island_logs/{run_id}/{_safe_filename(island_name)}",
     )
-    trainer.inject_strategy(seed)
+    if seed is not None:
+        trainer.inject_strategy(seed)
     trainer.set_baseline_panel(panel)
 
     start = time.monotonic()
@@ -144,25 +143,25 @@ def run_one_island(
     elapsed = time.monotonic() - start
 
     if best is None:
-        raise RuntimeError(f"Island {seed_name} produced no champion")
+        raise RuntimeError(f"Island {island_name} produced no champion")
 
     # Replace the GA's auto-generated internal name (e.g. "gen3-4773797616")
     # with something readable so the tournament report identifies champions by
     # their archetype rather than a memory address.
-    best.name = f"{seed_name} Champion"
+    best.name = f"{island_name} Champion"
 
-    output_path = Path(output_dir) / f"{_safe_filename(seed_name)}_champion.py"
-    save_strategy_as_python(best, output_path, _safe_class_name(seed_name))
+    output_path = Path(output_dir) / f"{_safe_filename(island_name)}_champion.py"
+    save_strategy_as_python(best, output_path, _safe_class_name(island_name))
     logger.info(
         "Island done: %s  fitness=%.2f  win_rate=%.1f%%  saved=%s",
-        seed_name,
+        island_name,
         metrics.get("fitness", 0.0),
         metrics.get("win_rate", 0.0),
         output_path,
     )
 
     return IslandResult(
-        seed_name=seed_name,
+        seed_name=island_name,
         output_path=str(output_path),
         fitness=float(metrics.get("fitness", 0.0)),
         win_rate_vs_panel=float(metrics.get("win_rate", 0.0)),
@@ -173,6 +172,35 @@ def run_one_island(
         panel_breakdown=list(trainer.best_eval_breakdown),
         wall_seconds=elapsed,
     )
+
+
+def _resolve_panel_names(board_config, explicit: list[str] | None) -> list[str]:
+    """Resolve the opponent panel names shared by every island.
+
+    With ``--panel``, the user's names are used verbatim (they must resolve
+    via StrategyLoader, both here and later in island_merge). Otherwise the
+    default is the built-in baseline panel compatible with this kingdom —
+    deterministic for a given board, so every island sees the same panel.
+    """
+    if explicit:
+        return list(explicit)
+
+    probe = GeneticTrainer(
+        kingdom_cards=board_config.kingdom_cards,
+        population_size=1,
+        generations=1,
+        board_config=board_config,
+        log_folder="island_logs/_panel_probe",
+    )
+    panel = probe.build_default_baseline_panel()
+    loader = StrategyLoader()
+    names = []
+    for strategy in panel:
+        # Manifest panel names must round-trip through StrategyLoader (the
+        # merge stage re-resolves them), so verify before recording.
+        if loader.get_strategy(strategy.name) is not None:
+            names.append(strategy.name)
+    return names or ["Big Money"]
 
 
 def main() -> None:
@@ -192,12 +220,27 @@ def main() -> None:
     parser.add_argument(
         "--seeds",
         nargs="+",
-        default=LISBON_SEEDS,
-        help="Seed strategy names. Defaults to the six Lisbon island seeds.",
+        default=None,
+        help="Explicit seed strategy names (registered in the StrategyLoader). "
+        "Default: derive the island roster from the board (library reuse + "
+        "trick scanner + Big Money + random islands).",
+    )
+    parser.add_argument(
+        "--max-islands",
+        type=int,
+        default=6,
+        help="Roster size when deriving islands from the board (default: 6).",
+    )
+    parser.add_argument(
+        "--panel",
+        nargs="+",
+        default=None,
+        help="Opponent panel strategy names shared by every island. "
+        "Default: the built-in baseline panel compatible with this kingdom.",
     )
     parser.add_argument(
         "--only",
-        help="Run only this seed (for debugging one island in isolation).",
+        help="Run only the island with this name (for debugging in isolation).",
     )
     parser.add_argument(
         "--parallel",
@@ -208,7 +251,7 @@ def main() -> None:
         "--max-workers",
         type=int,
         default=0,
-        help="Cap parallel workers. 0 = number of seeds (one worker per island).",
+        help="Cap parallel workers. 0 = number of islands (one worker each).",
     )
     parser.add_argument(
         "--smoke",
@@ -222,15 +265,32 @@ def main() -> None:
         args.generations = 5
         args.games_per_eval = 8
 
-    seeds = [args.only] if args.only else list(args.seeds)
+    board_config = load_board(args.board)
+
+    if args.seeds:
+        specs = [IslandSpec("loader", name, name) for name in args.seeds]
+    else:
+        specs = derive_island_specs(board_config, max_islands=args.max_islands)
+        logger.info(
+            "Derived island roster from board: %s",
+            ", ".join(f"{s.name} [{s.kind}]" for s in specs),
+        )
+
+    if args.only:
+        specs = [s for s in specs if s.name == args.only]
+        if not specs:
+            logger.error("No island named %r in the roster", args.only)
+            sys.exit(1)
+
+    panel_names = _resolve_panel_names(board_config, args.panel)
 
     run_id = datetime.now().strftime("%Y%m%d_%H%M%S")
     output_dir = Path(args.output_dir) / run_id
     output_dir.mkdir(parents=True, exist_ok=True)
 
     logger.info("Run id: %s", run_id)
-    logger.info("Seeds: %s", seeds)
-    logger.info("Panel: %s", LISBON_PANEL)
+    logger.info("Islands: %s", [s.name for s in specs])
+    logger.info("Panel: %s", panel_names)
     logger.info(
         "Hyperparameters: pop=%d gens=%d games=%d mut=%.2f parallel=%s",
         args.population, args.generations, args.games_per_eval, args.mutation_rate, args.parallel,
@@ -238,7 +298,7 @@ def main() -> None:
 
     kwargs = dict(
         board_path=args.board,
-        panel_names=LISBON_PANEL,
+        panel_names=panel_names,
         population=args.population,
         generations=args.generations,
         games_per_eval=args.games_per_eval,
@@ -252,37 +312,50 @@ def main() -> None:
     # downstream tournament would treat as complete. The whole point of the
     # island model is that every seed gets the same budget — if one island
     # crashed mid-evolution, comparing the rest is meaningless.
-    failed_seeds: list[str] = []
+    failed_islands: list[str] = []
 
-    if args.parallel and len(seeds) > 1:
-        max_workers = args.max_workers or len(seeds)
+    if args.parallel and len(specs) > 1:
+        max_workers = args.max_workers or len(specs)
         # 'spawn' is the safe default — 'fork' on macOS can deadlock with
         # libraries that aren't fork-safe (notably some BLAS / logging stacks).
         ctx = mp.get_context("spawn")
         with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as ex:
             futures = {
-                ex.submit(run_one_island, seed_name=seed, **kwargs): seed
-                for seed in seeds
+                ex.submit(
+                    run_one_island,
+                    spec_kind=spec.kind,
+                    spec_key=spec.key,
+                    island_name=spec.name,
+                    **kwargs,
+                ): spec.name
+                for spec in specs
             }
             for fut in as_completed(futures):
-                seed = futures[fut]
+                name = futures[fut]
                 try:
                     results.append(fut.result())
                 except Exception:
-                    logger.exception("Island %s failed", seed)
-                    failed_seeds.append(seed)
+                    logger.exception("Island %s failed", name)
+                    failed_islands.append(name)
     else:
-        for seed in seeds:
+        for spec in specs:
             try:
-                results.append(run_one_island(seed_name=seed, **kwargs))
+                results.append(
+                    run_one_island(
+                        spec_kind=spec.kind,
+                        spec_key=spec.key,
+                        island_name=spec.name,
+                        **kwargs,
+                    )
+                )
             except Exception:
-                logger.exception("Island %s failed", seed)
-                failed_seeds.append(seed)
+                logger.exception("Island %s failed", spec.name)
+                failed_islands.append(spec.name)
 
-    if failed_seeds:
+    if failed_islands:
         logger.error(
             "Run incomplete — %d/%d islands failed: %s. Not writing manifest.",
-            len(failed_seeds), len(seeds), failed_seeds,
+            len(failed_islands), len(specs), failed_islands,
         )
         sys.exit(1)
 
@@ -290,7 +363,8 @@ def main() -> None:
     manifest = {
         "run_id": run_id,
         "board": args.board,
-        "panel": LISBON_PANEL,
+        "panel": panel_names,
+        "islands_specs": [asdict(s) for s in specs],
         "hyperparameters": {
             "population": args.population,
             "generations": args.generations,
@@ -304,7 +378,7 @@ def main() -> None:
     logger.info("Manifest written: %s", manifest_path)
 
     print("\n=== Island summary ===")
-    print(f"{'Seed':<35} {'fitness':>8} {'win%':>7} {'time(s)':>9}")
+    print(f"{'Island':<35} {'fitness':>8} {'win%':>7} {'time(s)':>9}")
     for r in sorted(results, key=lambda r: -r.fitness):
         print(f"{r.seed_name:<35} {r.fitness:>8.2f} {r.win_rate_vs_panel:>6.1f}% {r.wall_seconds:>9.1f}")
 

--- a/scripts/island_evolve.py
+++ b/scripts/island_evolve.py
@@ -108,9 +108,26 @@ def _resolvable_seed_ref(spec_kind: str, spec_key: str, loader: StrategyLoader) 
                     are not, so they get ``None`` rather than a ref the
                     tournament would choke on.
     - ``trick`` / ``random`` : no standalone resolvable seed → ``None``.
+
+    The ref is canonicalized to the resolved strategy's display name
+    (``strategy.name``), NOT the input ``spec_key`` alias. ``spec_key`` may be a
+    loader *alias* (e.g. ``"Big Money"``) while the panel side
+    (:func:`_resolve_panel_names`) records ``strategy.name`` (e.g. ``"BigMoney"``).
+    If the two disagreed, ``assemble_entrants`` would see distinct ref strings
+    that resolve to the same display name and reject the whole tournament. By
+    emitting the same canonical key both sides record, the intended seed/panel
+    overlap dedupes instead of clashing. We only return the canonical name when
+    it itself round-trips through the loader (so the tournament can re-resolve
+    it); otherwise we fall back to ``spec_key`` if that round-trips.
     """
     if spec_kind in ("loader", "library"):
-        if loader.get_strategy(spec_key) is not None:
+        strategy = loader.get_strategy(spec_key)
+        if strategy is not None:
+            canonical = strategy.name
+            if canonical and loader.get_strategy(canonical) is not None:
+                return canonical
+            # Canonical name doesn't round-trip; fall back to the alias the
+            # caller passed (which we know resolves), keeping seed/panel in sync.
             return spec_key
     return None
 

--- a/scripts/island_evolve.py
+++ b/scripts/island_evolve.py
@@ -51,6 +51,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, asdict
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 import coloredlogs
 
@@ -76,6 +77,13 @@ class IslandResult:
     win_rate_vs_panel: float
     panel_breakdown: list[tuple]
     wall_seconds: float
+    # A reference the tournament's ``_resolve_strategy`` can re-resolve (a
+    # StrategyLoader name or a *.py path), so ``--include-seeds`` can compare a
+    # champion against its starting point. ``None`` for islands with no
+    # standalone resolvable seed (trick/random, or library entries whose name
+    # does not round-trip through the loader). ``seed_name`` stays the display
+    # name and must NOT be used as a resolvable ref.
+    seed_ref: Optional[str] = None
 
 
 def _safe_class_name(name: str) -> str:
@@ -85,6 +93,26 @@ def _safe_class_name(name: str) -> str:
 def _safe_filename(name: str) -> str:
     slug = name.lower().replace(" ", "_").replace("'", "")
     return "".join(ch for ch in slug if ch.isalnum() or ch in ("_",))
+
+
+def _resolvable_seed_ref(spec_kind: str, spec_key: str, loader: StrategyLoader) -> Optional[str]:
+    """Compute a tournament-resolvable reference for an island's seed, or None.
+
+    The tournament's ``_resolve_strategy`` only accepts StrategyLoader names or
+    ``*.py`` paths — not the ``module:function`` specs the reuse library uses.
+    So a seed is resolvable only when its name round-trips through the loader:
+
+    - ``loader``  : ``spec_key`` is the registered name → resolvable.
+    - ``library`` : resolvable only if the entry name (``spec_key``) is also a
+                    registered loader name; generated-strategy library entries
+                    are not, so they get ``None`` rather than a ref the
+                    tournament would choke on.
+    - ``trick`` / ``random`` : no standalone resolvable seed → ``None``.
+    """
+    if spec_kind in ("loader", "library"):
+        if loader.get_strategy(spec_key) is not None:
+            return spec_key
+    return None
 
 
 def run_one_island(
@@ -172,6 +200,7 @@ def run_one_island(
         # the final generation, not the saved champion.
         panel_breakdown=list(trainer.best_eval_breakdown),
         wall_seconds=elapsed,
+        seed_ref=_resolvable_seed_ref(spec_kind, spec_key, loader),
     )
 
 

--- a/scripts/island_evolve.py
+++ b/scripts/island_evolve.py
@@ -95,8 +95,37 @@ def _safe_filename(name: str) -> str:
     return "".join(ch for ch in slug if ch.isalnum() or ch in ("_",))
 
 
+def _canonical_ref(ref: str, loader: StrategyLoader) -> str:
+    """Map any strategy reference to ONE canonical string for the manifest.
+
+    This is the single chokepoint every ref written into the manifest (island
+    ``seed_ref`` AND ``panel`` entries) must pass through, so two refs that
+    denote the same underlying strategy are *byte-identical* strings. Without
+    that invariant, the tournament's ``assemble_entrants`` sees distinct ref
+    strings that resolve to the same display name and rejects the whole run.
+
+    Rule:
+
+    - If ``loader.get_strategy(ref)`` resolves, return that strategy's
+      ``.name`` — the canonical form the tournament/loader use (e.g. the alias
+      ``"Big Money"`` collapses to ``"BigMoney"``). Round-trip-guarded: only
+      canonicalize when the canonical name *itself* re-resolves via the loader,
+      so the tournament can still resolve the ref it reads back. Otherwise fall
+      back to ``ref`` (which we know resolves), keeping both sides in sync.
+    - If ``ref`` does not resolve (``*.py`` file paths, ``module:function``
+      library specs, unknown names), return ``ref`` unchanged.
+    """
+    strategy = loader.get_strategy(ref)
+    if strategy is None:
+        return ref
+    canonical = strategy.name
+    if canonical and loader.get_strategy(canonical) is not None:
+        return canonical
+    return ref
+
+
 def _resolvable_seed_ref(spec_kind: str, spec_key: str, loader: StrategyLoader) -> Optional[str]:
-    """Compute a tournament-resolvable reference for an island's seed, or None.
+    """Compute a tournament-resolvable, canonical reference for an island seed.
 
     The tournament's ``_resolve_strategy`` only accepts StrategyLoader names or
     ``*.py`` paths — not the ``module:function`` specs the reuse library uses.
@@ -109,26 +138,14 @@ def _resolvable_seed_ref(spec_kind: str, spec_key: str, loader: StrategyLoader) 
                     tournament would choke on.
     - ``trick`` / ``random`` : no standalone resolvable seed → ``None``.
 
-    The ref is canonicalized to the resolved strategy's display name
-    (``strategy.name``), NOT the input ``spec_key`` alias. ``spec_key`` may be a
-    loader *alias* (e.g. ``"Big Money"``) while the panel side
-    (:func:`_resolve_panel_names`) records ``strategy.name`` (e.g. ``"BigMoney"``).
-    If the two disagreed, ``assemble_entrants`` would see distinct ref strings
-    that resolve to the same display name and reject the whole tournament. By
-    emitting the same canonical key both sides record, the intended seed/panel
-    overlap dedupes instead of clashing. We only return the canonical name when
-    it itself round-trips through the loader (so the tournament can re-resolve
-    it); otherwise we fall back to ``spec_key`` if that round-trips.
+    When resolvable, the ref is canonicalized via :func:`_canonical_ref`, so it
+    is byte-identical to whatever the panel side records for the same strategy
+    (e.g. the loader alias ``"Big Money"`` becomes ``"BigMoney"``). This is the
+    one rule for both seeds and panels — see :func:`_canonical_ref`.
     """
     if spec_kind in ("loader", "library"):
-        strategy = loader.get_strategy(spec_key)
-        if strategy is not None:
-            canonical = strategy.name
-            if canonical and loader.get_strategy(canonical) is not None:
-                return canonical
-            # Canonical name doesn't round-trip; fall back to the alias the
-            # caller passed (which we know resolves), keeping seed/panel in sync.
-            return spec_key
+        if loader.get_strategy(spec_key) is not None:
+            return _canonical_ref(spec_key, loader)
     return None
 
 
@@ -224,15 +241,25 @@ def run_one_island(
 def _resolve_panel_names(board_config, explicit: list[str] | None) -> list[str]:
     """Resolve the opponent panel names shared by every island.
 
-    With ``--panel``, the user's names are used verbatim (they must resolve
-    via StrategyLoader, both here and later in island_merge). Otherwise the
-    default is the built-in baseline panel PLUS the board's compatible library
-    strategies — so every board trains against a panel stronger than
+    Every recorded name is run through :func:`_canonical_ref`, so a panel entry
+    is byte-identical to any island ``seed_ref`` that denotes the same strategy
+    (the alias ``"Big Money"`` collapses to ``"BigMoney"`` on both sides). This
+    is what lets seed/panel overlap dedupe rather than clash in the tournament.
+
+    With ``--panel``, the user's names are used (canonicalized; they must
+    resolve via StrategyLoader, both here and later in island_merge). Otherwise
+    the default is the built-in baseline panel PLUS the board's compatible
+    library strategies — so every board trains against a panel stronger than
     Big-Money-alone, derived from the board rather than hardcoded. It is
     deterministic for a given board, so every island sees the same panel.
     """
+    loader = StrategyLoader()
+
     if explicit:
-        return list(explicit)
+        # Canonicalize each user-supplied alias before it enters the manifest,
+        # so an explicit ``--panel "Big Money"`` records the same ``"BigMoney"``
+        # a Big Money island's seed_ref does.
+        return [_canonical_ref(name, loader) for name in explicit]
 
     probe = GeneticTrainer(
         kingdom_cards=board_config.kingdom_cards,
@@ -242,16 +269,17 @@ def _resolve_panel_names(board_config, explicit: list[str] | None) -> list[str]:
         log_folder="island_logs/_panel_probe",
     )
     panel = probe.build_default_baseline_panel()
-    loader = StrategyLoader()
     baseline_names = []
     for strategy in panel:
         # Manifest panel names must round-trip through StrategyLoader (the
-        # merge stage re-resolves them), so verify before recording.
+        # merge stage re-resolves them), so verify before recording, and
+        # canonicalize so they match the seed side.
         if loader.get_strategy(strategy.name) is not None:
-            baseline_names.append(strategy.name)
+            baseline_names.append(_canonical_ref(strategy.name, loader))
 
     names = augment_panel_with_compatible(board_config, baseline_names, loader)
-    return names or ["Big Money"]
+    canonical = [_canonical_ref(name, loader) for name in names]
+    return canonical or [_canonical_ref("Big Money", loader)]
 
 
 def main() -> None:

--- a/scripts/island_evolve.py
+++ b/scripts/island_evolve.py
@@ -60,8 +60,9 @@ from dominion.analysis.island_seeds import (
     augment_panel_with_compatible,
     derive_island_specs,
     resolve_island_seed,
+    resolve_library_spec,
 )
-from dominion.boards.loader import load_board
+from dominion.boards.loader import BoardConfig, load_board
 from dominion.runner import save_strategy_as_python
 from dominion.simulation.genetic_trainer import GeneticTrainer
 from dominion.strategy.strategy_loader import StrategyLoader
@@ -124,28 +125,56 @@ def _canonical_ref(ref: str, loader: StrategyLoader) -> str:
     return ref
 
 
-def _resolvable_seed_ref(spec_kind: str, spec_key: str, loader: StrategyLoader) -> Optional[str]:
+def _resolvable_seed_ref(
+    spec_kind: str,
+    spec_key: str,
+    loader: StrategyLoader,
+    board_config: Optional[BoardConfig] = None,
+) -> Optional[str]:
     """Compute a tournament-resolvable, canonical reference for an island seed.
 
     The tournament's ``_resolve_strategy`` only accepts StrategyLoader names or
     ``*.py`` paths — not the ``module:function`` specs the reuse library uses.
-    So a seed is resolvable only when its name round-trips through the loader:
+    So a seed is resolvable only when it can be reduced to a loader name:
 
     - ``loader``  : ``spec_key`` is the registered name → resolvable.
-    - ``library`` : resolvable only if the entry name (``spec_key``) is also a
-                    registered loader name; generated-strategy library entries
-                    are not, so they get ``None`` rather than a ref the
-                    tournament would choke on.
+    - ``library`` : ``spec_key`` is the entry *spec* (a ``module:function``
+                    reference), which the loader cannot resolve directly. Rebuild
+                    the strategy from the spec the same way
+                    :func:`~dominion.analysis.island_seeds.resolve_island_seed`
+                    does, then use its ``.name``. Resolvable only if that name
+                    round-trips through the loader (generated-strategy entries
+                    that aren't registered by name get ``None`` rather than a
+                    ref the tournament would choke on). Needs ``board_config``
+                    to do the spec→strategy lookup.
     - ``trick`` / ``random`` : no standalone resolvable seed → ``None``.
 
     When resolvable, the ref is canonicalized via :func:`_canonical_ref`, so it
     is byte-identical to whatever the panel side records for the same strategy
-    (e.g. the loader alias ``"Big Money"`` becomes ``"BigMoney"``). This is the
-    one rule for both seeds and panels — see :func:`_canonical_ref`.
+    (e.g. the loader alias ``"Big Money"`` becomes ``"BigMoney"``, and a library
+    spec collapses to the same ``.name`` the panel records). This is the one
+    rule for both seeds and panels — see :func:`_canonical_ref`.
     """
-    if spec_kind in ("loader", "library"):
+    if spec_kind == "loader":
         if loader.get_strategy(spec_key) is not None:
             return _canonical_ref(spec_key, loader)
+        return None
+
+    if spec_kind == "library":
+        if board_config is None:
+            return None
+        try:
+            strategy = resolve_library_spec(board_config, spec_key)
+        except ValueError:
+            return None
+        # The library spec resolves to a concrete strategy; it's only a usable
+        # tournament ref if that strategy is *also* registered by name in the
+        # loader. Route through _canonical_ref so it's byte-identical to the
+        # panel ref for the same strategy (preserving the dedupe invariant).
+        if loader.get_strategy(strategy.name) is None:
+            return None
+        return _canonical_ref(strategy.name, loader)
+
     return None
 
 
@@ -234,7 +263,7 @@ def run_one_island(
         # the final generation, not the saved champion.
         panel_breakdown=list(trainer.best_eval_breakdown),
         wall_seconds=elapsed,
-        seed_ref=_resolvable_seed_ref(spec_kind, spec_key, loader),
+        seed_ref=_resolvable_seed_ref(spec_kind, spec_key, loader, board_config),
     )
 
 

--- a/scripts/island_tournament.py
+++ b/scripts/island_tournament.py
@@ -352,6 +352,10 @@ def main() -> None:
     except ValueError as exc:
         parser.error(str(exc))
 
+    # Ordered list of entrant display names — drives the matrix rows/columns
+    # and the average-win-rate ranking below.
+    names = [name for name, _ in resolved]
+
     # Build matchup list (one entry per unordered pair).
     matchups: list[tuple[str, str, str, str]] = []  # (a_name, b_name, a_ref, b_ref)
     for i, (a_name, a_ref) in enumerate(resolved):

--- a/scripts/island_tournament.py
+++ b/scripts/island_tournament.py
@@ -111,6 +111,28 @@ def _seed_refs_from_manifest(manifest: dict) -> tuple[list[str], int]:
     return refs, skipped
 
 
+DEFAULT_BOARD = "boards/lisbon.txt"
+
+
+def resolve_tournament_board(
+    cli_board: Optional[str], manifest: Optional[dict]
+) -> tuple[str, str]:
+    """Resolve which board the tournament should run on.
+
+    Precedence: explicit ``--board`` > the manifest's training board (only when
+    a manifest is supplied) > the ``boards/lisbon.txt`` fallback. Returns
+    ``(board_path, source)`` where ``source`` is one of ``"CLI"``,
+    ``"manifest"``, or ``"default"`` (used purely for an informative log line).
+    """
+    if cli_board:
+        return cli_board, "CLI"
+    if manifest:
+        board = manifest.get("board")
+        if board:
+            return board, "manifest"
+    return DEFAULT_BOARD, "default"
+
+
 def _matchup_unique_key(a: str, b: str) -> tuple[str, str]:
     """Order-independent key for a matchup (so we don't run A-vs-B twice)."""
     return (a, b) if a <= b else (b, a)
@@ -220,7 +242,15 @@ def main() -> None:
         action="store_true",
         help="When using --manifest, also include each panel member as a tournament entrant.",
     )
-    parser.add_argument("--board", default="boards/lisbon.txt")
+    parser.add_argument(
+        "--board",
+        default=None,
+        help=(
+            "Board to evaluate on. Defaults to the manifest's training board "
+            "(when --manifest is used) and otherwise to boards/lisbon.txt. An "
+            "explicit value always wins."
+        ),
+    )
 
     def _positive_int(value: str) -> int:
         ivalue = int(value)
@@ -247,6 +277,7 @@ def main() -> None:
     args = parser.parse_args()
 
     refs: list[str] = []
+    manifest: Optional[dict] = None
     if args.manifest:
         manifest_path = Path(args.manifest)
         manifest = json.loads(manifest_path.read_text())
@@ -268,6 +299,9 @@ def main() -> None:
         refs = list(args.strategies)
     else:
         parser.error("Provide either --manifest or --strategies")
+
+    board_path, board_source = resolve_tournament_board(args.board, manifest)
+    logger.info("Tournament board: %s (from %s)", board_path, board_source)
 
     # Resolve once up-front so misspelled names fail immediately.
     loader = StrategyLoader()
@@ -315,7 +349,7 @@ def main() -> None:
         ctx = mp.get_context("spawn")
         with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as ex:
             futures = {
-                ex.submit(_run_matchup, a_ref, b_ref, args.games, args.board): (a_name, b_name)
+                ex.submit(_run_matchup, a_ref, b_ref, args.games, board_path): (a_name, b_name)
                 for a_name, b_name, a_ref, b_ref in matchups
             }
             for fut in as_completed(futures):
@@ -333,7 +367,7 @@ def main() -> None:
     else:
         for a_name, b_name, a_ref, b_ref in matchups:
             try:
-                r = _run_matchup(a_ref, b_ref, args.games, args.board)
+                r = _run_matchup(a_ref, b_ref, args.games, board_path)
                 raw_results.append(r)
                 logger.info(
                     "%s vs %s: %.1f%% (margin %+.1f)",
@@ -376,8 +410,9 @@ def main() -> None:
         avg_win[name] = sum(rates) / max(1, len(rates))
 
     lines = []
-    lines.append(f"# Lisbon Island Tournament — {args.games} games / matchup\n")
-    lines.append(f"Board: `{args.board}`\n")
+    board_label = Path(board_path).stem.replace("_", " ").title()
+    lines.append(f"# {board_label} Island Tournament — {args.games} games / matchup\n")
+    lines.append(f"Board: `{board_path}`\n")
     lines.append("## Win-rate matrix (row vs column)\n")
     lines.append(_format_matrix(names, win_cell))
     lines.append("\n## Average VP margin matrix (row minus column)\n")

--- a/scripts/island_tournament.py
+++ b/scripts/island_tournament.py
@@ -111,6 +111,44 @@ def _seed_refs_from_manifest(manifest: dict) -> tuple[list[str], int]:
     return refs, skipped
 
 
+def assemble_entrants(
+    refs: list[str], loader: StrategyLoader
+) -> list[tuple[str, str]]:
+    """Resolve tournament entrant ``refs`` to ``(display_name, ref)`` pairs.
+
+    Champions, ``--include-seeds`` seed refs, and ``--include-panel`` panel
+    names are concatenated by the caller, and these lists legitimately overlap:
+    on a board-derived manifest the seed refs and the panel both contain, e.g.,
+    ``Big Money`` and the board's compatible library strategies. Appending them
+    unconditionally would feed the same entrant in twice.
+
+    Dedup is by *ref identity*: when the exact same ref string appears more than
+    once (the intended overlap between champions/seeds/panel), only the first
+    occurrence is kept, preserving order. A genuine collision — two *distinct*
+    refs that resolve to the same display name (which would silently overwrite
+    matrix cells keyed on the name) — is still rejected with ``ValueError``, so
+    the guard against accidental name clashes is preserved.
+    """
+    resolved: list[tuple[str, str]] = []
+    seen_refs: set[str] = set()
+    name_to_ref: dict[str, str] = {}
+    for ref in refs:
+        if ref in seen_refs:
+            continue
+        name, _ = _resolve_strategy(ref, loader)
+        prior_ref = name_to_ref.get(name)
+        if prior_ref is not None:
+            # Distinct refs resolving to the same display name: a real clash.
+            raise ValueError(
+                f"Duplicate display name {name!r} from distinct entrants "
+                f"{prior_ref!r} and {ref!r}. Rename or deduplicate before running."
+            )
+        seen_refs.add(ref)
+        name_to_ref[name] = ref
+        resolved.append((name, ref))
+    return resolved
+
+
 DEFAULT_BOARD = "boards/lisbon.txt"
 
 
@@ -303,25 +341,16 @@ def main() -> None:
     board_path, board_source = resolve_tournament_board(args.board, manifest)
     logger.info("Tournament board: %s (from %s)", board_path, board_source)
 
-    # Resolve once up-front so misspelled names fail immediately.
+    # Resolve once up-front so misspelled names fail immediately. The helper
+    # dedupes the intended overlap between champions/seeds/panel (same ref
+    # appearing twice) and still rejects distinct refs that collide by display
+    # name — duplicate names would silently overwrite the matrix cells keyed on
+    # (a_name, b_name) and corrupt the report.
     loader = StrategyLoader()
-    resolved: list[tuple[str, str]] = []  # (display_name, ref-for-subprocess)
-    for ref in refs:
-        name, _ = _resolve_strategy(ref, loader)
-        resolved.append((name, ref))
-
-    names = [n for n, _ in resolved]
-    if len(set(names)) != len(names):
-        # The matrix cells are keyed on (a_name, b_name); duplicate names
-        # would silently overwrite cells and corrupt the report. Reject up
-        # front so the user can rename one of the duplicates rather than
-        # discovering it after the fact in a published table.
-        seen: set[str] = set()
-        dupes = sorted({n for n in names if n in seen or seen.add(n)})
-        parser.error(
-            f"Duplicate display names in tournament entrants: {dupes}. "
-            "Rename or deduplicate before running."
-        )
+    try:
+        resolved = assemble_entrants(refs, loader)  # (display_name, ref-for-subprocess)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     # Build matchup list (one entry per unordered pair).
     matchups: list[tuple[str, str, str, str]] = []  # (a_name, b_name, a_ref, b_ref)

--- a/scripts/island_tournament.py
+++ b/scripts/island_tournament.py
@@ -80,6 +80,37 @@ def _resolve_strategy(ref: str, loader: StrategyLoader) -> tuple[str, EnhancedSt
     return s.name, s
 
 
+def _seed_refs_from_manifest(manifest: dict) -> tuple[list[str], int]:
+    """Collect tournament-resolvable seed refs from a manifest's islands.
+
+    Returns ``(refs, skipped)`` where ``refs`` are resolvable seed references
+    (StrategyLoader names or ``*.py`` paths) and ``skipped`` counts islands with
+    no resolvable seed (trick/random, or library seeds that don't round-trip).
+
+    Board-derived manifests store ``seed_name`` as a DISPLAY name (``Reuse ...``,
+    a trick name, ``Random Island 1``), which ``_resolve_strategy`` cannot
+    resolve. Such manifests carry a separate ``seed_ref`` field (``None`` when
+    there is no resolvable seed). For backward compatibility, manifests written
+    before ``seed_ref`` existed (no island has the key) fall back to the old
+    ``seed_name`` behavior so they don't hard-break.
+    """
+    islands = manifest.get("islands", [])
+    has_seed_ref = any("seed_ref" in island for island in islands)
+    if not has_seed_ref:
+        # Legacy manifest: preserve prior behavior (resolve seed_name directly).
+        return [island["seed_name"] for island in islands], 0
+
+    refs: list[str] = []
+    skipped = 0
+    for island in islands:
+        ref = island.get("seed_ref")
+        if ref:
+            refs.append(ref)
+        else:
+            skipped += 1
+    return refs, skipped
+
+
 def _matchup_unique_key(a: str, b: str) -> tuple[str, str]:
     """Order-independent key for a matchup (so we don't run A-vs-B twice)."""
     return (a, b) if a <= b else (b, a)
@@ -224,8 +255,13 @@ def main() -> None:
         for island in manifest.get("islands", []):
             refs.append(island["output_path"])
         if args.include_seeds:
-            for island in manifest.get("islands", []):
-                refs.append(island["seed_name"])
+            seed_refs, skipped = _seed_refs_from_manifest(manifest)
+            refs.extend(seed_refs)
+            if skipped:
+                logger.info(
+                    "Skipping %d island(s) with no resolvable seed (trick/random)",
+                    skipped,
+                )
         if args.include_panel:
             refs.extend(manifest.get("panel", []))
     elif args.strategies:

--- a/tests/test_island_manifest.py
+++ b/tests/test_island_manifest.py
@@ -12,9 +12,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
+import pytest  # noqa: E402
+
 from island_tournament import (  # noqa: E402
     DEFAULT_BOARD,
     _seed_refs_from_manifest,
+    assemble_entrants,
     resolve_tournament_board,
 )
 
@@ -87,6 +90,53 @@ def test_all_unresolvable():
 
     assert refs == []
     assert skipped == 2
+
+
+class _FakeStrategy:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class _FakeLoader:
+    """Resolves a ref name to a strategy whose display name equals the ref,
+    unless an explicit ref->name mapping is given (to force a name collision)."""
+
+    def __init__(self, names: dict[str, str] | None = None):
+        self._names = names or {}
+
+    def get_strategy(self, ref: str):
+        return _FakeStrategy(self._names.get(ref, ref))
+
+
+def test_assemble_entrants_collapses_seed_panel_overlap():
+    # Champions (file-like names here resolve to themselves), then seeds, then
+    # panel — seeds and panel overlap exactly as on a default Lisbon roster.
+    champions = ["champ_a", "champ_b"]
+    seeds = ["Big Money", "Lisbon City Engine", "ClerkCollectionColony"]
+    panel = ["Big Money", "Lisbon City Engine", "ClerkCollectionColony", "Lisbon City Crusher"]
+    refs = champions + seeds + panel
+
+    resolved = assemble_entrants(refs, _FakeLoader())
+
+    names = [n for n, _ in resolved]
+    # Overlap collapsed: every entrant unique, first occurrence/order preserved.
+    assert names == [
+        "champ_a",
+        "champ_b",
+        "Big Money",
+        "Lisbon City Engine",
+        "ClerkCollectionColony",
+        "Lisbon City Crusher",
+    ]
+    assert len(set(names)) == len(names)
+
+
+def test_assemble_entrants_rejects_distinct_refs_with_same_name():
+    # Two DISTINCT refs resolve to the same display name -> genuine clash.
+    loader = _FakeLoader({"alpha": "Clash", "beta": "Clash"})
+
+    with pytest.raises(ValueError, match="Duplicate display name"):
+        assemble_entrants(["alpha", "beta"], loader)
 
 
 def test_legacy_manifest_without_seed_ref_falls_back_to_seed_name():

--- a/tests/test_island_manifest.py
+++ b/tests/test_island_manifest.py
@@ -187,11 +187,6 @@ def test_resolvable_seed_ref_canonicalizes_loader_alias():
     assert loader.get_strategy(ref) is not None
 
 
-def test_resolvable_seed_ref_library_canonicalizes_same_way():
-    loader = _AliasLoader()
-    assert _resolvable_seed_ref("library", "Big Money", loader) == "BigMoney"
-
-
 def test_resolvable_seed_ref_trick_and_random_return_none():
     loader = _AliasLoader()
     assert _resolvable_seed_ref("trick", "Big Money", loader) is None
@@ -201,6 +196,107 @@ def test_resolvable_seed_ref_trick_and_random_return_none():
 def test_resolvable_seed_ref_unknown_loader_key_returns_none():
     loader = _AliasLoader()
     assert _resolvable_seed_ref("loader", "Nonexistent", loader) is None
+
+
+# --- library seed_ref: spec -> canonical loadable NAME (PR #296 regression) --
+#
+# Library island specs are keyed by their ``module:function`` entry *spec*, not
+# a loader name. The seed_ref must resolve that spec back to the strategy's
+# canonical loadable name so ``--include-seeds`` enters the library seed again,
+# and so it dedupes byte-identically against the panel ref for that strategy.
+
+
+def _lisbon_board():
+    from dominion.boards.loader import load_board
+
+    return load_board("boards/lisbon.txt")
+
+
+def _a_loadable_library_spec(board, loader):
+    """Return (spec, strategy_name) for a real library entry whose name
+    round-trips through the loader, or None if the library has none."""
+    from dominion.analysis.strategy_library import find_compatible_strategies
+
+    for entry in find_compatible_strategies(board.kingdom_cards, top_k=10_000, min_overlap=1):
+        name = entry.factory().name
+        if loader.get_strategy(name) is not None:
+            return entry.spec, name
+    return None
+
+
+def test_resolvable_library_spec_returns_canonical_loadable_name():
+    from dominion.strategy.strategy_loader import StrategyLoader
+
+    board = _lisbon_board()
+    loader = StrategyLoader()
+    found = _a_loadable_library_spec(board, loader)
+    if found is None:
+        pytest.skip("no loadable library strategy for this board")
+    spec, name = found
+
+    ref = _resolvable_seed_ref("library", spec, loader, board)
+
+    # The NAME, not the module:function spec and not None.
+    assert ref == name
+    assert ref != spec
+    # And it round-trips through the loader so the tournament can re-resolve it.
+    assert loader.get_strategy(ref) is not None
+
+
+def test_resolvable_library_ref_equals_panel_ref_for_same_strategy():
+    # Dedupe invariant: the library island's seed_ref and the panel ref for the
+    # SAME strategy must be byte-identical canonical names.
+    from dominion.strategy.strategy_loader import StrategyLoader
+
+    board = _lisbon_board()
+    loader = StrategyLoader()
+    found = _a_loadable_library_spec(board, loader)
+    if found is None:
+        pytest.skip("no loadable library strategy for this board")
+    spec, name = found
+
+    seed_ref = _resolvable_seed_ref("library", spec, loader, board)
+    panel_ref = _canonical_ref(name, loader)  # how _resolve_panel_names records it
+
+    assert seed_ref == panel_ref
+
+
+def test_resolvable_library_spec_that_does_not_round_trip_returns_none():
+    # A spec that resolves to a strategy whose .name is NOT a registered loader
+    # name -> None (acceptable; the tournament just skips it). No crash.
+    from dominion.boards.loader import load_board
+
+    board = load_board("boards/lisbon.txt")
+
+    class _UnregisteredLoader:
+        def get_strategy(self, ref):
+            return None  # nothing round-trips
+
+    found = None
+    from dominion.analysis.strategy_library import find_compatible_strategies
+
+    for entry in find_compatible_strategies(board.kingdom_cards, top_k=10_000, min_overlap=1):
+        found = entry.spec
+        break
+    if found is None:
+        pytest.skip("no library strategy for this board")
+
+    assert _resolvable_seed_ref("library", found, _UnregisteredLoader(), board) is None
+
+
+def test_resolvable_library_unknown_spec_returns_none():
+    # A spec that matches no library entry -> None, no crash.
+    from dominion.strategy.strategy_loader import StrategyLoader
+
+    board = _lisbon_board()
+    assert (
+        _resolvable_seed_ref("library", "no.such:spec", StrategyLoader(), board) is None
+    )
+
+
+def test_resolvable_library_without_board_returns_none():
+    # Defensive: no board threaded through -> cannot resolve the spec -> None.
+    assert _resolvable_seed_ref("library", "no.such:spec", _AliasLoader()) is None
 
 
 def test_seed_and_panel_refs_dedupe_after_canonicalization():

--- a/tests/test_island_manifest.py
+++ b/tests/test_island_manifest.py
@@ -20,7 +20,7 @@ from island_tournament import (  # noqa: E402
     assemble_entrants,
     resolve_tournament_board,
 )
-from island_evolve import _resolvable_seed_ref  # noqa: E402
+from island_evolve import _canonical_ref, _resolvable_seed_ref  # noqa: E402
 
 
 def _manifest(islands):
@@ -212,6 +212,66 @@ def test_seed_and_panel_refs_dedupe_after_canonicalization():
     panel_name = _panel_recorded_name(loader, "Big Money")
 
     resolved = assemble_entrants([seed_ref, panel_name], _FakeLoader())
+
+    assert len(resolved) == 1
+    assert resolved[0][0] == "BigMoney"
+
+
+# --- _canonical_ref chokepoint: the single rule every manifest ref obeys ----
+
+
+def test_canonical_ref_collapses_alias_to_name():
+    loader = _AliasLoader()
+    assert _canonical_ref("Big Money", loader) == "BigMoney"
+
+
+def test_canonical_ref_is_idempotent_on_canonical_name():
+    loader = _AliasLoader()
+    assert _canonical_ref("BigMoney", loader) == "BigMoney"
+    # Idempotent: canonicalizing the canonical form is a fixed point.
+    assert _canonical_ref(_canonical_ref("Big Money", loader), loader) == "BigMoney"
+
+
+def test_canonical_ref_passes_through_py_path_unchanged():
+    loader = _AliasLoader()
+    path = "generated_strategies/island_champions/foo_champion.py"
+    assert _canonical_ref(path, loader) == path
+
+
+def test_canonical_ref_passes_through_unknown_ref_unchanged():
+    loader = _AliasLoader()
+    assert _canonical_ref("Totally Unknown", loader) == "Totally Unknown"
+
+
+def test_canonical_ref_falls_back_when_name_does_not_round_trip():
+    # alias resolves, but the resolved .name does NOT itself re-resolve ->
+    # keep the alias (which we know resolves) rather than emit a dead ref.
+    class _OneWayLoader:
+        def get_strategy(self, ref):
+            if ref == "alias":
+                return _FakeStrategy("Pretty Name")  # "Pretty Name" is unknown
+            return None
+
+    assert _canonical_ref("alias", _OneWayLoader()) == "alias"
+
+
+def test_explicit_panel_alias_is_canonicalized():
+    # The reported residual: an explicit --panel ["Big Money"] must record
+    # "BigMoney" so it can't collide with a canonicalized Big Money seed_ref.
+    loader = _AliasLoader()
+    recorded = [_canonical_ref(name, loader) for name in ["Big Money"]]
+    assert recorded == ["BigMoney"]
+
+
+def test_explicit_panel_and_seed_dedupe_end_to_end():
+    # Full class: a Big Money island seed_ref and an explicit --panel
+    # "Big Money" entry both reduce to "BigMoney"; assemble_entrants yields
+    # ONE entrant rather than raising on a name clash.
+    loader = _AliasLoader()
+    seed_ref = _resolvable_seed_ref("loader", "Big Money", loader)
+    explicit_panel = [_canonical_ref(name, loader) for name in ["Big Money"]]
+
+    resolved = assemble_entrants([seed_ref, *explicit_panel], _FakeLoader())
 
     assert len(resolved) == 1
     assert resolved[0][0] == "BigMoney"

--- a/tests/test_island_manifest.py
+++ b/tests/test_island_manifest.py
@@ -12,11 +12,37 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
-from island_tournament import _seed_refs_from_manifest  # noqa: E402
+from island_tournament import (  # noqa: E402
+    DEFAULT_BOARD,
+    _seed_refs_from_manifest,
+    resolve_tournament_board,
+)
 
 
 def _manifest(islands):
     return {"run_id": "x", "board": "boards/lisbon.txt", "islands": islands}
+
+
+def test_resolve_board_cli_wins_over_manifest():
+    manifest = {"board": "boards/rio.txt"}
+    assert resolve_tournament_board("boards/oslo.txt", manifest) == (
+        "boards/oslo.txt",
+        "CLI",
+    )
+
+
+def test_resolve_board_uses_manifest_when_cli_absent():
+    manifest = {"board": "boards/rio.txt"}
+    assert resolve_tournament_board(None, manifest) == ("boards/rio.txt", "manifest")
+
+
+def test_resolve_board_falls_back_to_default_without_manifest():
+    # --strategies path: no manifest, no --board.
+    assert resolve_tournament_board(None, None) == (DEFAULT_BOARD, "default")
+
+
+def test_resolve_board_falls_back_when_manifest_lacks_board():
+    assert resolve_tournament_board(None, {"islands": []}) == (DEFAULT_BOARD, "default")
 
 
 def test_keeps_loader_and_library_refs_skips_trick_and_random():

--- a/tests/test_island_manifest.py
+++ b/tests/test_island_manifest.py
@@ -1,0 +1,79 @@
+"""Tests for tournament seed-ref collection from island manifests.
+
+Board-derived manifests store ``seed_name`` as a display name (``Reuse ...``, a
+trick name, ``Random Island 1``) and a separate resolvable ``seed_ref``. The
+tournament's ``--include-seeds`` must collect ``seed_ref`` (skipping None) and
+NOT try to resolve the display ``seed_name`` (PR #296 regression)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from island_tournament import _seed_refs_from_manifest  # noqa: E402
+
+
+def _manifest(islands):
+    return {"run_id": "x", "board": "boards/lisbon.txt", "islands": islands}
+
+
+def test_keeps_loader_and_library_refs_skips_trick_and_random():
+    manifest = _manifest(
+        [
+            {"seed_name": "Big Money Island", "seed_ref": "Big Money"},
+            {"seed_name": "Reuse Lisbon City Engine", "seed_ref": "Lisbon City Engine"},
+            {"seed_name": "Some Trick", "seed_ref": None},
+            {"seed_name": "Random Island 1", "seed_ref": None},
+        ]
+    )
+
+    refs, skipped = _seed_refs_from_manifest(manifest)
+
+    assert refs == ["Big Money", "Lisbon City Engine"]
+    assert skipped == 2
+
+
+def test_all_resolvable():
+    manifest = _manifest(
+        [
+            {"seed_name": "Big Money Island", "seed_ref": "Big Money"},
+            {"seed_name": "Reuse X", "seed_ref": "X"},
+        ]
+    )
+
+    refs, skipped = _seed_refs_from_manifest(manifest)
+
+    assert refs == ["Big Money", "X"]
+    assert skipped == 0
+
+
+def test_all_unresolvable():
+    manifest = _manifest(
+        [
+            {"seed_name": "Trick A", "seed_ref": None},
+            {"seed_name": "Random Island 1", "seed_ref": None},
+        ]
+    )
+
+    refs, skipped = _seed_refs_from_manifest(manifest)
+
+    assert refs == []
+    assert skipped == 2
+
+
+def test_legacy_manifest_without_seed_ref_falls_back_to_seed_name():
+    # No island carries a seed_ref key → treat as a pre-seed_ref manifest and
+    # preserve the old behavior of resolving seed_name directly.
+    manifest = _manifest(
+        [
+            {"seed_name": "Big Money"},
+            {"seed_name": "Lisbon City Engine"},
+        ]
+    )
+
+    refs, skipped = _seed_refs_from_manifest(manifest)
+
+    assert refs == ["Big Money", "Lisbon City Engine"]
+    assert skipped == 0

--- a/tests/test_island_manifest.py
+++ b/tests/test_island_manifest.py
@@ -20,6 +20,7 @@ from island_tournament import (  # noqa: E402
     assemble_entrants,
     resolve_tournament_board,
 )
+from island_evolve import _resolvable_seed_ref  # noqa: E402
 
 
 def _manifest(islands):
@@ -153,3 +154,64 @@ def test_legacy_manifest_without_seed_ref_falls_back_to_seed_name():
 
     assert refs == ["Big Money", "Lisbon City Engine"]
     assert skipped == 0
+
+
+class _AliasLoader:
+    """Loader whose alias key differs from the strategy's canonical ``.name``.
+
+    Models the real Big Money case: ``get_strategy("Big Money").name ==
+    "BigMoney"`` and the canonical ``"BigMoney"`` itself round-trips. Any other
+    key is unknown (returns None)."""
+
+    _MAP = {"Big Money": "BigMoney", "BigMoney": "BigMoney"}
+
+    def get_strategy(self, ref: str):
+        name = self._MAP.get(ref)
+        return _FakeStrategy(name) if name is not None else None
+
+
+def _panel_recorded_name(loader, alias: str) -> str:
+    # Mirror what _resolve_panel_names records for a strategy: strategy.name.
+    return loader.get_strategy(alias).name
+
+
+def test_resolvable_seed_ref_canonicalizes_loader_alias():
+    loader = _AliasLoader()
+
+    # The seed side, fed the loader alias, must emit the canonical name...
+    ref = _resolvable_seed_ref("loader", "Big Money", loader)
+    assert ref == "BigMoney"
+    # ...which is exactly what the panel side records for the same strategy.
+    assert ref == _panel_recorded_name(loader, "Big Money")
+    # And it round-trips so the tournament can still re-resolve it.
+    assert loader.get_strategy(ref) is not None
+
+
+def test_resolvable_seed_ref_library_canonicalizes_same_way():
+    loader = _AliasLoader()
+    assert _resolvable_seed_ref("library", "Big Money", loader) == "BigMoney"
+
+
+def test_resolvable_seed_ref_trick_and_random_return_none():
+    loader = _AliasLoader()
+    assert _resolvable_seed_ref("trick", "Big Money", loader) is None
+    assert _resolvable_seed_ref("random", "0", loader) is None
+
+
+def test_resolvable_seed_ref_unknown_loader_key_returns_none():
+    loader = _AliasLoader()
+    assert _resolvable_seed_ref("loader", "Nonexistent", loader) is None
+
+
+def test_seed_and_panel_refs_dedupe_after_canonicalization():
+    # End-to-end of the bug: seed side and panel side must produce the SAME
+    # ref string for the same strategy so assemble_entrants dedupes (one
+    # entrant) instead of raising on a "distinct refs, same name" clash.
+    loader = _AliasLoader()
+    seed_ref = _resolvable_seed_ref("loader", "Big Money", loader)
+    panel_name = _panel_recorded_name(loader, "Big Money")
+
+    resolved = assemble_entrants([seed_ref, panel_name], _FakeLoader())
+
+    assert len(resolved) == 1
+    assert resolved[0][0] == "BigMoney"

--- a/tests/test_island_seeds.py
+++ b/tests/test_island_seeds.py
@@ -9,6 +9,7 @@ import pytest
 import dominion.analysis.island_seeds as island_seeds
 from dominion.analysis.island_seeds import (
     IslandSpec,
+    augment_panel_with_compatible,
     derive_island_specs,
     resolve_island_seed,
 )
@@ -152,6 +153,73 @@ class TestResolveIslandSeed:
     def test_unknown_kind_raises(self):
         with pytest.raises(ValueError, match="Unknown island spec kind"):
             resolve_island_seed(IslandSpec("weird", "x", "x"), _board(), _FakeLoader({}))
+
+    def test_library_resolution_not_truncated_below_derive(self, monkeypatch):
+        """Regression: with ``reuse_top_k`` > the old hardcoded 10, derive can
+        produce a library spec ranked beyond index 10. resolve must search far
+        enough to find it (it previously crashed with ``not found in strategy
+        library``). The lookup uses an effectively-unbounded ``top_k``."""
+        fake_entries = [_FakeLibraryEntry(f"Lib{i}") for i in range(15)]
+        monkeypatch.setattr(
+            island_seeds, "find_compatible_strategies",
+            lambda *a, **k: list(fake_entries),
+        )
+
+        specs = derive_island_specs(
+            _board(), max_islands=20, reuse_top_k=15, reuse_min_overlap=1
+        )
+        library_specs = [s for s in specs if s.kind == "library"]
+        assert len(library_specs) > 10
+
+        # Every derived library spec must resolve, including ones beyond index 10.
+        for spec in library_specs:
+            seed = resolve_island_seed(spec, _board(), _FakeLoader({}))
+            assert seed is not None and seed.name == spec.key
+
+        # Explicitly confirm an entry beyond the old top_k=10 bound resolves.
+        beyond = next(s for s in library_specs if s.key == "Lib11")
+        seed = resolve_island_seed(beyond, _board(), _FakeLoader({}))
+        assert seed is not None and seed.name == "Lib11"
+
+
+class TestAugmentPanelWithCompatible:
+    def test_adds_loadable_compatible_and_dedupes(self, monkeypatch):
+        compat = [
+            _FakeLibraryEntry("BigMoney"),  # dup of a baseline, dropped
+            _FakeLibraryEntry("EngineA"),
+            _FakeLibraryEntry("Unloadable"),  # loader can't resolve -> skipped
+            _FakeLibraryEntry("EngineB"),
+        ]
+        monkeypatch.setattr(
+            island_seeds, "find_compatible_strategies", lambda *a, **k: list(compat)
+        )
+        loader = _FakeLoader(
+            {"BigMoney": _strategy("BigMoney"),
+             "EngineA": _strategy("EngineA"),
+             "EngineB": _strategy("EngineB")}
+        )
+
+        names = augment_panel_with_compatible(_board(), ["BigMoney"], loader)
+
+        # Baseline first, then loadable+new compatible, dup and unloadable dropped.
+        assert names == ["BigMoney", "EngineA", "EngineB"]
+
+    def test_real_lisbon_panel_is_stronger_than_big_money_alone(self):
+        """On Lisbon the built-in baseline collapses to just Big Money; the
+        compatible-library augmentation must add real, loadable opponents so
+        the default panel is no longer a single weak opponent. Every name must
+        round-trip through StrategyLoader (the merge stage re-resolves them)."""
+        from dominion.boards.loader import load_board
+        from dominion.strategy.strategy_loader import StrategyLoader
+
+        board = load_board("boards/lisbon.txt")
+        loader = StrategyLoader()
+        names = augment_panel_with_compatible(board, ["Big Money"], loader)
+
+        assert names != ["Big Money"]
+        assert len(names) > 1
+        for name in names:
+            assert loader.get_strategy(name) is not None
 
 
 class TestRealBoardIntegration:

--- a/tests/test_island_seeds.py
+++ b/tests/test_island_seeds.py
@@ -28,9 +28,14 @@ def _strategy(name: str) -> EnhancedStrategy:
 
 
 class _FakeLibraryEntry:
-    def __init__(self, name: str):
+    def __init__(self, name: str, spec: str | None = None):
         self.name = name
-        self.factory = lambda _n=name: _strategy(_n)
+        # The real entry's ``spec`` is its unique ``module:function`` reference;
+        # default to a unique-per-name value so distinct fakes stay distinct.
+        self.spec = spec if spec is not None else f"fake.module:{name}"
+        # ``factory`` yields a strategy whose ``.name`` mirrors the spec, so a
+        # test can confirm which entry an island resolved to.
+        self.factory = lambda _n=self.spec: _strategy(_n)
 
 
 class _FakeLoader:
@@ -66,10 +71,51 @@ class TestDeriveIslandSpecs:
 
         specs = derive_island_specs(_board(), max_islands=6)
 
-        assert specs[0] == IslandSpec("library", "WitchEngine", "Reuse WitchEngine")
+        # Library specs are keyed by the entry *spec* (module:function), not
+        # the display name; the display name is "Reuse <name>".
+        assert specs[0] == IslandSpec("library", "fake.module:WitchEngine", "Reuse WitchEngine")
         assert specs[1] == IslandSpec("trick", "0", "Trail Butterfly Trick")
         assert specs[2] == IslandSpec("loader", "Big Money", "Big Money Island")
         assert [s.kind for s in specs[3:]] == ["random", "random", "random"]
+
+    def test_library_entries_sharing_a_name_get_distinct_key_and_name(self, monkeypatch):
+        """Two library strategies with the same display name but different
+        specs must yield two specs with DISTINCT keys (the specs) AND distinct
+        names — otherwise both islands resolve to the same seed and collide on
+        output filenames/logs."""
+        monkeypatch.setattr(
+            island_seeds, "find_compatible_strategies",
+            lambda *a, **k: [
+                _FakeLibraryEntry("BigMoneySmithy", spec="m:big_money_smithy"),
+                _FakeLibraryEntry("BigMoneySmithy", spec="m:big_money_smithy2"),
+            ],
+        )
+        monkeypatch.setattr(island_seeds, "build_seed_genomes", lambda board: [])
+
+        specs = derive_island_specs(_board(), max_islands=6)
+        library_specs = [s for s in specs if s.kind == "library"]
+
+        assert len(library_specs) == 2
+        # Distinct keys (the canonical module:function specs).
+        assert {s.key for s in library_specs} == {"m:big_money_smithy", "m:big_money_smithy2"}
+        # Distinct names (the second "Reuse BigMoneySmithy" is disambiguated).
+        assert len({s.name for s in library_specs}) == 2
+        assert "Reuse BigMoneySmithy" in {s.name for s in library_specs}
+
+    def test_roster_names_are_unique_even_when_library_names_collide(self, monkeypatch):
+        """General invariant: no two islands in a derived roster share a name,
+        even when several library entries collide on their display name."""
+        monkeypatch.setattr(
+            island_seeds, "find_compatible_strategies",
+            lambda *a, **k: [
+                _FakeLibraryEntry("Dup", spec=f"m:dup{i}") for i in range(3)
+            ],
+        )
+        monkeypatch.setattr(island_seeds, "build_seed_genomes", lambda board: [])
+
+        specs = derive_island_specs(_board(), max_islands=6)
+
+        assert len({s.name for s in specs}) == len(specs)
 
     def test_roster_is_truncated_at_max_islands(self, monkeypatch):
         monkeypatch.setattr(
@@ -174,22 +220,49 @@ class TestResolveIslandSeed:
         with pytest.raises(ValueError, match="out of range"):
             resolve_island_seed(IslandSpec("trick", "0", "Trick0"), _board(), _FakeLoader({}))
 
-    def test_library_seed_resolves_by_entry_name(self, monkeypatch):
+    def test_library_seed_resolves_by_entry_spec(self, monkeypatch):
         monkeypatch.setattr(
             island_seeds, "find_compatible_strategies",
             lambda *a, **k: [_FakeLibraryEntry("WitchEngine")],
         )
+        # The library branch matches on the entry spec (module:function), so
+        # the spec key is the entry's ``.spec``, not its display name.
         seed = resolve_island_seed(
-            IslandSpec("library", "WitchEngine", "Reuse WitchEngine"), _board(), _FakeLoader({})
+            IslandSpec("library", "fake.module:WitchEngine", "Reuse WitchEngine"),
+            _board(),
+            _FakeLoader({}),
         )
-        assert seed is not None and seed.name == "WitchEngine"
+        assert seed is not None and seed.name == "fake.module:WitchEngine"
 
     def test_library_seed_missing_raises(self, monkeypatch):
         monkeypatch.setattr(island_seeds, "find_compatible_strategies", lambda *a, **k: [])
         with pytest.raises(ValueError, match="not found in strategy library"):
             resolve_island_seed(
-                IslandSpec("library", "Gone", "Reuse Gone"), _board(), _FakeLoader({})
+                IslandSpec("library", "fake.module:Gone", "Reuse Gone"), _board(), _FakeLoader({})
             )
+
+    def test_library_seeds_sharing_a_name_resolve_to_own_strategy(self, monkeypatch):
+        """Regression: two library strategies can share a display name but have
+        distinct specs (e.g. big_money_smithy and big_money_smithy2 both name
+        themselves "BigMoneySmithy"). Keying by spec means each island resolves
+        to its OWN strategy rather than both collapsing onto the first match."""
+        entry_a = _FakeLibraryEntry("BigMoneySmithy", spec="dominion.strategy.strategies.big_money_smithy:build")
+        entry_b = _FakeLibraryEntry("BigMoneySmithy", spec="dominion.strategy.strategies.big_money_smithy2:build")
+        monkeypatch.setattr(
+            island_seeds, "find_compatible_strategies",
+            lambda *a, **k: [entry_a, entry_b],
+        )
+
+        spec_a = IslandSpec("library", entry_a.spec, "Reuse BigMoneySmithy")
+        spec_b = IslandSpec("library", entry_b.spec, "Reuse BigMoneySmithy")
+
+        seed_a = resolve_island_seed(spec_a, _board(), _FakeLoader({}))
+        seed_b = resolve_island_seed(spec_b, _board(), _FakeLoader({}))
+
+        # Each island resolves to its own strategy (the factory mirrors the spec).
+        assert seed_a is not None and seed_a.name == entry_a.spec
+        assert seed_b is not None and seed_b.name == entry_b.spec
+        assert seed_a.name != seed_b.name
 
     def test_unknown_kind_raises(self):
         with pytest.raises(ValueError, match="Unknown island spec kind"):
@@ -218,9 +291,9 @@ class TestResolveIslandSeed:
             assert seed is not None and seed.name == spec.key
 
         # Explicitly confirm an entry beyond the old top_k=10 bound resolves.
-        beyond = next(s for s in library_specs if s.key == "Lib11")
+        beyond = next(s for s in library_specs if s.key == "fake.module:Lib11")
         seed = resolve_island_seed(beyond, _board(), _FakeLoader({}))
-        assert seed is not None and seed.name == "Lib11"
+        assert seed is not None and seed.name == "fake.module:Lib11"
 
 
 class TestAugmentPanelWithCompatible:

--- a/tests/test_island_seeds.py
+++ b/tests/test_island_seeds.py
@@ -84,8 +84,49 @@ class TestDeriveIslandSpecs:
         specs = derive_island_specs(_board(), max_islands=5)
 
         assert len(specs) == 5
-        # Library entries (ranked by overlap) survive the cut first.
-        assert [s.kind for s in specs] == ["library"] * 4 + ["trick"]
+        # Big Money's slot is reserved in the last position; the strongest
+        # informed specs (library entries, ranked by overlap) fill the rest.
+        assert [s.kind for s in specs] == ["library"] * 4 + ["loader"]
+        assert specs[-1] == IslandSpec("loader", "Big Money", "Big Money Island")
+
+    def test_big_money_kept_when_informed_specs_fill_roster(self, monkeypatch):
+        """Regression: when library+trick alone meet/exceed max_islands, the
+        Big Money baseline must still be in the returned roster (it used to be
+        dropped by the final slice)."""
+        monkeypatch.setattr(
+            island_seeds, "find_compatible_strategies",
+            lambda *a, **k: [_FakeLibraryEntry(f"Lib{i}") for i in range(3)],
+        )
+        monkeypatch.setattr(
+            island_seeds, "build_seed_genomes",
+            lambda board: [(f"Trick{i}", _strategy(f"t{i}")) for i in range(3)],
+        )
+
+        # 3 library + 3 trick = 6 informed == max_islands (the bazaar_council case).
+        specs = derive_island_specs(_board(), max_islands=6)
+
+        assert len(specs) == 6
+        # Big Money is present and in the final reserved slot.
+        assert IslandSpec("loader", "Big Money", "Big Money Island") in specs
+        assert specs[-1] == IslandSpec("loader", "Big Money", "Big Money Island")
+        # Informed specs still lead, in ranked order, truncated to max-1.
+        assert [s.kind for s in specs[:-1]] == ["library"] * 3 + ["trick"] * 2
+        # No duplicate names.
+        assert len({s.name for s in specs}) == len(specs)
+
+    def test_max_islands_one_yields_only_big_money(self, monkeypatch):
+        monkeypatch.setattr(
+            island_seeds, "find_compatible_strategies",
+            lambda *a, **k: [_FakeLibraryEntry("Lib0")],
+        )
+        monkeypatch.setattr(
+            island_seeds, "build_seed_genomes",
+            lambda board: [("Trick0", _strategy("t0"))],
+        )
+
+        specs = derive_island_specs(_board(), max_islands=1)
+
+        assert specs == [IslandSpec("loader", "Big Money", "Big Money Island")]
 
     def test_specs_are_plain_string_dataclasses(self, monkeypatch):
         monkeypatch.setattr(island_seeds, "find_compatible_strategies", lambda *a, **k: [])

--- a/tests/test_island_seeds.py
+++ b/tests/test_island_seeds.py
@@ -1,0 +1,171 @@
+"""Tests for board-derived island seeds (dominion.analysis.island_seeds)."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+import pytest
+
+import dominion.analysis.island_seeds as island_seeds
+from dominion.analysis.island_seeds import (
+    IslandSpec,
+    derive_island_specs,
+    resolve_island_seed,
+)
+from dominion.boards.loader import BoardConfig
+from dominion.strategy.enhanced_strategy import EnhancedStrategy
+
+
+def _board() -> BoardConfig:
+    return BoardConfig(kingdom_cards=["Village", "Smithy", "Witch", "Chapel"])
+
+
+def _strategy(name: str) -> EnhancedStrategy:
+    s = EnhancedStrategy()
+    s.name = name
+    return s
+
+
+class _FakeLibraryEntry:
+    def __init__(self, name: str):
+        self.name = name
+        self.factory = lambda _n=name: _strategy(_n)
+
+
+class _FakeLoader:
+    def __init__(self, known: dict[str, EnhancedStrategy]):
+        self._known = known
+
+    def get_strategy(self, name: str):
+        return self._known.get(name)
+
+
+class TestDeriveIslandSpecs:
+    def test_random_islands_pad_the_roster(self, monkeypatch):
+        monkeypatch.setattr(island_seeds, "find_compatible_strategies", lambda *a, **k: [])
+        monkeypatch.setattr(island_seeds, "build_seed_genomes", lambda board: [])
+
+        specs = derive_island_specs(_board(), max_islands=4)
+
+        assert len(specs) == 4
+        assert specs[0] == IslandSpec("loader", "Big Money", "Big Money Island")
+        assert all(s.kind == "random" for s in specs[1:])
+        # Random islands get distinct names.
+        assert len({s.name for s in specs}) == 4
+
+    def test_library_and_trick_islands_come_first(self, monkeypatch):
+        monkeypatch.setattr(
+            island_seeds, "find_compatible_strategies",
+            lambda *a, **k: [_FakeLibraryEntry("WitchEngine")],
+        )
+        monkeypatch.setattr(
+            island_seeds, "build_seed_genomes",
+            lambda board: [("Trail Butterfly Trick", _strategy("trick0"))],
+        )
+
+        specs = derive_island_specs(_board(), max_islands=6)
+
+        assert specs[0] == IslandSpec("library", "WitchEngine", "Reuse WitchEngine")
+        assert specs[1] == IslandSpec("trick", "0", "Trail Butterfly Trick")
+        assert specs[2] == IslandSpec("loader", "Big Money", "Big Money Island")
+        assert [s.kind for s in specs[3:]] == ["random", "random", "random"]
+
+    def test_roster_is_truncated_at_max_islands(self, monkeypatch):
+        monkeypatch.setattr(
+            island_seeds, "find_compatible_strategies",
+            lambda *a, **k: [_FakeLibraryEntry(f"Lib{i}") for i in range(4)],
+        )
+        monkeypatch.setattr(
+            island_seeds, "build_seed_genomes",
+            lambda board: [(f"Trick{i}", _strategy(f"t{i}")) for i in range(4)],
+        )
+
+        specs = derive_island_specs(_board(), max_islands=5)
+
+        assert len(specs) == 5
+        # Library entries (ranked by overlap) survive the cut first.
+        assert [s.kind for s in specs] == ["library"] * 4 + ["trick"]
+
+    def test_specs_are_plain_string_dataclasses(self, monkeypatch):
+        monkeypatch.setattr(island_seeds, "find_compatible_strategies", lambda *a, **k: [])
+        monkeypatch.setattr(island_seeds, "build_seed_genomes", lambda board: [])
+
+        for spec in derive_island_specs(_board(), max_islands=3):
+            d = asdict(spec)
+            assert set(d) == {"kind", "key", "name"}
+            assert all(isinstance(v, str) for v in d.values())
+
+
+class TestResolveIslandSeed:
+    def test_random_resolves_to_none(self):
+        seed = resolve_island_seed(
+            IslandSpec("random", "1", "Random Island 1"), _board(), _FakeLoader({})
+        )
+        assert seed is None
+
+    def test_loader_seed_resolves(self):
+        bm = _strategy("BigMoney")
+        seed = resolve_island_seed(
+            IslandSpec("loader", "Big Money", "Big Money Island"),
+            _board(),
+            _FakeLoader({"Big Money": bm}),
+        )
+        assert seed is bm
+
+    def test_loader_seed_missing_raises(self):
+        with pytest.raises(ValueError, match="not found in strategy loader"):
+            resolve_island_seed(
+                IslandSpec("loader", "Nope", "Nope"), _board(), _FakeLoader({})
+            )
+
+    def test_trick_seed_resolves_by_index(self, monkeypatch):
+        t0, t1 = _strategy("t0"), _strategy("t1")
+        monkeypatch.setattr(
+            island_seeds, "build_seed_genomes",
+            lambda board: [("Trick0", t0), ("Trick1", t1)],
+        )
+        seed = resolve_island_seed(IslandSpec("trick", "1", "Trick1"), _board(), _FakeLoader({}))
+        assert seed is t1
+
+    def test_trick_index_out_of_range_raises(self, monkeypatch):
+        monkeypatch.setattr(island_seeds, "build_seed_genomes", lambda board: [])
+        with pytest.raises(ValueError, match="out of range"):
+            resolve_island_seed(IslandSpec("trick", "0", "Trick0"), _board(), _FakeLoader({}))
+
+    def test_library_seed_resolves_by_entry_name(self, monkeypatch):
+        monkeypatch.setattr(
+            island_seeds, "find_compatible_strategies",
+            lambda *a, **k: [_FakeLibraryEntry("WitchEngine")],
+        )
+        seed = resolve_island_seed(
+            IslandSpec("library", "WitchEngine", "Reuse WitchEngine"), _board(), _FakeLoader({})
+        )
+        assert seed is not None and seed.name == "WitchEngine"
+
+    def test_library_seed_missing_raises(self, monkeypatch):
+        monkeypatch.setattr(island_seeds, "find_compatible_strategies", lambda *a, **k: [])
+        with pytest.raises(ValueError, match="not found in strategy library"):
+            resolve_island_seed(
+                IslandSpec("library", "Gone", "Reuse Gone"), _board(), _FakeLoader({})
+            )
+
+    def test_unknown_kind_raises(self):
+        with pytest.raises(ValueError, match="Unknown island spec kind"):
+            resolve_island_seed(IslandSpec("weird", "x", "x"), _board(), _FakeLoader({}))
+
+
+class TestRealBoardIntegration:
+    def test_derive_specs_on_real_board(self):
+        """End-to-end: derive a roster for a real board file with the real
+        library and trick scanner — must produce a full roster topped off
+        with Big Money and at least one random island."""
+        from dominion.boards.loader import load_board
+
+        board = load_board("boards/siege_engine.txt")
+        specs = derive_island_specs(board, max_islands=6)
+
+        assert len(specs) == 6
+        kinds = {s.kind for s in specs}
+        assert "loader" in kinds or "library" in kinds
+        # Names are unique (the tournament keys islands by name).
+        assert len({s.name for s in specs}) == 6

--- a/tests/test_runner_panel.py
+++ b/tests/test_runner_panel.py
@@ -1,0 +1,47 @@
+"""Baseline-panel assembly regression tests for dominion.runner.
+
+Reuse is on by default, so a normal run with no ``--baseline-*`` must train
+against the DEFAULT baselines (Big Money + compatible built-ins) ALONGSIDE the
+reused strategies — not the reused strategies alone (PR #296 regression)."""
+
+from dominion.runner import merge_baseline_panel
+
+
+class _Strategy:
+    def __init__(self, name: str):
+        self.name = name
+
+
+def test_reuse_augments_default_panel_not_replaces():
+    default_panel = [_Strategy("Big Money"), _Strategy("ClerkCollectionColony")]
+    reused = [_Strategy("Reused A"), _Strategy("Reused B")]
+
+    panel = merge_baseline_panel(default_panel, reused)
+    names = [s.name for s in panel]
+
+    # Default baselines survive...
+    assert "Big Money" in names
+    assert "ClerkCollectionColony" in names
+    # ...alongside the reused strategies (not replaced by them).
+    assert "Reused A" in names
+    assert "Reused B" in names
+    assert names == ["Big Money", "ClerkCollectionColony", "Reused A", "Reused B"]
+
+
+def test_reuse_dedups_by_name():
+    default_panel = [_Strategy("Big Money")]
+    reused = [_Strategy("Big Money"), _Strategy("Reused A")]
+
+    panel = merge_baseline_panel(default_panel, reused)
+    names = [s.name for s in panel]
+
+    assert names.count("Big Money") == 1
+    assert names == ["Big Money", "Reused A"]
+
+
+def test_no_reuse_keeps_default_panel():
+    default_panel = [_Strategy("Big Money"), _Strategy("ClerkCollectionColony")]
+
+    panel = merge_baseline_panel(default_panel, [])
+
+    assert [s.name for s in panel] == ["Big Money", "ClerkCollectionColony"]


### PR DESCRIPTION
## Why

Third PR in the series (#294 evaluation, #295 genome). The discovery machinery this repo already had — the trick scanner, the strategy-reuse library — was opt-in or hardcoded to one board, so "hand it a board, get a strategy" required manual setup. This wires it all into the default paths.

## What changed

- **New `dominion/analysis/island_seeds.py`** — `derive_island_specs()` builds an island roster from the board itself: compatible strategies from the reuse library, one island per trick-scanner interaction, a Big Money archetype island, and random structured-menu islands to fill the roster (random init now produces coherent menus per #295, so unseeded islands are real hypotheses). Specs are plain string dataclasses (islands run in spawned subprocesses; strategy objects with lambda conditions can't cross that boundary); `resolve_island_seed()` rebuilds the seed inside the worker, failing loudly if a named seed is missing.

- **`scripts/island_evolve.py`** — `--seeds` now defaults to the board-derived roster; `LISBON_SEEDS`/`LISBON_PANEL` hardcoding is gone. The shared panel defaults to the built-in baseline panel compatible with the kingdom (`--panel` overrides), with names verified to round-trip through `StrategyLoader` since `island_merge` re-resolves them from the manifest.

- **`dominion/runner.py`** — `--reuse-compatible-strategies` is now on by default (`--no-reuse-compatible-strategies` to disable), with discovery failure downgraded from fatal to a warning; new default-on `--trick-seeds` flag injects trick-scanner seed genomes when `--board` is given (mirrors `evolve.py`).

## Validation

- Full suite: **1,700 passed** (13 new tests: roster derivation/truncation/padding, spec resolution including all failure modes, real-board integration).
- Smoke runs on `boards/siege_engine.txt`:
  - `island_evolve.py --smoke --max-islands 3` derives a roster, trains all islands, writes a tournament-ready manifest.
  - `dominion.runner --board ...` injects 3 reusable seeds + 3 trick seeds (`Trick Re-gain Plunder`, `Trick Re-gain Rocks`, `Trick Cost-mod Highway`) with no flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Island evolution is now board-agnostic: rosters are derived from the loaded board and per-island seeds are resolved accordingly (including tournament-resolvable `seed_ref` when available).
  * Island tournament runs are manifest-aware, building entrants from island outputs and optionally including seed references.
  * CLI defaults are now enabled by default for compatible reuse and trick seeds (with graceful fallback when unavailable).
* **Bug Fixes**
  * If compatible-strategy discovery fails, the run now warns and continues without reused entries.
* **Tests**
  * Added/expanded pytest coverage for roster derivation, seed resolution, compatible panel augmentation, manifest handling, tournament board precedence, and baseline-panel merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->