### PR TITLE
Ground-truth calibration suite: boards with community-known best strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,18 @@ python -m dominion.simulation.strategy_battle "Chapel Witch" "Big Money" --games
 If `--output` is omitted, reports are written to the `reports` directory with
 an auto-generated filename.
 
+## Calibration suite
+
+`boards/calibration/` pairs boards with community-known best strategies so
+the evolution pipeline can be scored against external ground truth instead of
+only against itself. Run the fast sanity check (known-best vs Big Money) or
+the full benchmark (evolved champion vs known-best):
+
+```
+PYTHONPATH=. python scripts/calibration_suite.py --mode sanity --games 400
+PYTHONPATH=. python scripts/calibration_suite.py --mode evolve --games 400
+```
+
+See `docs/calibration.md` for the board list, sources, and how to read the
+gap score.
+

--- a/boards/calibration/chapel_witch.txt
+++ b/boards/calibration/chapel_witch.txt
@@ -1,0 +1,11 @@
+# Calibration: Chapel + Witch; known best = thin with Chapel, curse with Witch, then money.
+Chapel
+Witch
+Cellar
+Moat
+Chancellor
+Woodcutter
+Bureaucrat
+Feast
+Mine
+Adventurer

--- a/boards/calibration/courtyard_bm.txt
+++ b/boards/calibration/courtyard_bm.txt
@@ -1,0 +1,11 @@
+# Calibration: Courtyard money; known best = two Courtyards bought on 2-4 coin hands.
+Courtyard
+Cellar
+Moat
+Chancellor
+Woodcutter
+Bureaucrat
+Feast
+Mine
+Adventurer
+Thief

--- a/boards/calibration/first_game.txt
+++ b/boards/calibration/first_game.txt
@@ -1,0 +1,11 @@
+# Calibration: the base-set "First Game" kingdom; known best = Smithy money with a Militia.
+Cellar
+Market
+Merchant
+Militia
+Mine
+Moat
+Remodel
+Smithy
+Village
+Workshop

--- a/boards/calibration/gardens_workshop.txt
+++ b/boards/calibration/gardens_workshop.txt
@@ -1,0 +1,11 @@
+# Calibration: Gardens + Workshop with weak money support; known best = Workshop/Gardens rush.
+Gardens
+Workshop
+Woodcutter
+Cellar
+Moat
+Chancellor
+Bureaucrat
+Feast
+Mine
+Thief

--- a/boards/calibration/jack_bm.txt
+++ b/boards/calibration/jack_bm.txt
@@ -1,0 +1,11 @@
+# Calibration: Jack of All Trades money; known best = Double Jack.
+Jack of All Trades
+Cellar
+Moat
+Chancellor
+Woodcutter
+Bureaucrat
+Feast
+Mine
+Adventurer
+Thief

--- a/boards/calibration/mountebank_bm.txt
+++ b/boards/calibration/mountebank_bm.txt
@@ -1,0 +1,11 @@
+# Calibration: Mountebank with no support; known best = Mountebank money.
+Mountebank
+Cellar
+Moat
+Chancellor
+Woodcutter
+Bureaucrat
+Feast
+Mine
+Adventurer
+Thief

--- a/boards/calibration/rebuild_duchy.txt
+++ b/boards/calibration/rebuild_duchy.txt
@@ -1,0 +1,11 @@
+# Calibration: Rebuild with no support; known best = Rebuild rush (Duchies over Gold).
+Rebuild
+Cellar
+Moat
+Chancellor
+Woodcutter
+Bureaucrat
+Feast
+Mine
+Adventurer
+Thief

--- a/boards/calibration/smithy_bm.txt
+++ b/boards/calibration/smithy_bm.txt
@@ -1,0 +1,11 @@
+# Calibration: Smithy is the only useful terminal; known best = Double Smithy (BM + 2 Smithy).
+Smithy
+Cellar
+Moat
+Chancellor
+Woodcutter
+Bureaucrat
+Feast
+Mine
+Adventurer
+Thief

--- a/boards/calibration/wharf_bm.txt
+++ b/boards/calibration/wharf_bm.txt
@@ -1,0 +1,11 @@
+# Calibration: Wharf with no engine support; known best = Big Money Wharf (2 Wharves).
+Wharf
+Cellar
+Moat
+Chancellor
+Woodcutter
+Bureaucrat
+Feast
+Mine
+Adventurer
+Thief

--- a/boards/calibration/witch_bm.txt
+++ b/boards/calibration/witch_bm.txt
@@ -1,0 +1,11 @@
+# Calibration: Witch with no engine support; known best = Double Witch money.
+Witch
+Cellar
+Moat
+Chancellor
+Woodcutter
+Bureaucrat
+Feast
+Mine
+Adventurer
+Thief

--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -1,0 +1,93 @@
+# Calibration suite: boards with known answers
+
+## Why this exists
+
+When an evolved champion is mediocre, four very different things can be wrong,
+and they need different fixes:
+
+1. **Simulator bug** — a card rule is wrong, so the board plays differently
+   than real Dominion (see the Hyderabad Exile bug, where one wrong rule
+   flipped a seed strategy from 4% to 93% vs Big Money).
+2. **Policy ceiling** — the priority-list DSL or a hardcoded AI hook cannot
+   represent the play the board demands.
+3. **Search failure** — the GA never finds a genome the DSL could express.
+4. **Evaluation noise** — the fitness signal was too noisy to rank candidates.
+
+Until now the repo had no way to tell these apart, because every result was
+measured against opponents the pipeline itself produced. The calibration
+suite adds an external reference: boards where the Dominion community
+established the best (or near-best) strategy years ago, paired with clean
+hand-written encodings of those strategies.
+
+## The boards
+
+All boards live in `boards/calibration/`. Most pair one strong kingdom card
+with deliberately weak support ("BM+X" boards), because those have the most
+settled community answers.
+
+| Board | Known best | The known answer |
+|---|---|---|
+| `smithy_bm` | Double Smithy | BM + 2 Smithies beats straight BM (classic sim result) |
+| `witch_bm` | Double Witch | Witch money crushes BM on support-free boards |
+| `chapel_witch` | Chapel Witch Classic | Chapel thinning into Witch beats unthinned Witch money |
+| `gardens_workshop` | Gardens Workshop Rush | Workshop-gains-Gardens rush beats money on weak-money boards |
+| `wharf_bm` | Big Money Wharf | BM-Wharf was the strongest classic BM+X |
+| `rebuild_duchy` | Rebuild Rush | Rebuild/Duchy (no Gold) beats money strategies outright |
+| `jack_bm` | Double Jack | Double Jack was the Isotropic-era benchmark |
+| `mountebank_bm` | Mountebank Money | Mountebank-BM is a standard strong baseline |
+| `courtyard_bm` | Courtyard Money | 2 Courtyards on $2–4 hands beats straight BM |
+| `first_game` | First Game Smithy Militia | Smithy money (+Militia) wins the base-set First Game kingdom |
+
+The known-best strategies are in
+`dominion/strategy/strategies/calibration_known_best.py`; the board/strategy
+pairing lives in `dominion/analysis/calibration.py` (`CALIBRATION_SUITE`).
+
+## How to run it
+
+**Sanity mode** — validates the simulator + strategy encodings. Each
+known-best battles Big Money; every board should PASS (CI lower bound above
+50%). A FAIL means the simulator or the encoding is broken on that board —
+fix that before trusting any evolution result there.
+
+```bash
+PYTHONPATH=. python scripts/calibration_suite.py --mode sanity --games 400
+```
+
+**Evolve mode** — the actual benchmark. Runs the genetic trainer on each
+board with out-of-the-box settings, then battles the champion against the
+known-best for `--games` games:
+
+```bash
+PYTHONPATH=. python scripts/calibration_suite.py --mode evolve \
+    --population 40 --generations 40 --games-per-eval 20 --games 400
+```
+
+Reports (markdown + JSON) land in `reports/calibration/`.
+
+## How to read the numbers
+
+Per board, the **gap** is how many percentage points the champion's win rate
+vs the known-best falls below 50. The suite-level number is the **mean gap**:
+
+- **0** — champions tie or beat every known answer. The pipeline is finding
+  the good strategies the community found.
+- **small (≤5)** — search is close; tuning (budgets, seeds, vocabulary) may
+  close it.
+- **large on specific boards** — read those boards' verdicts. A big gap on
+  `chapel_witch` or `gardens_workshop` but not on the BM+X boards points at
+  representation/play-skill limits (trash policy, gainer play) rather than
+  general search failure.
+
+When comparing pipeline changes, run evolve mode before and after with the
+same settings and compare mean gaps; the JSON output is meant for exactly
+that kind of regression tracking.
+
+## Caveats
+
+- The known-best strategies are strong reference points, not proofs of
+  optimality. A champion beating one is a good sign, not a guarantee.
+- Known-best play still flows through the same AI hooks as everyone else
+  (e.g. Jack of All Trades' hardcoded trash/discard choices), so a weak
+  hook drags both sides equally in the champion match, but can depress the
+  sanity-mode margin vs Big Money.
+- 400 games resolves ~5pp differences; use 1000+ for finer comparisons.

--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -82,6 +82,36 @@ When comparing pipeline changes, run evolve mode before and after with the
 same settings and compare mean gaps; the JSON output is meant for exactly
 that kind of regression tracking.
 
+## First results (2026-07-04)
+
+Baseline run: population 30, generations 30, games-per-eval 15, 400
+confirmation games, out-of-the-box trainer settings (Big Money panel).
+**Mean gap: 4.7pp; champions behind on 4 of 10 boards.** Full tables in
+`reports/calibration/evolve.md` and `sanity.md`. The failures split into
+exactly the categories the suite was designed to separate:
+
+- **Representability failure — `rebuild_duchy` (32.8%).** The Rebuild rush
+  needs "buy Duchy over Gold, unconditionally"; the structured genome's
+  greening block always gates Duchy behind `provinces_left <= 3..6` (both at
+  init and in the re-gate vocabulary in `structured_genome.py`), so the
+  known-best plan is outside the search space entirely. Fix: widen the
+  greening-gate vocabulary. `chapel_witch` (44.0%) is likely related — the
+  vocabulary has no "buy exactly one Chapel on turns 1-2" shape (turn-gated
+  picks exist but the trainer must find cap-1 + early-turn + Chapel jointly).
+- **Objective failure — `witch_bm` (40.5%), `smithy_bm` (41.8%).** Both
+  archetypes are fully representable (a capped kingdom pick over a money
+  backbone), yet champions trained against the Big Money panel converge to
+  something that beats Big Money without matching the tuned BM+X mirror.
+  Fixed weak panels give no gradient toward mirror-optimal play; this is the
+  motivation for a coevolution / champion-pool outer loop.
+- **Legitimate wins — `gardens_workshop` (93.2%), `courtyard_bm` (57.8%).**
+  On the Gardens board the GA found a genuinely better plan than the
+  community archetype: play money, contest the Gardens pile from the money
+  deck, and win the long game on Provinces. Hand-buffed rush variants
+  (uncapped Workshops, earlier Estates) still lose ~90% to the champion's
+  saved genome. The known-best label stays as a reference, but the community
+  answer is not the best strategy on this exact board in this simulator.
+
 ## Caveats
 
 - The known-best strategies are strong reference points, not proofs of

--- a/dominion/analysis/calibration.py
+++ b/dominion/analysis/calibration.py
@@ -21,7 +21,10 @@ import math
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Optional, Sequence
+from typing import TYPE_CHECKING, Iterable, Optional, Sequence
+
+if TYPE_CHECKING:
+    from dominion.strategy.enhanced_strategy import EnhancedStrategy
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BOARDS_DIR = REPO_ROOT / "boards" / "calibration"
@@ -241,7 +244,7 @@ def evolve_and_evaluate(
     confirm_games: int = 400,
     log_folder: str = "battle_logs/calibration",
     **trainer_kwargs,
-) -> tuple[MatchOutcome, dict, "EnhancedStrategy"]:
+) -> tuple[MatchOutcome, dict, EnhancedStrategy]:
     """Evolve a champion for the entry's board and battle it vs known-best.
 
     ``trainer_kwargs`` are forwarded to :class:`GeneticTrainer` (population

--- a/dominion/analysis/calibration.py
+++ b/dominion/analysis/calibration.py
@@ -1,0 +1,348 @@
+"""Ground-truth calibration suite.
+
+Each entry pairs a board with a community-known best strategy (encoded as a
+hand-written strategy in ``dominion/strategy/strategies/``). The suite gives
+the evolution pipeline an external reference: instead of only measuring
+champions against the panel they were trained on, we can ask two questions
+with well-established answers:
+
+1. Sanity: does the known-best archetype beat Big Money on its board in this
+   simulator? If not, the simulator or the strategy encoding is broken —
+   evolution results on that board cannot be trusted.
+2. Gap: does an evolved champion beat, tie, or lose to the known-best
+   strategy? The per-board gap (percentage points of win rate below 50%)
+   separates "search failure" from "policy ceiling" board by board.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BOARDS_DIR = REPO_ROOT / "boards" / "calibration"
+
+
+@dataclass(frozen=True)
+class CalibrationEntry:
+    """A board with a community-known best strategy."""
+
+    key: str
+    known_best: str  # display name registered in StrategyLoader
+    archetype: str  # one-line description of the known-best plan
+    source: str  # community reference for why this is the known answer
+
+    def board_path(self) -> Path:
+        return BOARDS_DIR / f"{self.key}.txt"
+
+
+CALIBRATION_SUITE: tuple[CalibrationEntry, ...] = (
+    CalibrationEntry(
+        key="smithy_bm",
+        known_best="Double Smithy",
+        archetype="Big Money plus two Smithies, green on Duchy late",
+        source="Classic simulator result (Geronimoo/Dominiate): BM+2 Smithy beats straight BM",
+    ),
+    CalibrationEntry(
+        key="witch_bm",
+        known_best="Double Witch",
+        archetype="Big Money plus two Witches; curse pressure wins the mirror-free board",
+        source="Community consensus: Witch-BM crushes BM on support-free boards",
+    ),
+    CalibrationEntry(
+        key="chapel_witch",
+        known_best="Chapel Witch Classic",
+        archetype="Open Chapel, thin hard, one-two Witches, then money and green",
+        source="Canonical Dominion opening: Chapel+Witch beats unthinned Witch money",
+    ),
+    CalibrationEntry(
+        key="gardens_workshop",
+        known_best="Gardens Workshop Rush",
+        archetype="Workshops gain Gardens every turn; fatten deck and end on piles",
+        source="Classic rush: Workshop/Gardens beats Big Money on weak-money boards",
+    ),
+    CalibrationEntry(
+        key="wharf_bm",
+        known_best="Big Money Wharf",
+        archetype="Big Money plus two Wharves; the strongest BM+X of the classic sims",
+        source="Dominiate/Councilroom era result: BM-Wharf beats BM and most BM+X",
+    ),
+    CalibrationEntry(
+        key="rebuild_duchy",
+        known_best="Rebuild Rush",
+        archetype="Two Rebuilds, buy Duchies over Gold, race the Province pile",
+        source="Rebuild dominated its era; Rebuild/Duchy beats money strategies outright",
+    ),
+    CalibrationEntry(
+        key="jack_bm",
+        known_best="Double Jack",
+        archetype="Two Jacks of All Trades plus money; steady Silver flow and filtering",
+        source="Double Jack was a famously strong benchmark strategy (Isotropic era)",
+    ),
+    CalibrationEntry(
+        key="mountebank_bm",
+        known_best="Mountebank Money",
+        archetype="Big Money plus one-two Mountebanks; junk the opponent, buy points",
+        source="Mountebank-BM is a standard strong baseline on support-free boards",
+    ),
+    CalibrationEntry(
+        key="courtyard_bm",
+        known_best="Courtyard Money",
+        archetype="Big Money plus two Courtyards bought on 2-4 coin hands",
+        source="BM-Courtyard is a classic strong BM+X (draw 3, topdeck spare card)",
+    ),
+    CalibrationEntry(
+        key="first_game",
+        known_best="First Game Smithy Militia",
+        archetype="Smithy money with a Militia on the base-set First Game kingdom",
+        source="Community consensus for the First Game kingdom: Smithy-BM (+Militia) wins",
+    ),
+)
+
+
+def entries_for_keys(keys: Optional[Iterable[str]]) -> list[CalibrationEntry]:
+    """Return suite entries for ``keys`` (all entries when ``keys`` is falsy)."""
+
+    if not keys:
+        return list(CALIBRATION_SUITE)
+    by_key = {entry.key: entry for entry in CALIBRATION_SUITE}
+    missing = [key for key in keys if key not in by_key]
+    if missing:
+        raise ValueError(f"Unknown calibration board(s): {', '.join(missing)}")
+    return [by_key[key] for key in keys]
+
+
+def wilson_interval(wins: int, games: int, z: float = 1.96) -> tuple[float, float]:
+    """95% Wilson score interval for a win proportion, as (lo, hi) in [0, 1]."""
+
+    if games <= 0:
+        return (0.0, 1.0)
+    p = wins / games
+    z2 = z * z
+    denom = 1 + z2 / games
+    center = (p + z2 / (2 * games)) / denom
+    margin = z * math.sqrt(p * (1 - p) / games + z2 / (4 * games * games)) / denom
+    return (max(0.0, center - margin), min(1.0, center + margin))
+
+
+def gap_points(winrate_pct: float) -> float:
+    """Percentage points of win rate below parity (0 when at or above 50%)."""
+
+    return max(0.0, 50.0 - winrate_pct)
+
+
+@dataclass
+class MatchOutcome:
+    """Result of one head-to-head series on a calibration board."""
+
+    board: str
+    strategy_a: str
+    strategy_b: str
+    wins_a: int
+    games: int
+
+    @property
+    def winrate_a(self) -> float:
+        return self.wins_a / self.games * 100 if self.games else 0.0
+
+    @property
+    def ci_a(self) -> tuple[float, float]:
+        lo, hi = wilson_interval(self.wins_a, self.games)
+        return (lo * 100, hi * 100)
+
+    def to_dict(self) -> dict:
+        lo, hi = self.ci_a
+        return {
+            "board": self.board,
+            "strategy_a": self.strategy_a,
+            "strategy_b": self.strategy_b,
+            "wins_a": self.wins_a,
+            "games": self.games,
+            "winrate_a": round(self.winrate_a, 2),
+            "ci_a": [round(lo, 2), round(hi, 2)],
+        }
+
+
+def _sanity_verdict(outcome: MatchOutcome) -> str:
+    lo, _ = outcome.ci_a
+    if lo > 50.0:
+        return "PASS"
+    if outcome.winrate_a > 50.0:
+        return "WEAK"
+    return "FAIL"
+
+
+def _evolve_verdict(outcome: MatchOutcome) -> str:
+    lo, hi = outcome.ci_a
+    if lo > 50.0:
+        return "BEATS KNOWN BEST"
+    if hi < 50.0:
+        return "BEHIND"
+    return "TIED"
+
+
+def run_match(
+    entry: CalibrationEntry,
+    strategy_a: str,
+    strategy_b: str,
+    games: int,
+    *,
+    log_folder: str = "battle_logs/calibration",
+    champion_factory=None,
+) -> MatchOutcome:
+    """Battle two registered strategies on the entry's board.
+
+    ``champion_factory`` registers an unregistered strategy (e.g. a freshly
+    evolved champion) under ``strategy_a`` before the battle runs.
+    """
+
+    from dominion.boards.loader import load_board
+    from dominion.simulation.strategy_battle import StrategyBattle
+
+    board = load_board(entry.board_path())
+    battle = StrategyBattle(board_config=board, log_folder=log_folder)
+    if champion_factory is not None:
+        battle.strategy_loader.register_strategy(strategy_a, champion_factory)
+    results = battle.run_battle(strategy_a, strategy_b, games)
+    return MatchOutcome(
+        board=entry.key,
+        strategy_a=strategy_a,
+        strategy_b=strategy_b,
+        wins_a=results["strategy1_wins"],
+        games=games,
+    )
+
+
+def run_sanity(
+    entries: Sequence[CalibrationEntry],
+    games: int,
+    baselines: Sequence[str] = ("Big Money",),
+    *,
+    log_folder: str = "battle_logs/calibration",
+) -> list[MatchOutcome]:
+    """Battle each entry's known-best strategy against the baseline(s)."""
+
+    outcomes = []
+    for entry in entries:
+        for baseline in baselines:
+            outcomes.append(
+                run_match(entry, entry.known_best, baseline, games, log_folder=log_folder)
+            )
+    return outcomes
+
+
+def evolve_and_evaluate(
+    entry: CalibrationEntry,
+    *,
+    confirm_games: int = 400,
+    log_folder: str = "battle_logs/calibration",
+    **trainer_kwargs,
+) -> tuple[MatchOutcome, dict]:
+    """Evolve a champion for the entry's board and battle it vs known-best.
+
+    ``trainer_kwargs`` are forwarded to :class:`GeneticTrainer` (population
+    size, generations, games_per_eval, ...). Returns the champion-vs-known-best
+    outcome and the trainer metadata.
+    """
+
+    from dominion.boards.loader import load_board
+    from dominion.simulation.genetic_trainer import GeneticTrainer
+
+    board = load_board(entry.board_path())
+    trainer = GeneticTrainer(
+        kingdom_cards=board.kingdom_cards,
+        board_config=board,
+        log_folder=f"training_logs/calibration/{entry.key}",
+        **trainer_kwargs,
+    )
+    champion, metadata = trainer.train()
+    if champion is None:
+        raise RuntimeError(f"Training produced no champion for board {entry.key}")
+
+    champion_name = f"Champion {entry.key}"
+    outcome = run_match(
+        entry,
+        champion_name,
+        entry.known_best,
+        confirm_games,
+        log_folder=log_folder,
+        champion_factory=lambda: deepcopy(champion),
+    )
+    return outcome, metadata
+
+
+def _markdown_table(header: list[str], rows: list[list[str]]) -> str:
+    lines = [
+        "| " + " | ".join(header) + " |",
+        "|" + "|".join("---" for _ in header) + "|",
+    ]
+    lines.extend("| " + " | ".join(row) + " |" for row in rows)
+    return "\n".join(lines)
+
+
+def render_sanity_report(outcomes: Sequence[MatchOutcome]) -> str:
+    """Markdown report: does each known-best beat its baseline?"""
+
+    rows = []
+    for o in outcomes:
+        lo, hi = o.ci_a
+        rows.append(
+            [
+                o.board,
+                o.strategy_a,
+                o.strategy_b,
+                str(o.games),
+                f"{o.winrate_a:.1f}%",
+                f"[{lo:.1f}%, {hi:.1f}%]",
+                _sanity_verdict(o),
+            ]
+        )
+    table = _markdown_table(
+        ["Board", "Known best", "Baseline", "Games", "Win rate", "95% CI", "Verdict"],
+        rows,
+    )
+    return "# Calibration sanity: known-best vs baseline\n\n" + table + "\n"
+
+
+def render_evolve_report(outcomes: Sequence[MatchOutcome]) -> str:
+    """Markdown report: evolved champion vs known-best, with per-board gap."""
+
+    rows = []
+    gaps = []
+    for o in outcomes:
+        lo, hi = o.ci_a
+        gap = gap_points(o.winrate_a)
+        gaps.append(gap)
+        rows.append(
+            [
+                o.board,
+                o.strategy_b,
+                str(o.games),
+                f"{o.winrate_a:.1f}%",
+                f"[{lo:.1f}%, {hi:.1f}%]",
+                f"{gap:.1f}",
+                _evolve_verdict(o),
+            ]
+        )
+    table = _markdown_table(
+        ["Board", "Known best", "Games", "Champion win rate", "95% CI", "Gap (pp)", "Verdict"],
+        rows,
+    )
+    mean_gap = sum(gaps) / len(gaps) if gaps else 0.0
+    return (
+        "# Calibration: evolved champion vs known-best\n\n"
+        + table
+        + f"\n\n**Mean gap: {mean_gap:.1f} percentage points** "
+        + "(0 = champions match or beat every known-best)\n"
+    )
+
+
+def save_outcomes_json(outcomes: Sequence[MatchOutcome], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps([o.to_dict() for o in outcomes], indent=2) + "\n", encoding="utf-8"
+    )

--- a/dominion/analysis/calibration.py
+++ b/dominion/analysis/calibration.py
@@ -110,6 +110,7 @@ CALIBRATION_SUITE: tuple[CalibrationEntry, ...] = (
 def entries_for_keys(keys: Optional[Iterable[str]]) -> list[CalibrationEntry]:
     """Return suite entries for ``keys`` (all entries when ``keys`` is falsy)."""
 
+    keys = list(keys) if keys is not None else None
     if not keys:
         return list(CALIBRATION_SUITE)
     by_key = {entry.key: entry for entry in CALIBRATION_SUITE}
@@ -202,6 +203,9 @@ def run_match(
     ``champion_factory`` registers an unregistered strategy (e.g. a freshly
     evolved champion) under ``strategy_a`` before the battle runs.
     """
+
+    if games <= 0:
+        raise ValueError(f"games must be positive, got {games}")
 
     from dominion.boards.loader import load_board
     from dominion.simulation.strategy_battle import StrategyBattle

--- a/dominion/analysis/calibration.py
+++ b/dominion/analysis/calibration.py
@@ -241,12 +241,13 @@ def evolve_and_evaluate(
     confirm_games: int = 400,
     log_folder: str = "battle_logs/calibration",
     **trainer_kwargs,
-) -> tuple[MatchOutcome, dict]:
+) -> tuple[MatchOutcome, dict, "EnhancedStrategy"]:
     """Evolve a champion for the entry's board and battle it vs known-best.
 
     ``trainer_kwargs`` are forwarded to :class:`GeneticTrainer` (population
     size, generations, games_per_eval, ...). Returns the champion-vs-known-best
-    outcome and the trainer metadata.
+    outcome, the trainer metadata, and the champion strategy itself (so
+    callers can persist the genome for diagnosis).
     """
 
     from dominion.boards.loader import load_board
@@ -272,7 +273,7 @@ def evolve_and_evaluate(
         log_folder=log_folder,
         champion_factory=lambda: deepcopy(champion),
     )
-    return outcome, metadata
+    return outcome, metadata, champion
 
 
 def _markdown_table(header: list[str], rows: list[list[str]]) -> str:

--- a/dominion/strategy/strategies/calibration_known_best.py
+++ b/dominion/strategy/strategies/calibration_known_best.py
@@ -1,0 +1,323 @@
+"""Known-best archetype strategies for the calibration suite.
+
+Each strategy encodes a community-known best (or near-best) plan for one of
+the boards in ``boards/calibration/``. They are deliberately simple, clean
+implementations of well-established archetypes — the point is to be a
+trustworthy external reference for the evolution pipeline, not to squeeze
+out the last percentage point.
+
+See ``dominion/analysis/calibration.py`` for the board pairings and
+``docs/calibration.md`` for sources.
+"""
+
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+def _greening_rules() -> list[PriorityRule]:
+    """Standard Big-Money-style greening: Province, then late Duchy/Estate."""
+    return [
+        PriorityRule("Province"),
+        PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4)),
+        PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),
+    ]
+
+
+class DoubleSmithy(EnhancedStrategy):
+    """Big Money plus two Smithies — the classic BM+X benchmark."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Double Smithy"
+        self.description = "Big Money with two Smithies and late greening"
+        self.version = "1.0"
+
+        self.gain_priority = _greening_rules() + [
+            PriorityRule("Gold"),
+            PriorityRule("Smithy", PriorityRule.max_in_deck("Smithy", 2)),
+            PriorityRule("Silver"),
+        ]
+        self.action_priority = [PriorityRule("Smithy")]
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+
+class DoubleWitch(EnhancedStrategy):
+    """Big Money plus two Witches — curse pressure wins support-free boards."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Double Witch"
+        self.description = "Big Money with two Witches and late greening"
+        self.version = "1.0"
+
+        self.gain_priority = _greening_rules() + [
+            PriorityRule("Witch", PriorityRule.max_in_deck("Witch", 2)),
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+        ]
+        self.action_priority = [PriorityRule("Witch")]
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+
+class ChapelWitchClassic(EnhancedStrategy):
+    """Open Chapel, thin hard, add Witches, then money and green."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Chapel Witch Classic"
+        self.description = "Chapel thinning into double Witch money"
+        self.version = "1.0"
+
+        self.gain_priority = _greening_rules() + [
+            PriorityRule("Witch", PriorityRule.max_in_deck("Witch", 2)),
+            PriorityRule("Gold"),
+            PriorityRule(
+                "Chapel",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Chapel", 1),
+                    PriorityRule.turn_number("<=", 3),
+                ),
+            ),
+            PriorityRule("Silver"),
+        ]
+        self.action_priority = [
+            PriorityRule("Witch"),
+            PriorityRule(
+                "Chapel",
+                lambda _s, me: me.count_in_deck("Curse") > 0
+                or me.count_in_deck("Estate") > 0
+                or me.count_in_deck("Copper") > 4,
+            ),
+        ]
+        self.trash_priority = [
+            PriorityRule("Curse"),
+            PriorityRule("Estate", PriorityRule.provinces_left(">", 2)),
+            PriorityRule(
+                "Copper",
+                PriorityRule.has_cards(["Silver", "Gold"], 2),
+            ),
+        ]
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+
+class GardensWorkshopRush(EnhancedStrategy):
+    """Workshops gain Gardens every turn; fatten the deck and end on piles."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Gardens Workshop Rush"
+        self.description = "Workshop/Gardens rush with Copper fattening"
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule("Province"),
+            PriorityRule("Gardens"),
+            PriorityRule("Workshop", PriorityRule.max_in_deck("Workshop", 3)),
+            PriorityRule("Estate", PriorityRule.empty_piles(">=", 1)),
+            PriorityRule("Silver"),
+            PriorityRule("Copper", PriorityRule.has_cards(["Gardens"], 3)),
+        ]
+        self.action_priority = [PriorityRule("Workshop")]
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+
+class BigMoneyWharf(EnhancedStrategy):
+    """Big Money plus two Wharves — the strongest classic BM+X."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Big Money Wharf"
+        self.description = "Big Money with two Wharves and late greening"
+        self.version = "1.0"
+
+        self.gain_priority = _greening_rules() + [
+            PriorityRule("Gold"),
+            PriorityRule("Wharf", PriorityRule.max_in_deck("Wharf", 2)),
+            PriorityRule("Silver"),
+        ]
+        self.action_priority = [PriorityRule("Wharf")]
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+
+class RebuildRush(EnhancedStrategy):
+    """Two Rebuilds, Duchies over Gold, race the Province pile."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Rebuild Rush"
+        self.description = "Rebuild/Duchy rush — no Gold, Duchies become Provinces"
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule("Province"),
+            PriorityRule("Rebuild", PriorityRule.max_in_deck("Rebuild", 2)),
+            PriorityRule("Duchy"),
+            PriorityRule("Estate", PriorityRule.provinces_left("<=", 2)),
+            PriorityRule("Silver"),
+        ]
+        self.action_priority = [PriorityRule("Rebuild")]
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+
+class DoubleJack(EnhancedStrategy):
+    """Two Jacks of All Trades plus money — the Isotropic-era benchmark."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Double Jack"
+        self.description = "Big Money with two Jacks of All Trades"
+        self.version = "1.0"
+
+        self.gain_priority = _greening_rules() + [
+            PriorityRule("Gold"),
+            PriorityRule(
+                "Jack of All Trades",
+                PriorityRule.max_in_deck("Jack of All Trades", 2),
+            ),
+            PriorityRule("Silver"),
+        ]
+        self.action_priority = [PriorityRule("Jack of All Trades")]
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+
+class MountebankMoney(EnhancedStrategy):
+    """Big Money plus two Mountebanks — junk the opponent, buy points."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Mountebank Money"
+        self.description = "Big Money with two Mountebanks and late greening"
+        self.version = "1.0"
+
+        self.gain_priority = _greening_rules() + [
+            PriorityRule("Mountebank", PriorityRule.max_in_deck("Mountebank", 2)),
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+        ]
+        self.action_priority = [PriorityRule("Mountebank")]
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+
+class CourtyardMoney(EnhancedStrategy):
+    """Big Money plus two Courtyards bought on 2-4 coin hands."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Courtyard Money"
+        self.description = "Big Money with two cheap Courtyards"
+        self.version = "1.0"
+
+        self.gain_priority = _greening_rules() + [
+            PriorityRule("Gold"),
+            PriorityRule(
+                "Courtyard",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Courtyard", 2),
+                    PriorityRule.resources("coins", "<=", 4),
+                ),
+            ),
+            PriorityRule("Silver"),
+        ]
+        self.action_priority = [PriorityRule("Courtyard")]
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+
+class FirstGameSmithyMilitia(EnhancedStrategy):
+    """Smithy money with a Militia on the base-set First Game kingdom."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "First Game Smithy Militia"
+        self.description = "Smithy money plus one Militia for the First Game kingdom"
+        self.version = "1.0"
+
+        self.gain_priority = _greening_rules() + [
+            PriorityRule("Gold"),
+            PriorityRule("Smithy", PriorityRule.max_in_deck("Smithy", 2)),
+            PriorityRule("Militia", PriorityRule.max_in_deck("Militia", 1)),
+            PriorityRule("Silver"),
+        ]
+        self.action_priority = [
+            PriorityRule("Smithy"),
+            PriorityRule("Militia"),
+        ]
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+
+def create_double_smithy() -> EnhancedStrategy:
+    return DoubleSmithy()
+
+
+def create_double_witch() -> EnhancedStrategy:
+    return DoubleWitch()
+
+
+def create_chapel_witch_classic() -> EnhancedStrategy:
+    return ChapelWitchClassic()
+
+
+def create_gardens_workshop_rush() -> EnhancedStrategy:
+    return GardensWorkshopRush()
+
+
+def create_big_money_wharf() -> EnhancedStrategy:
+    return BigMoneyWharf()
+
+
+def create_rebuild_rush() -> EnhancedStrategy:
+    return RebuildRush()
+
+
+def create_double_jack() -> EnhancedStrategy:
+    return DoubleJack()
+
+
+def create_mountebank_money() -> EnhancedStrategy:
+    return MountebankMoney()
+
+
+def create_courtyard_money() -> EnhancedStrategy:
+    return CourtyardMoney()
+
+
+def create_first_game_smithy_militia() -> EnhancedStrategy:
+    return FirstGameSmithyMilitia()

--- a/dominion/strategy/strategies/calibration_known_best.py
+++ b/dominion/strategy/strategies/calibration_known_best.py
@@ -88,13 +88,15 @@ class ChapelWitchClassic(EnhancedStrategy):
             PriorityRule("Silver"),
         ]
         self.action_priority = [
-            PriorityRule("Witch"),
+            # Chapel first while the deck still has junk: thinning compounds,
+            # so it outranks a single Witch play during the opening shuffles.
             PriorityRule(
                 "Chapel",
                 lambda _s, me: me.count_in_deck("Curse") > 0
                 or me.count_in_deck("Estate") > 0
                 or me.count_in_deck("Copper") > 4,
             ),
+            PriorityRule("Witch"),
         ]
         self.trash_priority = [
             PriorityRule("Curse"),

--- a/reports/calibration/evolve.json
+++ b/reports/calibration/evolve.json
@@ -1,0 +1,122 @@
+[
+  {
+    "board": "smithy_bm",
+    "strategy_a": "Champion smithy_bm",
+    "strategy_b": "Double Smithy",
+    "wins_a": 167,
+    "games": 400,
+    "winrate_a": 41.75,
+    "ci_a": [
+      37.02,
+      46.64
+    ]
+  },
+  {
+    "board": "witch_bm",
+    "strategy_a": "Champion witch_bm",
+    "strategy_b": "Double Witch",
+    "wins_a": 162,
+    "games": 400,
+    "winrate_a": 40.5,
+    "ci_a": [
+      35.8,
+      45.38
+    ]
+  },
+  {
+    "board": "chapel_witch",
+    "strategy_a": "Champion chapel_witch",
+    "strategy_b": "Chapel Witch Classic",
+    "wins_a": 176,
+    "games": 400,
+    "winrate_a": 44.0,
+    "ci_a": [
+      39.22,
+      48.9
+    ]
+  },
+  {
+    "board": "gardens_workshop",
+    "strategy_a": "Champion gardens_workshop",
+    "strategy_b": "Gardens Workshop Rush",
+    "wins_a": 373,
+    "games": 400,
+    "winrate_a": 93.25,
+    "ci_a": [
+      90.36,
+      95.32
+    ]
+  },
+  {
+    "board": "wharf_bm",
+    "strategy_a": "Champion wharf_bm",
+    "strategy_b": "Big Money Wharf",
+    "wins_a": 186,
+    "games": 400,
+    "winrate_a": 46.5,
+    "ci_a": [
+      41.67,
+      51.4
+    ]
+  },
+  {
+    "board": "rebuild_duchy",
+    "strategy_a": "Champion rebuild_duchy",
+    "strategy_b": "Rebuild Rush",
+    "wins_a": 131,
+    "games": 400,
+    "winrate_a": 32.75,
+    "ci_a": [
+      28.33,
+      37.49
+    ]
+  },
+  {
+    "board": "jack_bm",
+    "strategy_a": "Champion jack_bm",
+    "strategy_b": "Double Jack",
+    "wins_a": 192,
+    "games": 400,
+    "winrate_a": 48.0,
+    "ci_a": [
+      43.15,
+      52.89
+    ]
+  },
+  {
+    "board": "mountebank_bm",
+    "strategy_a": "Champion mountebank_bm",
+    "strategy_b": "Mountebank Money",
+    "wins_a": 201,
+    "games": 400,
+    "winrate_a": 50.25,
+    "ci_a": [
+      45.37,
+      55.12
+    ]
+  },
+  {
+    "board": "courtyard_bm",
+    "strategy_a": "Champion courtyard_bm",
+    "strategy_b": "Courtyard Money",
+    "wins_a": 231,
+    "games": 400,
+    "winrate_a": 57.75,
+    "ci_a": [
+      52.86,
+      62.49
+    ]
+  },
+  {
+    "board": "first_game",
+    "strategy_a": "Champion first_game",
+    "strategy_b": "First Game Smithy Militia",
+    "wins_a": 216,
+    "games": 400,
+    "winrate_a": 54.0,
+    "ci_a": [
+      49.1,
+      58.82
+    ]
+  }
+]

--- a/reports/calibration/evolve.md
+++ b/reports/calibration/evolve.md
@@ -1,0 +1,16 @@
+# Calibration: evolved champion vs known-best
+
+| Board | Known best | Games | Champion win rate | 95% CI | Gap (pp) | Verdict |
+|---|---|---|---|---|---|---|
+| smithy_bm | Double Smithy | 400 | 41.8% | [37.0%, 46.6%] | 8.2 | BEHIND |
+| witch_bm | Double Witch | 400 | 40.5% | [35.8%, 45.4%] | 9.5 | BEHIND |
+| chapel_witch | Chapel Witch Classic | 400 | 44.0% | [39.2%, 48.9%] | 6.0 | BEHIND |
+| gardens_workshop | Gardens Workshop Rush | 400 | 93.2% | [90.4%, 95.3%] | 0.0 | BEATS KNOWN BEST |
+| wharf_bm | Big Money Wharf | 400 | 46.5% | [41.7%, 51.4%] | 3.5 | TIED |
+| rebuild_duchy | Rebuild Rush | 400 | 32.8% | [28.3%, 37.5%] | 17.2 | BEHIND |
+| jack_bm | Double Jack | 400 | 48.0% | [43.1%, 52.9%] | 2.0 | TIED |
+| mountebank_bm | Mountebank Money | 400 | 50.2% | [45.4%, 55.1%] | 0.0 | TIED |
+| courtyard_bm | Courtyard Money | 400 | 57.8% | [52.9%, 62.5%] | 0.0 | BEATS KNOWN BEST |
+| first_game | First Game Smithy Militia | 400 | 54.0% | [49.1%, 58.8%] | 0.0 | TIED |
+
+**Mean gap: 4.7 percentage points** (0 = champions match or beat every known-best)

--- a/reports/calibration/evolve_parts/gardens_workshop/champion_gardens_workshop.py
+++ b/reports/calibration/evolve_parts/gardens_workshop/champion_gardens_workshop.py
@@ -1,0 +1,40 @@
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class ChampionGardensWorkshop(EnhancedStrategy):
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = 'gen17-4830900016'
+        self.description = "Auto-generated strategy from genetic training"
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule('Province'),
+            PriorityRule('Duchy', PriorityRule.provinces_left('<=', 6)),
+            PriorityRule('Gold'),
+            PriorityRule('Bureaucrat', PriorityRule.max_in_deck('Bureaucrat', 1)),
+            PriorityRule('Silver', PriorityRule.provinces_left('>', 4)),
+            PriorityRule('Gardens', PriorityRule.max_in_deck('Gardens', 6)),
+            PriorityRule('Moat', PriorityRule.max_in_deck('Moat', 3)),
+        ]
+
+        self.action_priority = [
+            PriorityRule('Cellar'),
+            PriorityRule('Moat'),
+            PriorityRule('Mine'),
+        ]
+
+        self.treasure_priority = [
+            PriorityRule('Gold'),
+            PriorityRule('Silver'),
+            PriorityRule('Copper'),
+        ]
+
+        self.trash_priority = [
+            PriorityRule('Curse'),
+            PriorityRule('Estate', PriorityRule.provinces_left('>', 3)),
+            PriorityRule('Copper', PriorityRule.has_cards(['Silver', 'Gold'], 3)),
+        ]
+
+def create_championgardensworkshop() -> EnhancedStrategy:
+    return ChampionGardensWorkshop()

--- a/reports/calibration/sanity.json
+++ b/reports/calibration/sanity.json
@@ -1,0 +1,122 @@
+[
+  {
+    "board": "smithy_bm",
+    "strategy_a": "Double Smithy",
+    "strategy_b": "Big Money",
+    "wins_a": 371,
+    "games": 400,
+    "winrate_a": 92.75,
+    "ci_a": [
+      89.78,
+      94.9
+    ]
+  },
+  {
+    "board": "witch_bm",
+    "strategy_a": "Double Witch",
+    "strategy_b": "Big Money",
+    "wins_a": 397,
+    "games": 400,
+    "winrate_a": 99.25,
+    "ci_a": [
+      97.82,
+      99.74
+    ]
+  },
+  {
+    "board": "chapel_witch",
+    "strategy_a": "Chapel Witch Classic",
+    "strategy_b": "Big Money",
+    "wins_a": 383,
+    "games": 400,
+    "winrate_a": 95.75,
+    "ci_a": [
+      93.3,
+      97.33
+    ]
+  },
+  {
+    "board": "gardens_workshop",
+    "strategy_a": "Gardens Workshop Rush",
+    "strategy_b": "Big Money",
+    "wins_a": 374,
+    "games": 400,
+    "winrate_a": 93.5,
+    "ci_a": [
+      90.65,
+      95.53
+    ]
+  },
+  {
+    "board": "wharf_bm",
+    "strategy_a": "Big Money Wharf",
+    "strategy_b": "Big Money",
+    "wins_a": 388,
+    "games": 400,
+    "winrate_a": 97.0,
+    "ci_a": [
+      94.83,
+      98.28
+    ]
+  },
+  {
+    "board": "rebuild_duchy",
+    "strategy_a": "Rebuild Rush",
+    "strategy_b": "Big Money",
+    "wins_a": 388,
+    "games": 400,
+    "winrate_a": 97.0,
+    "ci_a": [
+      94.83,
+      98.28
+    ]
+  },
+  {
+    "board": "jack_bm",
+    "strategy_a": "Double Jack",
+    "strategy_b": "Big Money",
+    "wins_a": 385,
+    "games": 400,
+    "winrate_a": 96.25,
+    "ci_a": [
+      93.91,
+      97.71
+    ]
+  },
+  {
+    "board": "mountebank_bm",
+    "strategy_a": "Mountebank Money",
+    "strategy_b": "Big Money",
+    "wins_a": 390,
+    "games": 400,
+    "winrate_a": 97.5,
+    "ci_a": [
+      95.46,
+      98.64
+    ]
+  },
+  {
+    "board": "courtyard_bm",
+    "strategy_a": "Courtyard Money",
+    "strategy_b": "Big Money",
+    "wins_a": 345,
+    "games": 400,
+    "winrate_a": 86.25,
+    "ci_a": [
+      82.53,
+      89.28
+    ]
+  },
+  {
+    "board": "first_game",
+    "strategy_a": "First Game Smithy Militia",
+    "strategy_b": "Big Money",
+    "wins_a": 363,
+    "games": 400,
+    "winrate_a": 90.75,
+    "ci_a": [
+      87.51,
+      93.21
+    ]
+  }
+]

--- a/reports/calibration/sanity.md
+++ b/reports/calibration/sanity.md
@@ -1,0 +1,14 @@
+# Calibration sanity: known-best vs baseline
+
+| Board | Known best | Baseline | Games | Win rate | 95% CI | Verdict |
+|---|---|---|---|---|---|---|
+| smithy_bm | Double Smithy | Big Money | 400 | 92.8% | [89.8%, 94.9%] | PASS |
+| witch_bm | Double Witch | Big Money | 400 | 99.2% | [97.8%, 99.7%] | PASS |
+| chapel_witch | Chapel Witch Classic | Big Money | 400 | 95.8% | [93.3%, 97.3%] | PASS |
+| gardens_workshop | Gardens Workshop Rush | Big Money | 400 | 93.5% | [90.6%, 95.5%] | PASS |
+| wharf_bm | Big Money Wharf | Big Money | 400 | 97.0% | [94.8%, 98.3%] | PASS |
+| rebuild_duchy | Rebuild Rush | Big Money | 400 | 97.0% | [94.8%, 98.3%] | PASS |
+| jack_bm | Double Jack | Big Money | 400 | 96.2% | [93.9%, 97.7%] | PASS |
+| mountebank_bm | Mountebank Money | Big Money | 400 | 97.5% | [95.5%, 98.6%] | PASS |
+| courtyard_bm | Courtyard Money | Big Money | 400 | 86.2% | [82.5%, 89.3%] | PASS |
+| first_game | First Game Smithy Militia | Big Money | 400 | 90.8% | [87.5%, 93.2%] | PASS |

--- a/scripts/calibration_suite.py
+++ b/scripts/calibration_suite.py
@@ -24,6 +24,8 @@ from pathlib import Path
 
 import coloredlogs
 
+from dominion.runner import save_strategy_as_python
+
 from dominion.analysis.calibration import (
     CALIBRATION_SUITE,
     entries_for_keys,
@@ -73,7 +75,7 @@ def main() -> None:
         outcomes = []
         for entry in entries:
             logger.info("Evolving champion for board %s ...", entry.key)
-            outcome, _meta = evolve_and_evaluate(
+            outcome, _meta, champion = evolve_and_evaluate(
                 entry,
                 confirm_games=args.games,
                 population_size=args.population,
@@ -88,6 +90,11 @@ def main() -> None:
                 entry.known_best,
             )
             outcomes.append(outcome)
+            champion_path = args.output_dir / f"champion_{entry.key}.py"
+            save_strategy_as_python(
+                champion, champion_path, class_name=f"Champion{entry.key.title().replace('_', '')}"
+            )
+            logger.info("Champion genome saved to %s", champion_path)
         report = render_evolve_report(outcomes)
         report_path = args.output_dir / "evolve.md"
         json_path = args.output_dir / "evolve.json"

--- a/scripts/calibration_suite.py
+++ b/scripts/calibration_suite.py
@@ -1,0 +1,102 @@
+"""Run the ground-truth calibration suite.
+
+Sanity mode (fast, run this first): battles each board's known-best strategy
+against Big Money. Every board should PASS — a FAIL means the simulator or
+the known-best encoding is broken on that board, and evolution results there
+cannot be trusted.
+
+    PYTHONPATH=. python scripts/calibration_suite.py --mode sanity --games 400
+
+Evolve mode (slow): runs the genetic trainer on each board with its default
+settings, then battles the champion against the known-best strategy. The gap
+(percentage points of champion win rate below 50%) is the number this repo
+is trying to drive to zero.
+
+    PYTHONPATH=. python scripts/calibration_suite.py --mode evolve \
+        --population 40 --generations 40 --games-per-eval 20 --games 400
+
+Use --boards to restrict either mode to a comma-separated subset of keys.
+"""
+
+import argparse
+import logging
+from pathlib import Path
+
+import coloredlogs
+
+from dominion.analysis.calibration import (
+    CALIBRATION_SUITE,
+    entries_for_keys,
+    evolve_and_evaluate,
+    render_evolve_report,
+    render_sanity_report,
+    run_sanity,
+    save_outcomes_json,
+)
+
+logger = logging.getLogger(__name__)
+coloredlogs.install(level="INFO", logger=logger)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=["sanity", "evolve"], default="sanity")
+    parser.add_argument(
+        "--games",
+        type=int,
+        default=400,
+        help="Games per matchup (sanity battles and evolve-mode confirmation)",
+    )
+    parser.add_argument(
+        "--boards",
+        type=str,
+        default=None,
+        help=f"Comma-separated board keys (default: all). Known: {', '.join(e.key for e in CALIBRATION_SUITE)}",
+    )
+    parser.add_argument("--population", type=int, default=40)
+    parser.add_argument("--generations", type=int, default=40)
+    parser.add_argument("--games-per-eval", type=int, default=20)
+    parser.add_argument(
+        "--output-dir", type=Path, default=Path("reports/calibration")
+    )
+    args = parser.parse_args()
+
+    entries = entries_for_keys(args.boards.split(",") if args.boards else None)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.mode == "sanity":
+        outcomes = run_sanity(entries, args.games)
+        report = render_sanity_report(outcomes)
+        report_path = args.output_dir / "sanity.md"
+        json_path = args.output_dir / "sanity.json"
+    else:
+        outcomes = []
+        for entry in entries:
+            logger.info("Evolving champion for board %s ...", entry.key)
+            outcome, _meta = evolve_and_evaluate(
+                entry,
+                confirm_games=args.games,
+                population_size=args.population,
+                generations=args.generations,
+                games_per_eval=args.games_per_eval,
+            )
+            logger.info(
+                "%s: champion won %.1f%% of %d games vs %s",
+                entry.key,
+                outcome.winrate_a,
+                outcome.games,
+                entry.known_best,
+            )
+            outcomes.append(outcome)
+        report = render_evolve_report(outcomes)
+        report_path = args.output_dir / "evolve.md"
+        json_path = args.output_dir / "evolve.json"
+
+    report_path.write_text(report, encoding="utf-8")
+    save_outcomes_json(outcomes, json_path)
+    print(report)
+    print(f"Report written to {report_path} (JSON: {json_path})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/calibration_suite.py
+++ b/scripts/calibration_suite.py
@@ -40,12 +40,22 @@ logger = logging.getLogger(__name__)
 coloredlogs.install(level="INFO", logger=logger)
 
 
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid int value: {value!r}") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"must be a positive integer, got {value!r}")
+    return parsed
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--mode", choices=["sanity", "evolve"], default="sanity")
     parser.add_argument(
         "--games",
-        type=int,
+        type=positive_int,
         default=400,
         help="Games per matchup (sanity battles and evolve-mode confirmation)",
     )
@@ -55,15 +65,16 @@ def main() -> None:
         default=None,
         help=f"Comma-separated board keys (default: all). Known: {', '.join(e.key for e in CALIBRATION_SUITE)}",
     )
-    parser.add_argument("--population", type=int, default=40)
-    parser.add_argument("--generations", type=int, default=40)
-    parser.add_argument("--games-per-eval", type=int, default=20)
+    parser.add_argument("--population", type=positive_int, default=40)
+    parser.add_argument("--generations", type=positive_int, default=40)
+    parser.add_argument("--games-per-eval", type=positive_int, default=20)
     parser.add_argument(
         "--output-dir", type=Path, default=Path("reports/calibration")
     )
     args = parser.parse_args()
 
-    entries = entries_for_keys(args.boards.split(",") if args.boards else None)
+    boards = [key.strip() for key in args.boards.split(",") if key.strip()] if args.boards else None
+    entries = entries_for_keys(boards)
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
     if args.mode == "sanity":

--- a/tests/test_calibration_suite.py
+++ b/tests/test_calibration_suite.py
@@ -1,0 +1,153 @@
+"""Tests for the ground-truth calibration suite.
+
+The calibration suite pairs boards with community-known best strategies so
+the evolution pipeline can be scored against an external reference instead
+of only against itself.
+"""
+
+import pytest
+
+from dominion.analysis.calibration import (
+    CALIBRATION_SUITE,
+    MatchOutcome,
+    entries_for_keys,
+    gap_points,
+    render_evolve_report,
+    render_sanity_report,
+    wilson_interval,
+)
+from dominion.boards.loader import load_board
+from dominion.cards.registry import get_card
+from dominion.strategy.enhanced_strategy import PriorityRule
+from dominion.strategy.strategy_loader import StrategyLoader
+
+BASIC_SUPPLY = {
+    "Copper",
+    "Silver",
+    "Gold",
+    "Platinum",
+    "Estate",
+    "Duchy",
+    "Province",
+    "Colony",
+    "Curse",
+}
+
+
+@pytest.fixture(scope="module")
+def loader():
+    return StrategyLoader()
+
+
+def test_suite_is_nonempty_with_unique_keys():
+    keys = [entry.key for entry in CALIBRATION_SUITE]
+    assert len(keys) >= 8
+    assert len(set(keys)) == len(keys)
+
+
+def test_entries_for_keys_filters_and_rejects_unknown():
+    all_entries = entries_for_keys(None)
+    assert list(all_entries) == list(CALIBRATION_SUITE)
+
+    first = CALIBRATION_SUITE[0]
+    assert [e.key for e in entries_for_keys([first.key])] == [first.key]
+
+    with pytest.raises(ValueError, match="no-such-board"):
+        entries_for_keys(["no-such-board"])
+
+
+@pytest.mark.parametrize("entry", CALIBRATION_SUITE, ids=lambda e: e.key)
+def test_board_file_loads_and_all_cards_resolve(entry):
+    config = load_board(entry.board_path())
+    assert len(config.kingdom_cards) == 10
+    for name in config.kingdom_cards:
+        get_card(name)  # raises on unknown card
+
+
+@pytest.mark.parametrize("entry", CALIBRATION_SUITE, ids=lambda e: e.key)
+def test_known_best_strategy_loads_and_fits_board(entry, loader):
+    strategy = loader.get_strategy(entry.known_best)
+    assert strategy is not None, f"strategy {entry.known_best!r} not registered"
+
+    config = load_board(entry.board_path())
+    allowed = set(config.kingdom_cards) | BASIC_SUPPLY
+    for rules in (
+        strategy.gain_priority,
+        strategy.action_priority,
+        strategy.treasure_priority,
+        strategy.trash_priority,
+    ):
+        for rule in rules:
+            if isinstance(rule, PriorityRule):
+                assert rule.card_name in allowed, (
+                    f"{entry.known_best} references {rule.card_name!r}, "
+                    f"which is not on board {entry.key}"
+                )
+
+
+def test_wilson_interval_midpoint():
+    lo, hi = wilson_interval(50, 100)
+    assert 0.40 < lo < 0.42
+    assert 0.58 < hi < 0.60
+
+
+def test_wilson_interval_extremes():
+    lo, hi = wilson_interval(10, 10)
+    assert lo > 0.65
+    assert hi > 0.99
+
+    lo, hi = wilson_interval(0, 10)
+    assert lo < 0.01
+    assert hi < 0.35
+
+    assert wilson_interval(0, 0) == (0.0, 1.0)
+
+
+def test_gap_points():
+    assert gap_points(50.0) == 0.0
+    assert gap_points(62.0) == 0.0
+    assert gap_points(43.5) == pytest.approx(6.5)
+
+
+def _outcome(**overrides):
+    base = dict(
+        board="smithy_bm",
+        strategy_a="Double Smithy",
+        strategy_b="Big Money",
+        wins_a=140,
+        games=200,
+    )
+    base.update(overrides)
+    return MatchOutcome(**base)
+
+
+def test_match_outcome_winrate_and_ci():
+    outcome = _outcome()
+    assert outcome.winrate_a == pytest.approx(70.0)
+    lo, hi = outcome.ci_a
+    assert 60.0 < lo < 70.0 < hi < 80.0
+
+
+def test_render_sanity_report_shows_boards_and_verdicts():
+    strong = _outcome()
+    weak = _outcome(board="rebuild_duchy", strategy_a="Rebuild Rush", wins_a=90)
+    text = render_sanity_report([strong, weak])
+    assert "smithy_bm" in text
+    assert "Double Smithy" in text
+    assert "70.0" in text
+    assert "PASS" in text
+    assert "FAIL" in text
+
+
+def test_render_evolve_report_includes_mean_gap():
+    tied = _outcome(strategy_a="Champion", strategy_b="Double Smithy", wins_a=100)
+    behind = _outcome(
+        board="rebuild_duchy",
+        strategy_a="Champion",
+        strategy_b="Rebuild Rush",
+        wins_a=80,
+    )
+    text = render_evolve_report([tied, behind])
+    assert "Mean gap" in text
+    # tied game: gap 0; behind: 40% -> gap 10; mean 5.0
+    assert "5.0" in text


### PR DESCRIPTION
## What this is

The repo had no way to tell whether a weak evolved champion meant a simulator bug, a policy-representation ceiling, a search failure, or evaluation noise — every result was measured against opponents the pipeline itself produced. This PR adds an external reference: 10 boards where the Dominion community established the best strategy years ago, paired with clean hand-written encodings of those strategies, plus a two-mode benchmark harness.

- `boards/calibration/` — 10 boards (mostly BM+X with deliberately weak support, where community answers are settled)
- `dominion/strategy/strategies/calibration_known_best.py` — known-best archetypes (Double Smithy/Witch/Jack, Chapel Witch, Workshop/Gardens rush, BM-Wharf, Rebuild rush, Mountebank/Courtyard money, First Game Smithy-Militia)
- `dominion/analysis/calibration.py` — suite definition, Wilson CIs, gap metric, reports
- `scripts/calibration_suite.py` — `--mode sanity` (known-best vs Big Money; validates sim + encodings) and `--mode evolve` (trains a champion per board, confirms vs known-best, saves the champion genome)
- `docs/calibration.md` — boards, sources, how to read the gap score, first results

## Baseline results

**Sanity: all 10 boards PASS** (known-best beats Big Money 86–99% at 400 games) — simulator and encodings are trustworthy on these boards.

**Evolve (out-of-the-box trainer, pop 30 / gens 30 / 15 games per eval, 400 confirm games): mean gap 4.7pp, champions behind on 4 of 10 boards**, and the failures split into exactly the categories the suite was built to separate:

| Category | Boards | Evidence |
|---|---|---|
| Representability ceiling | rebuild_duchy (32.8%), likely chapel_witch (44.0%) | The structured genome always gates Duchy behind `provinces_left <= 3..6` (init + re-gate vocabulary), so "Duchy over Gold from turn 1" — the Rebuild rush — is outside the search space entirely |
| Objective/panel failure | witch_bm (40.5%), smithy_bm (41.8%) | Both archetypes are fully representable, but training vs the Big Money panel gives no gradient toward the mirror-optimal BM+X |
| Pipeline wins | gardens_workshop (93.2%), courtyard_bm (57.8%) | On the Gardens board the GA found a genuinely better plan than the community rush — contest the Gardens pile from a money deck; hand-buffed rush variants still lose ~90% to the saved champion |

This makes the next two work items concrete and measurable: widen the greening-gate vocabulary (re-run rebuild_duchy to verify), and add a coevolution/champion-pool outer loop (re-run witch_bm/smithy_bm).

## Tests

- 28 new tests (board/strategy/suite integrity, Wilson CI, gap math, report rendering)
- Full suite: 1786 passed, 5 deselected (slow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a calibration suite for comparing evolved strategies against known benchmarks.
  * Added a command-line workflow to run calibration checks and generate reports.
  * Added calibration result outputs in Markdown and JSON.

* **Documentation**
  * Expanded the README and added a dedicated calibration guide with usage examples and result interpretation.

* **Tests**
  * Added coverage for calibration board loading, strategy matching, statistics helpers, and report formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->