### PR TITLE
[codex] Fix Collection buy choices with landscapes

### DIFF
--- a/dominion/strategy/enhanced_strategy.py
+++ b/dominion/strategy/enhanced_strategy.py
@@ -442,7 +442,7 @@ class EnhancedStrategy:
         if getattr(player, "collection_played", 0) <= 0:
             return normal
 
-        if normal is not None and normal.is_action:
+        if normal is not None and getattr(normal, "is_action", False):
             return normal
 
         if normal is not None and normal.name not in {"Copper", "Silver"}:
@@ -452,7 +452,7 @@ class EnhancedStrategy:
             card
             for card in choices
             if card is not None
-            and card.is_action
+            and getattr(card, "is_action", False)
             and getattr(state, "supply", {}).get(card.name, 1) > 0
         ]
         if not actions:

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 
 from dominion.cards.registry import get_card
+from dominion.events.looting import Looting
+from dominion.projects.sewers import Sewers
 from dominion.strategy.card_roles import cards_with_role, infer_card_roles
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
 from dominion.strategy.lint import lint_strategy, normalize_strategy
@@ -18,6 +20,7 @@ def _state(turn_number=5, provinces_left=8, empty_piles=0):
 def _player(cards=None):
     cards = cards or []
     return SimpleNamespace(
+        collection_played=0,
         all_cards=lambda: list(cards),
         count_in_deck=lambda name: sum(1 for card in cards if card.name == name),
     )
@@ -94,6 +97,22 @@ def test_phase_aware_strategy_uses_phase_priority_then_fallback():
     )
 
     assert fallback.name == "Silver"
+
+
+def test_collection_gain_bias_ignores_landscape_buy_choices():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [PriorityRule("Silver")]
+    player = _player()
+    player.collection_played = 1
+    state = SimpleNamespace(supply={"Smithy": 10, "Silver": 40})
+
+    choice = strategy.choose_gain(
+        state,
+        player,
+        [Sewers(), Looting(), get_card("Silver"), get_card("Smithy"), None],
+    )
+
+    assert choice.name == "Smithy"
 
 
 def test_phase_classifier_switches_to_endgame():


### PR DESCRIPTION
Fixes a crash when Events or Projects appear in the buy menu while the Collection action-gain bias is active.

The root cause was the strategy helper assuming every buy choice was a card with `is_action`; landscape choices like `Sewers` and `Looting` do not expose that attribute.

The fix ignores non-action non-card choices while preserving the existing preference for useful Action gains.

Validated with `pytest tests/test_strategy_lint_and_phase.py -q` and a full landscape-included open-board smoke of 1,225 pairings / 2,450 games.