### PR TITLE
[codex] Clean generated strategies before publication

### DIFF
--- a/dominion/runner.py
+++ b/dominion/runner.py
@@ -41,10 +41,11 @@ def save_strategy_as_python(
     class_name: str = "GeneratedStrategy",
     *,
     clean_for_publication: bool = True,
+    board_config: BoardConfig | None = None,
 ) -> None:
     """Serialize an EnhancedStrategy as a Python module."""
     if clean_for_publication:
-        strategy = cleanup_for_publication(strategy)
+        strategy = cleanup_for_publication(strategy, board_config=board_config)
 
     def format_list(name: str, rules: list[PriorityRule]) -> list[str]:
         lines = [f"        self.{name} = ["]
@@ -417,7 +418,7 @@ def main():
     if best_strategy is None:
         logger.info("No viable strategy was found.")
     else:
-        best_strategy = cleanup_for_publication(best_strategy)
+        best_strategy = cleanup_for_publication(best_strategy, board_config=board_config)
         lint_warnings = lint_strategy(best_strategy)
         if lint_warnings:
             logger.info("Strategy lint diagnostics:")
@@ -487,7 +488,12 @@ def main():
 
         # Save the strategy
         try:
-            save_strategy_as_python(best_strategy, strategy_path, class_name)
+            save_strategy_as_python(
+                best_strategy,
+                strategy_path,
+                class_name,
+                board_config=board_config,
+            )
             logger.info("✅ Strategy automatically saved to: %s", strategy_path)
             logger.info("Class name: %s", class_name)
             logger.info("Win rate vs BigMoney: %.1f%%", metrics.get('win_rate', 0.0))

--- a/dominion/runner.py
+++ b/dominion/runner.py
@@ -11,7 +11,7 @@ from dominion.boards.loader import BoardConfig, load_board
 from dominion.analysis.strategy_library import find_compatible_strategies
 from dominion.simulation.genetic_trainer import GeneticTrainer
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
-from dominion.strategy.lint import lint_strategy, normalize_strategy
+from dominion.strategy.lint import cleanup_for_publication, lint_strategy
 
 logger = logging.getLogger(__name__)
 coloredlogs.install(level="INFO", logger=logger)
@@ -35,8 +35,16 @@ def load_kingdom_cards_from_yaml(yaml_path: str) -> tuple[list[str], dict]:
         raise ValueError(f"Error parsing YAML file: {e}")
 
 
-def save_strategy_as_python(strategy: EnhancedStrategy, path: Path, class_name: str = "GeneratedStrategy") -> None:
+def save_strategy_as_python(
+    strategy: EnhancedStrategy,
+    path: Path,
+    class_name: str = "GeneratedStrategy",
+    *,
+    clean_for_publication: bool = True,
+) -> None:
     """Serialize an EnhancedStrategy as a Python module."""
+    if clean_for_publication:
+        strategy = cleanup_for_publication(strategy)
 
     def format_list(name: str, rules: list[PriorityRule]) -> list[str]:
         lines = [f"        self.{name} = ["]
@@ -409,7 +417,7 @@ def main():
     if best_strategy is None:
         logger.info("No viable strategy was found.")
     else:
-        best_strategy = normalize_strategy(best_strategy)
+        best_strategy = cleanup_for_publication(best_strategy)
         lint_warnings = lint_strategy(best_strategy)
         if lint_warnings:
             logger.info("Strategy lint diagnostics:")

--- a/dominion/runner.py
+++ b/dominion/runner.py
@@ -336,7 +336,7 @@ def main():
     # Trick-scanner seeds: one strategy per mechanical interaction surfaced
     # on this board, so the GA starts with the trick encoded instead of
     # having to rediscover it by random mutation. Mirrors evolve.py.
-    if args.trick_seeds and board_config is not None:
+    if args.trick_seeds and args.board and board_config is not None:
         from dominion.analysis.seed_genomes import build_seed_genomes
 
         try:

--- a/dominion/runner.py
+++ b/dominion/runner.py
@@ -259,6 +259,9 @@ def main():
         ]
         logger.info("Using default kingdom cards: %s", ", ".join(kingdom_cards))
 
+    if board_config is None:
+        board_config = BoardConfig(list(kingdom_cards))
+
     # Use parameters from command line args, falling back to YAML config, then defaults
     population_size = args.population_size or training_params.get('population_size', 5)
     generations = args.generations or training_params.get('generations', 10)

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -22,7 +22,7 @@ Severity = Literal["info", "warning", "error"]
 
 _HAS_CARDS_ZERO_RE = re.compile(r"^PriorityRule\.has_cards\(.+,\s*0\)$")
 _BUILTIN_OFF_MENU_ACTION_GAINS = frozenset({"Trail"})
-_GAMESTATE_OFF_MENU_ACTION_GAINERS = frozenset({"Quartermaster"})
+_EXPLICIT_OFF_MENU_ACTION_GAINERS = frozenset({"Forge", "Quartermaster"})
 
 
 @dataclass(frozen=True)
@@ -253,7 +253,7 @@ def _board_has_non_card_off_menu_gain_paths(board_config: BoardConfig | None) ->
 def _card_can_gain_off_menu_actions(card_name: str) -> bool:
     return (
         card_name == "Collection"
-        or card_name in _GAMESTATE_OFF_MENU_ACTION_GAINERS
+        or card_name in _EXPLICIT_OFF_MENU_ACTION_GAINERS
         or infer_card_roles(card_name).has("gainer")
     )
 

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import Iterable, Literal, Optional
 
 from dominion.boards.loader import BoardConfig
+from dominion.cards.registry import get_card
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
 from dominion.strategy.card_roles import infer_card_roles
 from dominion.strategy.genome_simplification import simplify_strategy
@@ -247,7 +248,18 @@ def _board_has_non_card_off_menu_gain_paths(board_config: BoardConfig | None) ->
         or board_config.ways
         or board_config.allies
         or board_config.traits
+        or _board_has_omen(board_config)
     )
+
+
+def _board_has_omen(board_config: BoardConfig) -> bool:
+    for card_name in board_config.kingdom_cards:
+        try:
+            if get_card(card_name).is_omen:
+                return True
+        except ValueError:
+            continue
+    return False
 
 
 def _card_can_gain_off_menu_actions(card_name: str) -> bool:
@@ -269,9 +281,9 @@ def cleanup_for_publication(
     intact, applies behavior-preserving syntactic simplification, and removes
     action rules for cards the strategy never tries to gain only when the board
     context rules out off-menu Action gain paths. Collection, gainers, Events,
-    Ways, Allies, and Traits can cause a strategy to gain Actions that are not
-    explicitly named in gain_priority, so action priorities remain meaningful
-    in those cases.
+    Ways, Allies, Traits, and Omens can cause a strategy to gain Actions that
+    are not explicitly named in gain_priority, so action priorities remain
+    meaningful in those cases.
     """
 
     cleaned = normalize_strategy(strategy)

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -24,7 +24,7 @@ Severity = Literal["info", "warning", "error"]
 _HAS_CARDS_ZERO_RE = re.compile(r"^PriorityRule\.has_cards\(.+,\s*0\)$")
 _BUILTIN_OFF_MENU_ACTION_GAINS = frozenset({"Trail"})
 _EXPLICIT_OFF_MENU_ACTION_GAINERS = frozenset(
-    {"Death Cart", "Forge", "Overlord", "Page", "Peasant", "Quartermaster"}
+    {"Death Cart", "Forge", "Livery", "Overlord", "Page", "Peasant", "Quartermaster"}
 )
 
 

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -241,15 +241,19 @@ def cleanup_for_publication(strategy: EnhancedStrategy) -> EnhancedStrategy:
 
     This pass is intentionally conservative. It keeps the evaluated gain policy
     intact, applies behavior-preserving syntactic simplification, and removes
-    action rules for cards the strategy never tries to gain. Such rules are
-    noise in generated files: they cannot affect normal play unless an opponent
-    or card effect hands the strategy an off-plan action, and the executor
-    already has a fallback for unexpected actions.
+    action rules for cards the strategy never tries to gain only when the
+    strategy has no known off-menu gain path. Collection and gainers can cause
+    a strategy to gain Actions that are not explicitly named in gain_priority,
+    so action priorities remain meaningful in those cases.
     """
 
     cleaned = normalize_strategy(strategy)
     gained_cards = {rule.card_name for rule in getattr(cleaned, "gain_priority", []) or []}
-    if gained_cards:
+    can_gain_off_menu_actions = any(
+        card_name == "Collection" or infer_card_roles(card_name).has("gainer")
+        for card_name in gained_cards
+    )
+    if gained_cards and not can_gain_off_menu_actions:
         cleaned.action_priority = [
             rule
             for rule in getattr(cleaned, "action_priority", []) or []

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -252,6 +252,7 @@ def _board_has_non_card_off_menu_gain_paths(board_config: BoardConfig | None) ->
         or board_config.traits
         or _board_has_omen(board_config)
         or _board_has_attack(board_config)
+        or _board_has_fate_or_doom(board_config)
     )
 
 
@@ -275,6 +276,17 @@ def _board_has_omen(board_config: BoardConfig) -> bool:
     return False
 
 
+def _board_has_fate_or_doom(board_config: BoardConfig) -> bool:
+    for card_name in board_config.kingdom_cards:
+        try:
+            card = get_card(card_name)
+        except ValueError:
+            continue
+        if card.is_fate or card.is_doom:
+            return True
+    return False
+
+
 def _card_can_gain_off_menu_actions(card_name: str) -> bool:
     return (
         card_name == "Collection"
@@ -295,9 +307,9 @@ def cleanup_for_publication(
     intact, applies behavior-preserving syntactic simplification, and removes
     action rules for cards the strategy never tries to gain only when the board
     context rules out off-menu Action gain paths. Collection, gainers, Events,
-    Ways, Allies, Traits, Omens, and Attacks can cause a strategy to gain
-    Actions that are not explicitly named in gain_priority, so action
-    priorities remain meaningful in those cases.
+    Ways, Allies, Traits, Omens, Attacks, Fate, and Doom cards can cause a
+    strategy to gain Actions that are not explicitly named in gain_priority, so
+    action priorities remain meaningful in those cases.
     """
 
     cleaned = normalize_strategy(strategy)

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -251,7 +251,18 @@ def _board_has_non_card_off_menu_gain_paths(board_config: BoardConfig | None) ->
         or board_config.allies
         or board_config.traits
         or _board_has_omen(board_config)
+        or _board_has_attack(board_config)
     )
+
+
+def _board_has_attack(board_config: BoardConfig) -> bool:
+    for card_name in board_config.kingdom_cards:
+        try:
+            if get_card(card_name).is_attack:
+                return True
+        except ValueError:
+            continue
+    return False
 
 
 def _board_has_omen(board_config: BoardConfig) -> bool:
@@ -283,9 +294,9 @@ def cleanup_for_publication(
     intact, applies behavior-preserving syntactic simplification, and removes
     action rules for cards the strategy never tries to gain only when the board
     context rules out off-menu Action gain paths. Collection, gainers, Events,
-    Ways, Allies, Traits, and Omens can cause a strategy to gain Actions that
-    are not explicitly named in gain_priority, so action priorities remain
-    meaningful in those cases.
+    Ways, Allies, Traits, Omens, and Attacks can cause a strategy to gain
+    Actions that are not explicitly named in gain_priority, so action
+    priorities remain meaningful in those cases.
     """
 
     cleaned = normalize_strategy(strategy)

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -242,7 +242,12 @@ def normalize_strategy(strategy: EnhancedStrategy) -> EnhancedStrategy:
 def _board_has_non_card_off_menu_gain_paths(board_config: BoardConfig | None) -> bool:
     if board_config is None:
         return True
-    return bool(board_config.events or board_config.ways or board_config.allies)
+    return bool(
+        board_config.events
+        or board_config.ways
+        or board_config.allies
+        or board_config.traits
+    )
 
 
 def _card_can_gain_off_menu_actions(card_name: str) -> bool:
@@ -264,7 +269,7 @@ def cleanup_for_publication(
     intact, applies behavior-preserving syntactic simplification, and removes
     action rules for cards the strategy never tries to gain only when the board
     context rules out off-menu Action gain paths. Collection, gainers, Events,
-    Ways, and Allies can cause a strategy to gain Actions that are not
+    Ways, Allies, and Traits can cause a strategy to gain Actions that are not
     explicitly named in gain_priority, so action priorities remain meaningful
     in those cases.
     """

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -13,6 +13,7 @@ import re
 from dataclasses import dataclass
 from typing import Iterable, Literal, Optional
 
+from dominion.boards.loader import BoardConfig
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
 from dominion.strategy.card_roles import infer_card_roles
 from dominion.strategy.genome_simplification import simplify_strategy
@@ -237,20 +238,30 @@ def normalize_strategy(strategy: EnhancedStrategy) -> EnhancedStrategy:
     return simplify_strategy(strategy)
 
 
-def cleanup_for_publication(strategy: EnhancedStrategy) -> EnhancedStrategy:
+def _board_has_non_card_off_menu_gain_paths(board_config: BoardConfig | None) -> bool:
+    if board_config is None:
+        return True
+    return bool(board_config.events or board_config.ways)
+
+
+def cleanup_for_publication(
+    strategy: EnhancedStrategy,
+    *,
+    board_config: BoardConfig | None = None,
+) -> EnhancedStrategy:
     """Return a generated-strategy copy suitable for publication.
 
     This pass is intentionally conservative. It keeps the evaluated gain policy
     intact, applies behavior-preserving syntactic simplification, and removes
-    action rules for cards the strategy never tries to gain only when the
-    strategy has no known off-menu gain path. Collection and gainers can cause
-    a strategy to gain Actions that are not explicitly named in gain_priority,
-    so action priorities remain meaningful in those cases.
+    action rules for cards the strategy never tries to gain only when the board
+    context rules out off-menu Action gain paths. Collection, gainers, Events,
+    and Ways can cause a strategy to gain Actions that are not explicitly named
+    in gain_priority, so action priorities remain meaningful in those cases.
     """
 
     cleaned = normalize_strategy(strategy)
     gained_cards = {rule.card_name for rule in getattr(cleaned, "gain_priority", []) or []}
-    can_gain_off_menu_actions = any(
+    can_gain_off_menu_actions = _board_has_non_card_off_menu_gain_paths(board_config) or any(
         card_name == "Collection" or infer_card_roles(card_name).has("gainer")
         for card_name in gained_cards
     )

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -24,7 +24,7 @@ Severity = Literal["info", "warning", "error"]
 _HAS_CARDS_ZERO_RE = re.compile(r"^PriorityRule\.has_cards\(.+,\s*0\)$")
 _BUILTIN_OFF_MENU_ACTION_GAINS = frozenset({"Trail"})
 _EXPLICIT_OFF_MENU_ACTION_GAINERS = frozenset(
-    {"Forge", "Page", "Peasant", "Quartermaster"}
+    {"Death Cart", "Forge", "Overlord", "Page", "Peasant", "Quartermaster"}
 )
 
 
@@ -279,6 +279,7 @@ def _card_can_gain_off_menu_actions(card_name: str) -> bool:
     return (
         card_name == "Collection"
         or card_name in _EXPLICIT_OFF_MENU_ACTION_GAINERS
+        or infer_card_roles(card_name).has("command")
         or infer_card_roles(card_name).has("gainer")
     )
 

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import Iterable, Literal, Optional
 
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
+from dominion.strategy.card_roles import infer_card_roles
 from dominion.strategy.genome_simplification import simplify_strategy
 
 Severity = Literal["info", "warning", "error"]
@@ -132,6 +133,44 @@ def _lint_priority_list(
         if rule.condition is None:
             first_unconditional.setdefault(card_name, idx)
 
+    if list_name == "action":
+        warnings.extend(_lint_action_order(list(rules)))
+
+    return warnings
+
+
+def _lint_action_order(rules: list[PriorityRule]) -> list[StrategyLintWarning]:
+    """Flag action-order patterns that are usually tactical mistakes."""
+
+    warnings: list[StrategyLintWarning] = []
+    earlier_terminal: tuple[int, PriorityRule] | None = None
+    for idx, rule in enumerate(rules):
+        roles = infer_card_roles(rule.card_name)
+        if roles.has("cantrip") and earlier_terminal is not None:
+            earlier_idx, earlier_rule = earlier_terminal
+            warnings.append(
+                StrategyLintWarning(
+                    code="CANTRIP_AFTER_TERMINAL",
+                    message=(
+                        f"Cantrip {rule.card_name} appears after terminal "
+                        f"{earlier_rule.card_name} at index {earlier_idx}; "
+                        "cantrips usually preserve actions and should be "
+                        "played first unless the terminal is explicitly gated."
+                    ),
+                    list_name="action",
+                    index=idx,
+                    card_name=rule.card_name,
+                )
+            )
+            continue
+
+        if (
+            roles.has("terminal")
+            and not roles.has("nonterminal")
+            and rule.condition is None
+        ):
+            earlier_terminal = (idx, rule)
+
     return warnings
 
 
@@ -195,3 +234,25 @@ def normalize_strategy(strategy: EnhancedStrategy) -> EnhancedStrategy:
     """Return a behavior-preserving simplified copy of ``strategy``."""
 
     return simplify_strategy(strategy)
+
+
+def cleanup_for_publication(strategy: EnhancedStrategy) -> EnhancedStrategy:
+    """Return a generated-strategy copy suitable for publication.
+
+    This pass is intentionally conservative. It keeps the evaluated gain policy
+    intact, applies behavior-preserving syntactic simplification, and removes
+    action rules for cards the strategy never tries to gain. Such rules are
+    noise in generated files: they cannot affect normal play unless an opponent
+    or card effect hands the strategy an off-plan action, and the executor
+    already has a fallback for unexpected actions.
+    """
+
+    cleaned = normalize_strategy(strategy)
+    gained_cards = {rule.card_name for rule in getattr(cleaned, "gain_priority", []) or []}
+    if gained_cards:
+        cleaned.action_priority = [
+            rule
+            for rule in getattr(cleaned, "action_priority", []) or []
+            if rule.card_name in gained_cards
+        ]
+    return cleaned

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -22,6 +22,7 @@ Severity = Literal["info", "warning", "error"]
 
 _HAS_CARDS_ZERO_RE = re.compile(r"^PriorityRule\.has_cards\(.+,\s*0\)$")
 _BUILTIN_OFF_MENU_ACTION_GAINS = frozenset({"Trail"})
+_GAMESTATE_OFF_MENU_ACTION_GAINERS = frozenset({"Quartermaster"})
 
 
 @dataclass(frozen=True)
@@ -241,7 +242,15 @@ def normalize_strategy(strategy: EnhancedStrategy) -> EnhancedStrategy:
 def _board_has_non_card_off_menu_gain_paths(board_config: BoardConfig | None) -> bool:
     if board_config is None:
         return True
-    return bool(board_config.events or board_config.ways)
+    return bool(board_config.events or board_config.ways or board_config.allies)
+
+
+def _card_can_gain_off_menu_actions(card_name: str) -> bool:
+    return (
+        card_name == "Collection"
+        or card_name in _GAMESTATE_OFF_MENU_ACTION_GAINERS
+        or infer_card_roles(card_name).has("gainer")
+    )
 
 
 def cleanup_for_publication(
@@ -255,15 +264,15 @@ def cleanup_for_publication(
     intact, applies behavior-preserving syntactic simplification, and removes
     action rules for cards the strategy never tries to gain only when the board
     context rules out off-menu Action gain paths. Collection, gainers, Events,
-    and Ways can cause a strategy to gain Actions that are not explicitly named
-    in gain_priority, so action priorities remain meaningful in those cases.
+    Ways, and Allies can cause a strategy to gain Actions that are not
+    explicitly named in gain_priority, so action priorities remain meaningful
+    in those cases.
     """
 
     cleaned = normalize_strategy(strategy)
     gained_cards = {rule.card_name for rule in getattr(cleaned, "gain_priority", []) or []}
     can_gain_off_menu_actions = _board_has_non_card_off_menu_gain_paths(board_config) or any(
-        card_name == "Collection" or infer_card_roles(card_name).has("gainer")
-        for card_name in gained_cards
+        _card_can_gain_off_menu_actions(card_name) for card_name in gained_cards
     )
     if gained_cards and not can_gain_off_menu_actions:
         cleaned.action_priority = [

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -24,7 +24,19 @@ Severity = Literal["info", "warning", "error"]
 _HAS_CARDS_ZERO_RE = re.compile(r"^PriorityRule\.has_cards\(.+,\s*0\)$")
 _BUILTIN_OFF_MENU_ACTION_GAINS = frozenset({"Trail"})
 _EXPLICIT_OFF_MENU_ACTION_GAINERS = frozenset(
-    {"Death Cart", "Forge", "Livery", "Overlord", "Page", "Peasant", "Quartermaster"}
+    {
+        "Abundance",
+        "Death Cart",
+        "Forge",
+        "Jewelled Egg",
+        "Livery",
+        "Overlord",
+        "Page",
+        "Peasant",
+        "Quartermaster",
+        "Sack of Loot",
+        "Search",
+    }
 )
 
 

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -23,7 +23,9 @@ Severity = Literal["info", "warning", "error"]
 
 _HAS_CARDS_ZERO_RE = re.compile(r"^PriorityRule\.has_cards\(.+,\s*0\)$")
 _BUILTIN_OFF_MENU_ACTION_GAINS = frozenset({"Trail"})
-_EXPLICIT_OFF_MENU_ACTION_GAINERS = frozenset({"Forge", "Quartermaster"})
+_EXPLICIT_OFF_MENU_ACTION_GAINERS = frozenset(
+    {"Forge", "Page", "Peasant", "Quartermaster"}
+)
 
 
 @dataclass(frozen=True)

--- a/dominion/strategy/lint.py
+++ b/dominion/strategy/lint.py
@@ -20,6 +20,7 @@ from dominion.strategy.genome_simplification import simplify_strategy
 Severity = Literal["info", "warning", "error"]
 
 _HAS_CARDS_ZERO_RE = re.compile(r"^PriorityRule\.has_cards\(.+,\s*0\)$")
+_BUILTIN_OFF_MENU_ACTION_GAINS = frozenset({"Trail"})
 
 
 @dataclass(frozen=True)
@@ -257,6 +258,9 @@ def cleanup_for_publication(strategy: EnhancedStrategy) -> EnhancedStrategy:
         cleaned.action_priority = [
             rule
             for rule in getattr(cleaned, "action_priority", []) or []
-            if rule.card_name in gained_cards
+            if (
+                rule.card_name in gained_cards
+                or rule.card_name in _BUILTIN_OFF_MENU_ACTION_GAINS
+            )
         ]
     return cleaned

--- a/evolve.py
+++ b/evolve.py
@@ -319,7 +319,12 @@ def main():
         slug = seed_name.lower().replace(" ", "_")
         filename = f"{board_name}_evolved_{slug}_{timestamp}.py"
         class_name = f"Evolved{slug.title().replace('_', '')}"
-        save_strategy_as_python(best_strategy, args.output_dir / filename, class_name)
+        save_strategy_as_python(
+            best_strategy,
+            args.output_dir / filename,
+            class_name,
+            board_config=board_config,
+        )
         logger.info("  Saved: %s", filename)
 
     # --- Phase 3: Final Tournament ---

--- a/scripts/evolve_wizards_lich.py
+++ b/scripts/evolve_wizards_lich.py
@@ -70,7 +70,7 @@ def main() -> None:
     args.output_dir.mkdir(exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     out_file = args.output_dir / f"{board_name}_evolved_{timestamp}.py"
-    save_strategy_as_python(best, out_file, "WizardsLichEvolved")
+    save_strategy_as_python(best, out_file, "WizardsLichEvolved", board_config=cfg)
     logger.info("Saved evolved strategy to %s", out_file)
 
     # Validation: head-to-head vs hand-written and BM

--- a/scripts/island_evolve.py
+++ b/scripts/island_evolve.py
@@ -243,7 +243,12 @@ def run_one_island(
     best.name = f"{island_name} Champion"
 
     output_path = Path(output_dir) / f"{_safe_filename(island_name)}_champion.py"
-    save_strategy_as_python(best, output_path, _safe_class_name(island_name))
+    save_strategy_as_python(
+        best,
+        output_path,
+        _safe_class_name(island_name),
+        board_config=board_config,
+    )
     logger.info(
         "Island done: %s  fitness=%.2f  win_rate=%.1f%%  saved=%s",
         island_name,

--- a/scripts/island_merge.py
+++ b/scripts/island_merge.py
@@ -140,7 +140,12 @@ def main() -> None:
     best.name = "Lisbon Merged Champion"
 
     output_path = output_dir / "merged_champion.py"
-    save_strategy_as_python(best, output_path, "LisbonMergedChampion")
+    save_strategy_as_python(
+        best,
+        output_path,
+        "LisbonMergedChampion",
+        board_config=board_config,
+    )
     logger.info(
         "Merged champion fitness=%.2f win_rate=%.1f%% saved=%s (%.1fs)",
         metrics.get("fitness", 0.0),

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -438,6 +438,41 @@ class TestSerialization:
             sys.path.pop(0)
             sys.modules.pop("test_strategy", None)
 
+    def test_save_strategy_cleans_dead_action_rules_by_default(self, tmp_path):
+        from runner import save_strategy_as_python
+
+        strategy = BaseStrategy()
+        strategy.name = "PublishedCleanup"
+        strategy.gain_priority = [
+            PriorityRule("City"),
+            PriorityRule("Peddler"),
+            PriorityRule("Silver"),
+        ]
+        strategy.action_priority = [
+            PriorityRule("City"),
+            PriorityRule("Watchtower"),
+            PriorityRule("Peddler"),
+        ]
+
+        out_file = tmp_path / "published_cleanup.py"
+        save_strategy_as_python(strategy, out_file, "PublishedCleanup")
+
+        source = out_file.read_text()
+        assert "PriorityRule('Watchtower')" not in source
+
+        import sys
+        sys.path.insert(0, str(tmp_path))
+        try:
+            mod = importlib.import_module("published_cleanup")
+            generated = mod.PublishedCleanup()
+            assert [rule.card_name for rule in generated.action_priority] == [
+                "City",
+                "Peddler",
+            ]
+        finally:
+            sys.path.pop(0)
+            sys.modules.pop("published_cleanup", None)
+
     def test_none_conditions_serialize_cleanly(self, tmp_path):
         """Rules without conditions should not emit broken repr."""
         from runner import save_strategy_as_python

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -55,6 +55,40 @@ def test_runner_builds_simple_board_config_for_kingdom_cards(monkeypatch):
     assert captured["board_config"].kingdom_cards == ["City", "Watchtower", "Peddler"]
 
 
+def test_runner_limits_trick_seeds_to_explicit_board(monkeypatch):
+    runner = importlib.import_module("dominion.runner")
+
+    class DummyTrainer:
+        default_baseline_panel = False
+
+        def __init__(self, kingdom_cards, **kwargs):
+            pass
+
+        def train(self):
+            return None, {}
+
+    def fail_build_seed_genomes(_board_config):
+        raise AssertionError("trick seeds should require --board")
+
+    seed_genomes = importlib.import_module("dominion.analysis.seed_genomes")
+    monkeypatch.setattr(runner, "GeneticTrainer", DummyTrainer)
+    monkeypatch.setattr(seed_genomes, "build_seed_genomes", fail_build_seed_genomes)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "runner",
+            "--kingdom-cards",
+            "City",
+            "Watchtower",
+            "Peddler",
+            "--no-reuse-compatible-strategies",
+        ],
+    )
+
+    runner.main()
+
+
 def test_evaluate_strategy_counts_second_seat_wins(monkeypatch):
     # shape_rewards=False to keep this asserting raw win-rate behavior.
     trainer = GeneticTrainer(

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -455,7 +455,13 @@ class TestSerialization:
         ]
 
         out_file = tmp_path / "published_cleanup.py"
-        save_strategy_as_python(strategy, out_file, "PublishedCleanup")
+        from dominion.boards.loader import BoardConfig
+        save_strategy_as_python(
+            strategy,
+            out_file,
+            "PublishedCleanup",
+            board_config=BoardConfig(["City", "Watchtower", "Peddler"]),
+        )
 
         source = out_file.read_text()
         assert "PriorityRule('Watchtower')" not in source

--- a/tests/test_genetic_trainer.py
+++ b/tests/test_genetic_trainer.py
@@ -1,4 +1,5 @@
 import importlib
+import sys
 import types
 from pathlib import Path
 
@@ -17,6 +18,41 @@ def make_stub_strategy() -> BaseStrategy:
         PriorityRule("Copper"),
     ]
     return strategy
+
+
+def test_runner_builds_simple_board_config_for_kingdom_cards(monkeypatch):
+    runner = importlib.import_module("dominion.runner")
+    captured = {}
+
+    class DummyTrainer:
+        default_baseline_panel = False
+
+        def __init__(self, kingdom_cards, **kwargs):
+            captured["kingdom_cards"] = kingdom_cards
+            captured["board_config"] = kwargs["board_config"]
+
+        def train(self):
+            return None, {}
+
+    monkeypatch.setattr(runner, "GeneticTrainer", DummyTrainer)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "runner",
+            "--kingdom-cards",
+            "City",
+            "Watchtower",
+            "Peddler",
+            "--no-reuse-compatible-strategies",
+            "--no-trick-seeds",
+        ],
+    )
+
+    runner.main()
+
+    assert captured["kingdom_cards"] == ["City", "Watchtower", "Peddler"]
+    assert captured["board_config"].kingdom_cards == ["City", "Watchtower", "Peddler"]
 
 
 def test_evaluate_strategy_counts_second_seat_wins(monkeypatch):

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -106,6 +106,25 @@ def test_cleanup_for_publication_keeps_actions_without_explicit_gain_plan():
     assert [rule.card_name for rule in cleaned.action_priority] == ["Smithy"]
 
 
+def test_cleanup_for_publication_keeps_off_menu_actions_with_collection():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [
+        PriorityRule("Collection"),
+        PriorityRule("Silver"),
+    ]
+    strategy.action_priority = [
+        PriorityRule("Smithy"),
+        PriorityRule("Village"),
+    ]
+
+    cleaned = cleanup_for_publication(strategy)
+
+    assert [rule.card_name for rule in cleaned.action_priority] == [
+        "Smithy",
+        "Village",
+    ]
+
+
 def test_card_role_inference_identifies_village_and_terminal_draw():
     village = infer_card_roles("Village")
     smithy = infer_card_roles("Smithy")

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -191,6 +191,19 @@ def test_cleanup_for_publication_keeps_actions_on_omen_boards():
     assert [rule.card_name for rule in cleaned.action_priority] == ["Smithy"]
 
 
+def test_cleanup_for_publication_keeps_actions_on_attack_boards():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [PriorityRule("Silver")]
+    strategy.action_priority = [PriorityRule("Cellar")]
+
+    cleaned = cleanup_for_publication(
+        strategy,
+        board_config=BoardConfig(["Swindler", "Cellar"]),
+    )
+
+    assert [rule.card_name for rule in cleaned.action_priority] == ["Cellar"]
+
+
 def test_cleanup_for_publication_keeps_actions_with_quartermaster():
     strategy = EnhancedStrategy()
     strategy.gain_priority = [

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -248,6 +248,28 @@ def test_cleanup_for_publication_keeps_actions_with_forge():
     ]
 
 
+def test_cleanup_for_publication_keeps_horse_action_rule_with_livery():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [
+        PriorityRule("Livery"),
+        PriorityRule("Silver"),
+    ]
+    strategy.action_priority = [
+        PriorityRule("Horse"),
+        PriorityRule("Smithy"),
+    ]
+
+    cleaned = cleanup_for_publication(
+        strategy,
+        board_config=BoardConfig(["Livery", "Smithy"]),
+    )
+
+    assert [rule.card_name for rule in cleaned.action_priority] == [
+        "Horse",
+        "Smithy",
+    ]
+
+
 def test_cleanup_for_publication_keeps_traveller_chain_action_rules():
     strategy = EnhancedStrategy()
     strategy.gain_priority = [

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -200,6 +200,28 @@ def test_cleanup_for_publication_keeps_actions_with_quartermaster():
     ]
 
 
+def test_cleanup_for_publication_keeps_actions_with_forge():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [
+        PriorityRule("Forge"),
+        PriorityRule("Silver"),
+    ]
+    strategy.action_priority = [
+        PriorityRule("Smithy"),
+        PriorityRule("Village"),
+    ]
+
+    cleaned = cleanup_for_publication(
+        strategy,
+        board_config=BoardConfig(["Forge", "Smithy", "Village"]),
+    )
+
+    assert [rule.card_name for rule in cleaned.action_priority] == [
+        "Smithy",
+        "Village",
+    ]
+
+
 def test_cleanup_for_publication_keeps_trail_action_rule():
     strategy = EnhancedStrategy()
     strategy.gain_priority = [

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -235,6 +235,30 @@ def test_cleanup_for_publication_keeps_actions_with_forge():
     ]
 
 
+def test_cleanup_for_publication_keeps_traveller_chain_action_rules():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [
+        PriorityRule("Page"),
+        PriorityRule("Silver"),
+    ]
+    strategy.action_priority = [
+        PriorityRule("Treasure Hunter"),
+        PriorityRule("Warrior"),
+        PriorityRule("Page"),
+    ]
+
+    cleaned = cleanup_for_publication(
+        strategy,
+        board_config=BoardConfig(["Page", "Smithy"]),
+    )
+
+    assert [rule.card_name for rule in cleaned.action_priority] == [
+        "Treasure Hunter",
+        "Warrior",
+        "Page",
+    ]
+
+
 def test_cleanup_for_publication_keeps_trail_action_rule():
     strategy = EnhancedStrategy()
     strategy.gain_priority = [

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -272,6 +272,50 @@ def test_cleanup_for_publication_keeps_traveller_chain_action_rules():
     ]
 
 
+def test_cleanup_for_publication_keeps_command_proxy_action_rules():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [
+        PriorityRule("Overlord"),
+        PriorityRule("Silver"),
+    ]
+    strategy.action_priority = [
+        PriorityRule("Smithy"),
+        PriorityRule("Overlord"),
+    ]
+
+    cleaned = cleanup_for_publication(
+        strategy,
+        board_config=BoardConfig(["Overlord", "Smithy"]),
+    )
+
+    assert [rule.card_name for rule in cleaned.action_priority] == [
+        "Smithy",
+        "Overlord",
+    ]
+
+
+def test_cleanup_for_publication_keeps_death_cart_ruins_action_rules():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [
+        PriorityRule("Death Cart"),
+        PriorityRule("Silver"),
+    ]
+    strategy.action_priority = [
+        PriorityRule("Ruined Village"),
+        PriorityRule("Death Cart"),
+    ]
+
+    cleaned = cleanup_for_publication(
+        strategy,
+        board_config=BoardConfig(["Death Cart", "Smithy"]),
+    )
+
+    assert [rule.card_name for rule in cleaned.action_priority] == [
+        "Ruined Village",
+        "Death Cart",
+    ]
+
+
 def test_cleanup_for_publication_keeps_trail_action_rule():
     strategy = EnhancedStrategy()
     strategy.gain_priority = [

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -152,6 +152,41 @@ def test_cleanup_for_publication_keeps_actions_on_event_boards():
     assert [rule.card_name for rule in cleaned.action_priority] == ["Smithy"]
 
 
+def test_cleanup_for_publication_keeps_actions_on_ally_boards():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [PriorityRule("Silver")]
+    strategy.action_priority = [PriorityRule("Smithy")]
+
+    cleaned = cleanup_for_publication(
+        strategy,
+        board_config=BoardConfig(["Smithy"], allies=["Crafters' Guild"]),
+    )
+
+    assert [rule.card_name for rule in cleaned.action_priority] == ["Smithy"]
+
+
+def test_cleanup_for_publication_keeps_actions_with_quartermaster():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [
+        PriorityRule("Quartermaster"),
+        PriorityRule("Silver"),
+    ]
+    strategy.action_priority = [
+        PriorityRule("Smithy"),
+        PriorityRule("Village"),
+    ]
+
+    cleaned = cleanup_for_publication(
+        strategy,
+        board_config=BoardConfig(["Quartermaster", "Smithy", "Village"]),
+    )
+
+    assert [rule.card_name for rule in cleaned.action_priority] == [
+        "Smithy",
+        "Village",
+    ]
+
+
 def test_cleanup_for_publication_keeps_trail_action_rule():
     strategy = EnhancedStrategy()
     strategy.gain_priority = [

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -288,6 +288,25 @@ def test_cleanup_for_publication_keeps_horse_action_rule_with_livery():
     ]
 
 
+def test_cleanup_for_publication_keeps_actions_with_loot_gainers():
+    for loot_gainer in ("Jewelled Egg", "Search", "Abundance", "Sack of Loot"):
+        strategy = EnhancedStrategy()
+        strategy.gain_priority = [
+            PriorityRule(loot_gainer),
+            PriorityRule("Silver"),
+        ]
+        strategy.action_priority = [
+            PriorityRule("Smithy"),
+        ]
+
+        cleaned = cleanup_for_publication(
+            strategy,
+            board_config=BoardConfig([loot_gainer, "Smithy"]),
+        )
+
+        assert [rule.card_name for rule in cleaned.action_priority] == ["Smithy"]
+
+
 def test_cleanup_for_publication_keeps_traveller_chain_action_rules():
     strategy = EnhancedStrategy()
     strategy.gain_priority = [

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -178,6 +178,19 @@ def test_cleanup_for_publication_keeps_actions_on_trait_boards():
     assert [rule.card_name for rule in cleaned.action_priority] == ["Smithy"]
 
 
+def test_cleanup_for_publication_keeps_actions_on_omen_boards():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [PriorityRule("Silver")]
+    strategy.action_priority = [PriorityRule("Smithy")]
+
+    cleaned = cleanup_for_publication(
+        strategy,
+        board_config=BoardConfig(["Rustic Village", "Smithy"]),
+    )
+
+    assert [rule.card_name for rule in cleaned.action_priority] == ["Smithy"]
+
+
 def test_cleanup_for_publication_keeps_actions_with_quartermaster():
     strategy = EnhancedStrategy()
     strategy.gain_priority = [

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -165,6 +165,19 @@ def test_cleanup_for_publication_keeps_actions_on_ally_boards():
     assert [rule.card_name for rule in cleaned.action_priority] == ["Smithy"]
 
 
+def test_cleanup_for_publication_keeps_actions_on_trait_boards():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [PriorityRule("Silver")]
+    strategy.action_priority = [PriorityRule("Smithy")]
+
+    cleaned = cleanup_for_publication(
+        strategy,
+        board_config=BoardConfig(["Smithy"], traits={"Smithy": "Inherited"}),
+    )
+
+    assert [rule.card_name for rule in cleaned.action_priority] == ["Smithy"]
+
+
 def test_cleanup_for_publication_keeps_actions_with_quartermaster():
     strategy = EnhancedStrategy()
     strategy.gain_priority = [

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+from dominion.boards.loader import BoardConfig
 from dominion.cards.registry import get_card
 from dominion.events.looting import Looting
 from dominion.projects.sewers import Sewers
@@ -71,7 +72,7 @@ def test_lint_flags_cantrip_after_ungated_terminal():
     assert "CANTRIP_AFTER_TERMINAL" in {warning.code for warning in warnings}
 
 
-def test_cleanup_for_publication_drops_actions_not_in_gain_plan():
+def test_cleanup_for_publication_drops_actions_not_in_gain_plan_on_simple_board():
     strategy = EnhancedStrategy()
     strategy.gain_priority = [
         PriorityRule("City"),
@@ -84,7 +85,10 @@ def test_cleanup_for_publication_drops_actions_not_in_gain_plan():
         PriorityRule("Peddler"),
     ]
 
-    cleaned = cleanup_for_publication(strategy)
+    cleaned = cleanup_for_publication(
+        strategy,
+        board_config=BoardConfig(["City", "Watchtower", "Peddler"]),
+    )
 
     assert [rule.card_name for rule in cleaned.action_priority] == [
         "City",
@@ -99,6 +103,16 @@ def test_cleanup_for_publication_drops_actions_not_in_gain_plan():
 
 def test_cleanup_for_publication_keeps_actions_without_explicit_gain_plan():
     strategy = EnhancedStrategy()
+    strategy.action_priority = [PriorityRule("Smithy")]
+
+    cleaned = cleanup_for_publication(strategy)
+
+    assert [rule.card_name for rule in cleaned.action_priority] == ["Smithy"]
+
+
+def test_cleanup_for_publication_keeps_actions_without_board_context():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [PriorityRule("Silver")]
     strategy.action_priority = [PriorityRule("Smithy")]
 
     cleaned = cleanup_for_publication(strategy)
@@ -125,6 +139,19 @@ def test_cleanup_for_publication_keeps_off_menu_actions_with_collection():
     ]
 
 
+def test_cleanup_for_publication_keeps_actions_on_event_boards():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [PriorityRule("Silver")]
+    strategy.action_priority = [PriorityRule("Smithy")]
+
+    cleaned = cleanup_for_publication(
+        strategy,
+        board_config=BoardConfig(["Smithy"], events=["Seaway"]),
+    )
+
+    assert [rule.card_name for rule in cleaned.action_priority] == ["Smithy"]
+
+
 def test_cleanup_for_publication_keeps_trail_action_rule():
     strategy = EnhancedStrategy()
     strategy.gain_priority = [
@@ -135,7 +162,7 @@ def test_cleanup_for_publication_keeps_trail_action_rule():
         PriorityRule("Smithy"),
     ]
 
-    cleaned = cleanup_for_publication(strategy)
+    cleaned = cleanup_for_publication(strategy, board_config=BoardConfig(["Trail", "Smithy"]))
 
     assert [rule.card_name for rule in cleaned.action_priority] == ["Trail"]
 

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -125,6 +125,21 @@ def test_cleanup_for_publication_keeps_off_menu_actions_with_collection():
     ]
 
 
+def test_cleanup_for_publication_keeps_trail_action_rule():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [
+        PriorityRule("Silver"),
+    ]
+    strategy.action_priority = [
+        PriorityRule("Trail"),
+        PriorityRule("Smithy"),
+    ]
+
+    cleaned = cleanup_for_publication(strategy)
+
+    assert [rule.card_name for rule in cleaned.action_priority] == ["Trail"]
+
+
 def test_card_role_inference_identifies_village_and_terminal_draw():
     village = infer_card_roles("Village")
     smithy = infer_card_roles("Smithy")

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -204,6 +204,24 @@ def test_cleanup_for_publication_keeps_actions_on_attack_boards():
     assert [rule.card_name for rule in cleaned.action_priority] == ["Cellar"]
 
 
+def test_cleanup_for_publication_keeps_actions_on_fate_or_doom_boards():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [PriorityRule("Bard"), PriorityRule("Silver")]
+    strategy.action_priority = [PriorityRule("Smithy")]
+
+    fate_cleaned = cleanup_for_publication(
+        strategy,
+        board_config=BoardConfig(["Bard", "Smithy"]),
+    )
+    doom_cleaned = cleanup_for_publication(
+        strategy,
+        board_config=BoardConfig(["Cursed Village", "Smithy"]),
+    )
+
+    assert [rule.card_name for rule in fate_cleaned.action_priority] == ["Smithy"]
+    assert [rule.card_name for rule in doom_cleaned.action_priority] == ["Smithy"]
+
+
 def test_cleanup_for_publication_keeps_actions_with_quartermaster():
     strategy = EnhancedStrategy()
     strategy.gain_priority = [

--- a/tests/test_strategy_lint_and_phase.py
+++ b/tests/test_strategy_lint_and_phase.py
@@ -5,7 +5,7 @@ from dominion.events.looting import Looting
 from dominion.projects.sewers import Sewers
 from dominion.strategy.card_roles import cards_with_role, infer_card_roles
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
-from dominion.strategy.lint import lint_strategy, normalize_strategy
+from dominion.strategy.lint import cleanup_for_publication, lint_strategy, normalize_strategy
 from dominion.strategy.phase_strategy import PhaseAwareStrategy, StrategyPhase
 
 
@@ -57,6 +57,53 @@ def test_normalize_strategy_drops_behavior_preserving_dead_rules():
     normalized = normalize_strategy(strategy)
 
     assert [rule.card_name for rule in normalized.gain_priority] == ["Gold"]
+
+
+def test_lint_flags_cantrip_after_ungated_terminal():
+    strategy = EnhancedStrategy()
+    strategy.action_priority = [
+        PriorityRule("Watchtower"),
+        PriorityRule("Peddler"),
+    ]
+
+    warnings = lint_strategy(strategy)
+
+    assert "CANTRIP_AFTER_TERMINAL" in {warning.code for warning in warnings}
+
+
+def test_cleanup_for_publication_drops_actions_not_in_gain_plan():
+    strategy = EnhancedStrategy()
+    strategy.gain_priority = [
+        PriorityRule("City"),
+        PriorityRule("Peddler"),
+        PriorityRule("Silver"),
+    ]
+    strategy.action_priority = [
+        PriorityRule("City"),
+        PriorityRule("Watchtower"),
+        PriorityRule("Peddler"),
+    ]
+
+    cleaned = cleanup_for_publication(strategy)
+
+    assert [rule.card_name for rule in cleaned.action_priority] == [
+        "City",
+        "Peddler",
+    ]
+    assert [rule.card_name for rule in strategy.action_priority] == [
+        "City",
+        "Watchtower",
+        "Peddler",
+    ]
+
+
+def test_cleanup_for_publication_keeps_actions_without_explicit_gain_plan():
+    strategy = EnhancedStrategy()
+    strategy.action_priority = [PriorityRule("Smithy")]
+
+    cleaned = cleanup_for_publication(strategy)
+
+    assert [rule.card_name for rule in cleaned.action_priority] == ["Smithy"]
 
 
 def test_card_role_inference_identifies_village_and_terminal_draw():


### PR DESCRIPTION
## Summary

- add publication cleanup for generated strategies before serialization
- remove action rules for cards absent from an explicit gain plan, preventing dead artifacts like Watchtower action priorities in strategies that never gain Watchtower
- add an action-order lint warning when an ungated terminal appears before a later cantrip
- route `runner.py` and `save_strategy_as_python` through the cleanup pass by default

## Why

The Lisbon strategy search exposed that generated strategies can publish misleading priority rules even when those rules are dead in normal play. This is a small trainer-quality step: generated artifacts should be leaner and should flag tactically suspicious action orders instead of presenting them as meaningful strategy.

## Validation

- `PYTHONPATH=. pytest tests/test_strategy_lint_and_phase.py tests/test_genetic_trainer.py -q`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new lint warning for strategies that place cantrips after an earlier terminal action in action priority.
  * Strategies exported for publication are now automatically cleaned up during saving, filtering action rules based on the active board configuration.

* **Tests**
  * Expanded lint and publication cleanup test coverage, including ordering diagnostics and board-context-specific action rule filtering.

* **Chores**
  * Updated strategy export calls across evolution and merge scripts to pass along the active board configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->