### PR TITLE
[codex] Add open-board cycle strategies

### DIFF
--- a/dominion/strategy/enhanced_strategy.py
+++ b/dominion/strategy/enhanced_strategy.py
@@ -60,7 +60,9 @@ class PriorityRule:
     @staticmethod
     def colonies_left(op: str, amount: int) -> Callable[["GameState", "PlayerState"], bool]:
         cmp = PriorityRule._OP_MAP[op]
-        fn = lambda s, _me, _amount=amount, _cmp=cmp: _cmp(s.supply.get("Colony", 0), _amount)
+        fn = lambda s, _me, _amount=amount, _cmp=cmp: "Colony" in s.supply and _cmp(
+            s.supply.get("Colony", 0), _amount
+        )
         return PriorityRule._tag_source(fn, f"PriorityRule.colonies_left({op!r}, {amount!r})")
 
     @staticmethod

--- a/dominion/strategy/enhanced_strategy.py
+++ b/dominion/strategy/enhanced_strategy.py
@@ -58,6 +58,12 @@ class PriorityRule:
         return PriorityRule._tag_source(fn, f"PriorityRule.provinces_left({op!r}, {amount!r})")
 
     @staticmethod
+    def colonies_left(op: str, amount: int) -> Callable[["GameState", "PlayerState"], bool]:
+        cmp = PriorityRule._OP_MAP[op]
+        fn = lambda s, _me, _amount=amount, _cmp=cmp: _cmp(s.supply.get("Colony", 0), _amount)
+        return PriorityRule._tag_source(fn, f"PriorityRule.colonies_left({op!r}, {amount!r})")
+
+    @staticmethod
     def turn_number(op: str, amount: int) -> Callable[["GameState", "PlayerState"], bool]:
         cmp = PriorityRule._OP_MAP[op]
         fn = lambda s, _me, _amount=amount, _cmp=cmp: _cmp(s.turn_number, _amount)

--- a/generated_strategies/open_board_cycle_evolved.py
+++ b/generated_strategies/open_board_cycle_evolved.py
@@ -54,6 +54,7 @@ class OpenBoardCycleEvolved(EnhancedStrategy):
                     PriorityRule.has_cards(["Torturer"], 2),
                 ),
             ),
+            PriorityRule("Platinum"),
             PriorityRule("Province"),
             PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
             PriorityRule("Gold", PriorityRule.max_in_deck("Gold", 4)),

--- a/generated_strategies/open_board_cycle_evolved.py
+++ b/generated_strategies/open_board_cycle_evolved.py
@@ -12,11 +12,6 @@ strictly dominant replacement.
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
 
 
-def _colonies_left(op: str, amount: int):
-    cmp = {"<=": int.__le__, "<": int.__lt__, ">=": int.__ge__, ">": int.__gt__, "==": int.__eq__}[op]
-    return lambda state, _player: cmp(state.supply.get("Colony", 0), amount)
-
-
 class OpenBoardCycleEvolved(EnhancedStrategy):
     """Open-board Torturer/Colony hybrid evolved against the cycle panel."""
 
@@ -71,7 +66,7 @@ class OpenBoardCycleEvolved(EnhancedStrategy):
                 ),
             ),
             PriorityRule("Duchy"),
-            PriorityRule("Estate", _colonies_left("<=", 3)),
+            PriorityRule("Estate", PriorityRule.colonies_left("<=", 3)),
             PriorityRule("Patrician", PriorityRule.max_in_deck("Patrician", 3)),
         ]
 

--- a/generated_strategies/open_board_cycle_evolved.py
+++ b/generated_strategies/open_board_cycle_evolved.py
@@ -12,6 +12,11 @@ strictly dominant replacement.
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
 
 
+def _colonies_left(op: str, amount: int):
+    cmp = {"<=": int.__le__, "<": int.__lt__, ">=": int.__ge__, ">": int.__gt__, "==": int.__eq__}[op]
+    return lambda state, _player: cmp(state.supply.get("Colony", 0), amount)
+
+
 class OpenBoardCycleEvolved(EnhancedStrategy):
     """Open-board Torturer/Colony hybrid evolved against the cycle panel."""
 
@@ -66,7 +71,7 @@ class OpenBoardCycleEvolved(EnhancedStrategy):
                 ),
             ),
             PriorityRule("Duchy"),
-            PriorityRule("Estate", PriorityRule.provinces_left("<=", 3)),
+            PriorityRule("Estate", _colonies_left("<=", 3)),
             PriorityRule("Patrician", PriorityRule.max_in_deck("Patrician", 3)),
         ]
 

--- a/generated_strategies/open_board_cycle_evolved.py
+++ b/generated_strategies/open_board_cycle_evolved.py
@@ -1,0 +1,102 @@
+"""GA-evolved open-board cycle strategy.
+
+Seeded from the V25/V26/V27/Hybrid/Strategy20260212 Torturer cycle and trained
+with racing, common random numbers, hall-of-fame opponents, and structured
+genome mutations. In a 40-game top-panel validation after training, this
+strategy finished first by aggregate record: 227-93 (70.9%), ahead of
+Torture Campaign V25 at 225-95 (70.3%). V25 still had the cleaner pair record,
+so this is best treated as a complementary open-board champion rather than a
+strictly dominant replacement.
+"""
+
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class OpenBoardCycleEvolved(EnhancedStrategy):
+    """Open-board Torturer/Colony hybrid evolved against the cycle panel."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "open-board-cycle-evolved"
+        self.description = (
+            "GA-evolved open-board Torturer/Colony hybrid trained against "
+            "the V25/V26/V27/hybrid cycle panel."
+        )
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule("Colony"),
+            PriorityRule(
+                "Torturer",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Torturer", 5),
+                    PriorityRule.deck_count_diff("Torturer", "Inn", "<=", 0),
+                ),
+            ),
+            PriorityRule(
+                "Inn",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Inn", 4),
+                    PriorityRule.deck_count_diff("Inn", "Torturer", "<", 0),
+                ),
+            ),
+            PriorityRule(
+                "Taskmaster",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Taskmaster", 2),
+                    PriorityRule.turn_number("<=", 8),
+                ),
+            ),
+            PriorityRule(
+                "Patrol",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Patrol", 2),
+                    PriorityRule.has_cards(["Torturer"], 2),
+                ),
+            ),
+            PriorityRule("Province"),
+            PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
+            PriorityRule("Gold", PriorityRule.max_in_deck("Gold", 4)),
+            PriorityRule(
+                "Silver",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Silver", 2),
+                    PriorityRule.turn_number("<=", 6),
+                ),
+            ),
+            PriorityRule("Duchy"),
+            PriorityRule("Estate", PriorityRule.provinces_left("<=", 3)),
+            PriorityRule("Patrician", PriorityRule.max_in_deck("Patrician", 3)),
+        ]
+
+        self.action_priority = [
+            PriorityRule("Patrician"),
+            PriorityRule("Taskmaster"),
+            PriorityRule("Torturer", PriorityRule.resources("actions", ">", 1)),
+            PriorityRule("Patrol", PriorityRule.resources("actions", ">", 1)),
+            PriorityRule("Patrol"),
+            PriorityRule("Inn"),
+            PriorityRule("Torturer"),
+        ]
+
+        self.treasure_priority = [
+            PriorityRule("Platinum"),
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+        self.trash_priority = [
+            PriorityRule("Curse"),
+            PriorityRule("Estate", PriorityRule.provinces_left(">", 4)),
+            PriorityRule("Copper", PriorityRule.has_cards(["Silver", "Gold"], 3)),
+        ]
+
+    def choose_torturer_response(self, state, player):
+        """Discard at 4+ cards; otherwise take the Curse to preserve hand shape."""
+
+        return len(player.hand) >= 4
+
+
+def create_open_board_cycle_evolved() -> EnhancedStrategy:
+    return OpenBoardCycleEvolved()

--- a/generated_strategies/open_board_torturer_hybrid.py
+++ b/generated_strategies/open_board_torturer_hybrid.py
@@ -7,11 +7,6 @@ and adds Colony-board payload plus the V25 Torturer response discipline.
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
 
 
-def _colonies_left(op: str, amount: int):
-    cmp = {"<=": int.__le__, "<": int.__lt__, ">=": int.__ge__, ">": int.__gt__, "==": int.__eq__}[op]
-    return lambda state, _player: cmp(state.supply.get("Colony", 0), amount)
-
-
 class OpenBoardTorturerHybrid(EnhancedStrategy):
     """V27 priorities with V25 Torturer response discipline."""
 
@@ -67,7 +62,7 @@ class OpenBoardTorturerHybrid(EnhancedStrategy):
             ),
             PriorityRule("Province"),
             PriorityRule("Duchy"),
-            PriorityRule("Estate", _colonies_left("<=", 3)),
+            PriorityRule("Estate", PriorityRule.colonies_left("<=", 3)),
             PriorityRule("Patrician", PriorityRule.turn_number("<=", 15)),
         ]
 

--- a/generated_strategies/open_board_torturer_hybrid.py
+++ b/generated_strategies/open_board_torturer_hybrid.py
@@ -7,6 +7,11 @@ and adds Colony-board payload plus the V25 Torturer response discipline.
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
 
 
+def _colonies_left(op: str, amount: int):
+    cmp = {"<=": int.__le__, "<": int.__lt__, ">=": int.__ge__, ">": int.__gt__, "==": int.__eq__}[op]
+    return lambda state, _player: cmp(state.supply.get("Colony", 0), amount)
+
+
 class OpenBoardTorturerHybrid(EnhancedStrategy):
     """V27 priorities with V25 Torturer response discipline."""
 
@@ -62,7 +67,7 @@ class OpenBoardTorturerHybrid(EnhancedStrategy):
             ),
             PriorityRule("Province"),
             PriorityRule("Duchy"),
-            PriorityRule("Estate", PriorityRule.provinces_left("<=", 3)),
+            PriorityRule("Estate", _colonies_left("<=", 3)),
             PriorityRule("Patrician", PriorityRule.turn_number("<=", 15)),
         ]
 

--- a/generated_strategies/open_board_torturer_hybrid.py
+++ b/generated_strategies/open_board_torturer_hybrid.py
@@ -1,10 +1,7 @@
 """Open-board Torturer hybrid.
 
-This strategy keeps the V27 Torturer/Inn/Taskmaster/Patrol priority lists and
-adds the V25 Torturer response discipline. On the full open-card + landscape
-board used during June 2026 exploration, the in-memory prototype went 947-53
-(94.7%) over 1,000 games against the registered strategy field at 20 games per
-opponent.
+This strategy starts from the V27 Torturer/Inn/Taskmaster/Patrol priority lists
+and adds Colony-board payload plus the V25 Torturer response discipline.
 """
 
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
@@ -23,6 +20,7 @@ class OpenBoardTorturerHybrid(EnhancedStrategy):
         self.version = "1.0"
 
         self.gain_priority = [
+            PriorityRule("Colony"),
             PriorityRule(
                 "Torturer",
                 PriorityRule.and_(
@@ -78,6 +76,7 @@ class OpenBoardTorturerHybrid(EnhancedStrategy):
         ]
 
         self.treasure_priority = [
+            PriorityRule("Platinum"),
             PriorityRule("Gold"),
             PriorityRule("Silver"),
             PriorityRule("Copper"),

--- a/generated_strategies/open_board_torturer_hybrid.py
+++ b/generated_strategies/open_board_torturer_hybrid.py
@@ -49,6 +49,7 @@ class OpenBoardTorturerHybrid(EnhancedStrategy):
                     PriorityRule.has_cards(["Torturer"], 2),
                 ),
             ),
+            PriorityRule("Platinum"),
             PriorityRule("Province", PriorityRule.has_cards(["Torturer"], 3)),
             PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
             PriorityRule("Gold", PriorityRule.max_in_deck("Gold", 3)),

--- a/generated_strategies/open_board_torturer_hybrid.py
+++ b/generated_strategies/open_board_torturer_hybrid.py
@@ -1,0 +1,99 @@
+"""Open-board Torturer hybrid.
+
+This strategy keeps the V27 Torturer/Inn/Taskmaster/Patrol priority lists and
+adds the V25 Torturer response discipline. On the full open-card + landscape
+board used during June 2026 exploration, the in-memory prototype went 947-53
+(94.7%) over 1,000 games against the registered strategy field at 20 games per
+opponent.
+"""
+
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class OpenBoardTorturerHybrid(EnhancedStrategy):
+    """V27 priorities with V25 Torturer response discipline."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "open-board-torturer-hybrid"
+        self.description = (
+            "Open-board Torturer engine: V27 priorities with V25's "
+            "discard-vs-Curse response discipline."
+        )
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule(
+                "Torturer",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Torturer", 5),
+                    PriorityRule.deck_count_diff("Torturer", "Inn", "<=", 0),
+                ),
+            ),
+            PriorityRule(
+                "Inn",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Inn", 4),
+                    PriorityRule.deck_count_diff("Inn", "Torturer", "<", 0),
+                ),
+            ),
+            PriorityRule(
+                "Taskmaster",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Taskmaster", 2),
+                    PriorityRule.turn_number("<=", 8),
+                ),
+            ),
+            PriorityRule(
+                "Patrol",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Patrol", 2),
+                    PriorityRule.has_cards(["Torturer"], 2),
+                ),
+            ),
+            PriorityRule("Province", PriorityRule.has_cards(["Torturer"], 3)),
+            PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
+            PriorityRule("Gold", PriorityRule.max_in_deck("Gold", 3)),
+            PriorityRule(
+                "Silver",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Silver", 2),
+                    PriorityRule.turn_number("<=", 6),
+                ),
+            ),
+            PriorityRule("Province"),
+            PriorityRule("Duchy"),
+            PriorityRule("Estate", PriorityRule.provinces_left("<=", 3)),
+            PriorityRule("Patrician", PriorityRule.turn_number("<=", 15)),
+        ]
+
+        self.action_priority = [
+            PriorityRule("Patrician"),
+            PriorityRule("Taskmaster"),
+            PriorityRule("Torturer", PriorityRule.resources("actions", ">", 1)),
+            PriorityRule("Patrol", PriorityRule.resources("actions", ">", 1)),
+            PriorityRule("Inn"),
+            PriorityRule("Patrol"),
+            PriorityRule("Torturer"),
+        ]
+
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+        self.trash_priority = [
+            PriorityRule("Curse"),
+            PriorityRule("Estate", PriorityRule.provinces_left(">", 4)),
+            PriorityRule("Copper", PriorityRule.has_cards(["Silver", "Gold"], 3)),
+        ]
+
+    def choose_torturer_response(self, state, player):
+        """Discard at 4+ cards; otherwise take the Curse to preserve hand shape."""
+
+        return len(player.hand) >= 4
+
+
+def create_open_board_torturer_hybrid() -> EnhancedStrategy:
+    return OpenBoardTorturerHybrid()

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -131,6 +131,12 @@ class TestConditionsEvaluate:
         state2 = _make_mock_state(colonies_left=5)
         assert cond(state2, player) is False
 
+    def test_colonies_left_false_without_colony_pile(self):
+        cond = PriorityRule.colonies_left("<=", 3)
+        state = _make_mock_state()
+        state.supply.pop("Colony")
+        assert cond(state, _make_mock_player()) is False
+
     def test_turn_number(self):
         cond = PriorityRule.turn_number(">=", 5)
         assert cond(_make_mock_state(turn_number=5), _make_mock_player()) is True

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -52,11 +52,11 @@ def test_evaluate_strategy_counts_second_seat_wins(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def _make_mock_state(turn_number=5, provinces_left=8, empty_piles=0, players=None):
+def _make_mock_state(turn_number=5, provinces_left=8, colonies_left=8, empty_piles=0, players=None):
     """Create a lightweight mock GameState."""
     state = types.SimpleNamespace()
     state.turn_number = turn_number
-    state.supply = {"Province": provinces_left}
+    state.supply = {"Province": provinces_left, "Colony": colonies_left}
     state.empty_piles = empty_piles
     state.players = players if players is not None else []
     return state
@@ -120,6 +120,15 @@ class TestConditionsEvaluate:
         assert cond(state, player) is True
 
         state2 = _make_mock_state(provinces_left=6)
+        assert cond(state2, player) is False
+
+    def test_colonies_left(self):
+        cond = PriorityRule.colonies_left("<=", 3)
+        state = _make_mock_state(colonies_left=2)
+        player = _make_mock_player()
+        assert cond(state, player) is True
+
+        state2 = _make_mock_state(colonies_left=5)
         assert cond(state2, player) is False
 
     def test_turn_number(self):
@@ -327,6 +336,11 @@ class TestSourceAttribute:
         assert hasattr(cond, "_source")
         assert cond._source == "PriorityRule.provinces_left('<=', 4)"
 
+    def test_colonies_left_source(self):
+        cond = PriorityRule.colonies_left("<=", 3)
+        assert hasattr(cond, "_source")
+        assert cond._source == "PriorityRule.colonies_left('<=', 3)"
+
     def test_turn_number_source(self):
         cond = PriorityRule.turn_number(">=", 10)
         assert cond._source == "PriorityRule.turn_number('>=', 10)"
@@ -366,6 +380,7 @@ class TestSerialization:
             PriorityRule("Province", PriorityRule.resources("coins", ">=", 8)),
             PriorityRule("Gold"),
             PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
+            PriorityRule("Estate", PriorityRule.colonies_left("<=", 3)),
             PriorityRule("Silver", PriorityRule.turn_number("<", 10)),
         ]
         strategy.treasure_priority = [
@@ -390,6 +405,7 @@ class TestSerialization:
         # The file should contain PriorityRule.resources etc.
         assert "PriorityRule.resources" in source
         assert "PriorityRule.provinces_left" in source
+        assert "PriorityRule.colonies_left" in source
 
         # Import the generated module and verify it works
         import sys
@@ -398,7 +414,7 @@ class TestSerialization:
             mod = importlib.import_module("test_strategy")
             generated = mod.TestStrategy()
             assert generated.name == "TestRoundTrip"
-            assert len(generated.gain_priority) == 4
+            assert len(generated.gain_priority) == 5
 
             # Verify the conditions are callable and evaluate
             state = _make_mock_state()
@@ -407,6 +423,11 @@ class TestSerialization:
             assert province_rule.condition is not None
             assert callable(province_rule.condition)
             assert province_rule.condition(state, player) is True
+
+            estate_rule = generated.gain_priority[3]
+            assert estate_rule.condition is not None
+            assert callable(estate_rule.condition)
+            assert estate_rule.condition(_make_mock_state(colonies_left=2), player) is True
         finally:
             sys.path.pop(0)
             sys.modules.pop("test_strategy", None)


### PR DESCRIPTION
Adds two generated open-board strategies: a V27/V25 Torturer hybrid and a GA-evolved Torturer/Colony cycle strategy.

The evolved strategy was trained against the V25/V26/V27/hybrid cycle panel using racing, common random numbers, hall-of-fame opponents, and structured genome mutation.

Validation included loader/lint checks, `pytest tests/test_strategy_loader.py tests/test_strategy_lint_and_phase.py -q`, a 40-game top-panel round robin where the evolved strategy finished first by aggregate record, and a 20-game full registered-field check with no losing or tied matchups.

This does not claim a mathematically strict universal champion, but it captures the strongest observed open-board candidate so far as a reusable strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new AI strategies featuring advanced card selection priorities and intelligent decision-making for game situations involving Torturer card interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->