### PR TITLE
Add phase-aware Dominion strategy genomes

### DIFF
--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -119,10 +119,11 @@ exactly the categories the suite was designed to separate:
 
 - The known-best strategies are strong reference points, not proofs of
   optimality. A champion beating one is a good sign, not a guarantee.
-- Known-best play still flows through the same computer-player hooks as everyone else
-  (e.g. Jack of All Trades' hardcoded trash/discard choices), so a weak
-  hook drags both sides equally in the champion match, but can depress the
-  sanity-mode margin vs Big Money.
+- Known-best play still flows through the same computer-player hooks as everyone
+  else (e.g. Jack of All Trades' hardcoded trash/discard choices). A weak hook
+  can affect both strategies, but not necessarily equally: the strategy that
+  buys or invokes the card more often may be hurt more. Interpret sanity-mode
+  margins involving such hooks with caution.
 - 400 games resolves ~5pp differences; use 1000+ for finer comparisons.
 
 ## Representation update (2026-07-10)

--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -8,9 +8,11 @@ and they need different fixes:
 1. **Simulator bug** — a card rule is wrong, so the board plays differently
    than real Dominion (see the Hyderabad Exile bug, where one wrong rule
    flipped a seed strategy from 4% to 93% vs Big Money).
-2. **Policy ceiling** — the priority-list DSL or a hardcoded AI hook cannot
+2. **Policy ceiling** — the priority-list strategy language or a hardcoded
+   computer-player hook cannot
    represent the play the board demands.
-3. **Search failure** — the GA never finds a genome the DSL could express.
+3. **Search failure** — genetic search never finds a genome the strategy
+   language could express.
 4. **Evaluation noise** — the fitness signal was too noisy to rank candidates.
 
 Until now the repo had no way to tell these apart, because every result was
@@ -22,20 +24,21 @@ hand-written encodings of those strategies.
 ## The boards
 
 All boards live in `boards/calibration/`. Most pair one strong kingdom card
-with deliberately weak support ("BM+X" boards), because those have the most
+with deliberately weak support (Big Money plus one focal kingdom card),
+because those have the most
 settled community answers.
 
 | Board | Known best | The known answer |
 |---|---|---|
-| `smithy_bm` | Double Smithy | BM + 2 Smithies beats straight BM (classic sim result) |
-| `witch_bm` | Double Witch | Witch money crushes BM on support-free boards |
+| `smithy_bm` | Double Smithy | Big Money plus two Smithies beats straight Big Money (classic simulation result) |
+| `witch_bm` | Double Witch | Witch money crushes Big Money on support-free boards |
 | `chapel_witch` | Chapel Witch Classic | Chapel thinning into Witch beats unthinned Witch money |
 | `gardens_workshop` | Gardens Workshop Rush | Workshop-gains-Gardens rush beats money on weak-money boards |
-| `wharf_bm` | Big Money Wharf | BM-Wharf was the strongest classic BM+X |
+| `wharf_bm` | Big Money Wharf | Big Money with Wharf was the strongest classic focal-card strategy |
 | `rebuild_duchy` | Rebuild Rush | Rebuild/Duchy (no Gold) beats money strategies outright |
 | `jack_bm` | Double Jack | Double Jack was the Isotropic-era benchmark |
-| `mountebank_bm` | Mountebank Money | Mountebank-BM is a standard strong baseline |
-| `courtyard_bm` | Courtyard Money | 2 Courtyards on $2–4 hands beats straight BM |
+| `mountebank_bm` | Mountebank Money | Mountebank money is a standard strong baseline |
+| `courtyard_bm` | Courtyard Money | Two Courtyards on $2–4 hands beats straight Big Money |
 | `first_game` | First Game Smithy Militia | Smithy money (+Militia) wins the base-set First Game kingdom |
 
 The known-best strategies are in
@@ -74,7 +77,7 @@ vs the known-best falls below 50. The suite-level number is the **mean gap**:
 - **small (≤5)** — search is close; tuning (budgets, seeds, vocabulary) may
   close it.
 - **large on specific boards** — read those boards' verdicts. A big gap on
-  `chapel_witch` or `gardens_workshop` but not on the BM+X boards points at
+  `chapel_witch` or `gardens_workshop` but not on the focal-card boards points at
   representation/play-skill limits (trash policy, gainer play) rather than
   general search failure.
 
@@ -101,11 +104,11 @@ exactly the categories the suite was designed to separate:
 - **Objective failure — `witch_bm` (40.5%), `smithy_bm` (41.8%).** Both
   archetypes are fully representable (a capped kingdom pick over a money
   backbone), yet champions trained against the Big Money panel converge to
-  something that beats Big Money without matching the tuned BM+X mirror.
+  something that beats Big Money without matching the tuned focal-card mirror.
   Fixed weak panels give no gradient toward mirror-optimal play; this is the
   motivation for a coevolution / champion-pool outer loop.
 - **Legitimate wins — `gardens_workshop` (93.2%), `courtyard_bm` (57.8%).**
-  On the Gardens board the GA found a genuinely better plan than the
+  On the Gardens board genetic search found a genuinely better plan than the
   community archetype: play money, contest the Gardens pile from the money
   deck, and win the long game on Provinces. Hand-buffed rush variants
   (uncapped Workshops, earlier Estates) still lose ~90% to the champion's
@@ -116,8 +119,20 @@ exactly the categories the suite was designed to separate:
 
 - The known-best strategies are strong reference points, not proofs of
   optimality. A champion beating one is a good sign, not a guarantee.
-- Known-best play still flows through the same AI hooks as everyone else
+- Known-best play still flows through the same computer-player hooks as everyone else
   (e.g. Jack of All Trades' hardcoded trash/discard choices), so a weak
   hook drags both sides equally in the champion match, but can depress the
   sanity-mode margin vs Big Money.
 - 400 games resolves ~5pp differences; use 1000+ for finer comparisons.
+
+## Representation update (2026-07-10)
+
+The structured search representation now uses typed opening, build, economy,
+greening, and endgame modules. The Rebuild plan, an exact early single-card
+opening, and score-aware third-pile endings are directly representable and
+covered by tests. See `docs/strategy-search-architecture.md`.
+
+The first-results table above remains the historical baseline. It should not
+be overwritten by a small smoke run; the next comparable run must use the same
+30-individual, 30-generation, 15-game evaluation budget and 400 confirmation
+games.

--- a/docs/strategy-search-architecture.md
+++ b/docs/strategy-search-architecture.md
@@ -1,0 +1,65 @@
+# Strategy search architecture
+
+The solver searches complete strategic plans rather than treating an ordered
+buy list as the strategy itself. Gameplay still consumes ordinary priority
+rules, but search operates on typed modules and compiles them into those rules.
+This keeps saved strategies readable and compatible with the simulator while
+making genetic edits strategically meaningful.
+
+## Typed strategy modules
+
+`dominion/simulation/strategic_genome.py` defines the current modules:
+
+- opening targets, including an exact copy count and opening turn window;
+- build targets, including copy count, timing, dependencies, and their
+  priority relative to Province and Duchy;
+- economy policy, including deliberate no-Gold rushes;
+- Province, Duchy, and Estate greening policy;
+- score-aware third-pile endings;
+- trashing thresholds;
+- action and Treasure play order.
+
+The compiler attaches the typed genome to an ordinary `BaseStrategy` as
+`_strategic_genome`. Semantic mutation changes one of the modules and then
+recompiles the phenotype. Semantic crossover exchanges whole modules between
+parents. Hand-written or older generated strategies without typed metadata
+continue through the previous structured-list operators.
+
+The initial representability targets are all covered directly:
+
+- one Chapel during the first two turns;
+- two Rebuilds followed by unconditional Duchies, with Gold disabled;
+- an Estate that takes the third pile only when it ends the game without
+  falling behind.
+
+## Validation standard
+
+Every community reference strategy in the calibration suite should be
+expressible without a custom Python decision hook. A representability test is
+required before interpreting a poor calibration result as a search failure.
+
+Small calibration runs are useful for detecting crashes and degenerate search
+dynamics, but not for comparing strategy strength. The published baseline used
+30 individuals, 30 generations, 15 screening games, and 400 confirmation
+games. Comparisons against it must use an equivalent budget and fixed seeds.
+
+## Next search layer: adversarial league training
+
+The next architectural slice replaces a fixed opponent average with an
+iterative league:
+
+1. optimize separate strategic archetypes;
+2. build their complete cross-play matrix;
+3. search for a counterstrategy to the current league leader or mixture;
+4. retain counters that expose a statistically meaningful weakness;
+5. train subsequent candidates against a weighted league mixture;
+6. stop only after repeated counter searches fail to find an exploit.
+
+League evaluation should report both mixture win rate and the candidate's
+worst supported matchup. Historical champions remain useful regression
+opponents, but they are not a substitute for actively generated counters.
+
+After league training, the next coverage layer is declarative card capability
+metadata and board-derived archetypes. This will replace source-text role
+inference with explicit descriptions of draw, village capacity, gain topology,
+trashing, attacks, alternate scoring, pile pressure, and tactical choices.

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -1093,6 +1093,13 @@ class GeneticTrainer:
                 from dominion.strategy.rule_pruning import prune_unfired_rules
                 prune_unfired_rules(parent1, min_rules=self.prune_min_rules)
                 prune_unfired_rules(parent2, min_rules=self.prune_min_rules)
+                if self.structured_genome:
+                    from dominion.simulation.strategic_genome import (
+                        synchronize_strategic_genome,
+                    )
+
+                    synchronize_strategic_genome(parent1, self._kingdom_info)
+                    synchronize_strategic_genome(parent2, self._kingdom_info)
 
             child = self._crossover(parent1, parent2)
             child = self._mutate(child)
@@ -1154,6 +1161,15 @@ class GeneticTrainer:
                         simplify_strategy,
                     )
                     population = [simplify_strategy(s) for s in population]
+                    if self.structured_genome:
+                        from dominion.simulation.strategic_genome import (
+                            synchronize_strategic_genome,
+                        )
+
+                        for strategy in population:
+                            synchronize_strategic_genome(
+                                strategy, self._kingdom_info
+                            )
 
                 # --- Screen: every individual gets the cheap budget. With
                 # common random numbers, the whole generation plays the same

--- a/dominion/simulation/genetic_trainer.py
+++ b/dominion/simulation/genetic_trainer.py
@@ -750,7 +750,24 @@ class GeneticTrainer:
 
     def _crossover(self, parent1: BaseStrategy, parent2: BaseStrategy) -> BaseStrategy:
         """Create a new strategy by combining two parent strategies"""
+        if self.structured_genome:
+            from dominion.simulation.strategic_genome import (
+                crossover_strategic_strategies,
+            )
+
+            semantic_child = crossover_strategic_strategies(
+                parent1, parent2, self._kingdom_info
+            )
+            if semantic_child is not None:
+                return semantic_child
+
         child = deepcopy(parent1)
+        # Positional crossover is the compatibility path for a hand-written
+        # or older parent. Its result no longer corresponds to parent1's typed
+        # modules, so discard stale metadata; subsequent mutation correctly
+        # stays on the legacy structured operators.
+        if hasattr(child, "_strategic_genome"):
+            delattr(child, "_strategic_genome")
 
         # Crossover gain priorities
         for i, priority in enumerate(child.gain_priority):

--- a/dominion/simulation/strategic_genome.py
+++ b/dominion/simulation/strategic_genome.py
@@ -246,6 +246,94 @@ class StrategicGenome:
         return strategy
 
 
+def _rule_signature(rule: PriorityRule) -> tuple[str, str | None]:
+    condition = getattr(rule, "condition", None)
+    return (
+        rule.card_name,
+        getattr(condition, "_source", None) if condition is not None else None,
+    )
+
+
+def synchronize_strategic_genome(strategy: BaseStrategy, info) -> bool:
+    """Reconcile typed modules with a simplified or empirically pruned phenotype.
+
+    Simplification and rule pruning operate on compiled priority lists. Without
+    this reconciliation, semantic crossover would compile the pre-pruning
+    modules and resurrect removed rules. The phenotype remains authoritative:
+    modules whose compiled rules disappeared are removed or disabled, while
+    surviving action and Treasure order is copied back verbatim.
+
+    Returns ``False`` for legacy strategies without typed metadata.
+    """
+
+    original = getattr(strategy, "_strategic_genome", None)
+    if original is None:
+        return False
+    genome = deepcopy(original)
+    gain_signatures = {_rule_signature(rule) for rule in strategy.gain_priority}
+    action_names = [rule.card_name for rule in strategy.action_priority]
+    treasure_names = [rule.card_name for rule in strategy.treasure_priority]
+    trash_signatures = {_rule_signature(rule) for rule in strategy.trash_priority}
+
+    # Match typed entries by compiling each one in isolation. This avoids
+    # relying on positions that differ across opening/green priority bands.
+    kept_openings = []
+    for opening in genome.openings:
+        probe = StrategicGenome(
+            openings=[deepcopy(opening)],
+            greening=GreeningPlan(duchy_mode="never"),
+            economy=EconomyPlan(buy_gold=False, buy_silver=False),
+        ).compile_into(BaseStrategy(), info)
+        signature = next(
+            (_rule_signature(rule) for rule in probe.gain_priority if rule.card_name == opening.card),
+            None,
+        )
+        if signature in gain_signatures:
+            kept_openings.append(opening)
+    genome.openings = kept_openings
+
+    kept_targets = []
+    for target in genome.build_targets:
+        probe = StrategicGenome(
+            build_targets=[deepcopy(target)],
+            greening=GreeningPlan(duchy_mode="never"),
+            economy=EconomyPlan(buy_gold=False, buy_silver=False),
+        ).compile_into(BaseStrategy(), info)
+        signature = next(
+            (_rule_signature(rule) for rule in probe.gain_priority if rule.card_name == target.card),
+            None,
+        )
+        if signature in gain_signatures:
+            kept_targets.append(target)
+    genome.build_targets = kept_targets
+
+    if not any(card == "Duchy" for card, _condition in gain_signatures):
+        genome.greening.duchy_mode = "never"
+    if not any(
+        card == "Estate" and "empty_piles" not in (condition or "")
+        for card, condition in gain_signatures
+    ):
+        genome.greening.estate_mode = "never"
+    if not any(
+        card == "Estate" and "empty_piles" in (condition or "")
+        for card, condition in gain_signatures
+    ):
+        genome.endgame.estate_pileout = False
+    genome.economy.buy_gold = any(card == "Gold" for card, _ in gain_signatures)
+    genome.economy.buy_silver = any(card == "Silver" for card, _ in gain_signatures)
+
+    genome.action_order = [card for card in action_names if card in genome.action_order]
+    genome.treasure_order = [card for card in treasure_names if card in genome.treasure_order]
+    genome.trash.trash_curse = any(card == "Curse" for card, _ in trash_signatures)
+    if not any(card == "Estate" for card, _ in trash_signatures):
+        genome.trash.estate_until_provinces = None
+    if not any(card == "Copper" for card, _ in trash_signatures):
+        genome.trash.copper_after_treasures = None
+
+    strategy._strategic_genome = genome
+    return True
+
+
 def _default_action_order(info, rng) -> list[str]:
     ordered: list[str] = []
     for source in (info.villages, info.cantrips, info.terminal_draw, info.other_terminals):

--- a/dominion/simulation/strategic_genome.py
+++ b/dominion/simulation/strategic_genome.py
@@ -1,0 +1,435 @@
+"""Typed, phase-aware genome for Dominion strategy search.
+
+The original structured genome mutates a compiled priority list directly.
+That keeps random strategies coherent, but it loses the strategic meaning of
+an edit: "move this rule" can accidentally change an opening, a greening
+threshold, or an endgame tactic.  This module stores those concepts as typed
+blocks and compiles them to the existing :class:`BaseStrategy` phenotype.
+
+Keeping the phenotype unchanged is deliberate.  Battles, decision tracing,
+linting, generated Python strategies, and hand-written seed strategies all
+continue to use ordinary ``PriorityRule`` lists.  The trainer can use semantic
+mutation/crossover whenever both parents carry ``_strategic_genome`` and fall
+back to the legacy structured operators for older seeds.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+import random as _random_module
+from typing import Literal
+
+from dominion.strategy.card_roles import infer_card_roles
+from dominion.strategy.enhanced_strategy import PriorityRule
+from dominion.strategy.strategies.base_strategy import BaseStrategy
+
+
+@dataclass
+class OpeningTarget:
+    """Buy exactly ``copies`` of ``card`` during the opening window."""
+
+    card: str
+    copies: int = 1
+    through_turn: int = 4
+
+
+@dataclass
+class BuildTarget:
+    """A deck-composition target used during the build phase."""
+
+    card: str
+    copies: int
+    through_turn: int | None = None
+    while_provinces_above: int | None = None
+    requires_card: str | None = None
+    priority_band: Literal["before_province", "before_duchy", "build"] = "build"
+
+
+@dataclass
+class EconomyPlan:
+    buy_gold: bool = True
+    buy_silver: bool = True
+    silver_cap: int | None = None
+    silver_through_turn: int | None = None
+    gold_cap: int | None = None
+    prefer_platinum: bool = True
+
+
+@dataclass
+class GreeningPlan:
+    """Victory-card policy, independent of the build and opening blocks."""
+
+    province_mode: Literal["always", "threshold"] = "always"
+    province_threshold: int = 8
+    duchy_mode: Literal["never", "threshold", "always"] = "threshold"
+    duchy_threshold: int = 4
+    estate_mode: Literal["never", "threshold"] = "never"
+    estate_threshold: int = 2
+
+
+@dataclass
+class EndgamePlan:
+    """Policies whose purpose is ending or denying the game, not deck growth."""
+
+    estate_pileout: bool = False
+    pileout_max_remaining: int = 1
+    pileout_min_score_diff: int = 0
+
+
+@dataclass
+class TrashPlan:
+    trash_curse: bool = True
+    estate_until_provinces: int | None = 4
+    copper_after_treasures: int | None = 3
+
+
+@dataclass
+class StrategicGenome:
+    """A complete high-level strategy that compiles to priority lists."""
+
+    openings: list[OpeningTarget] = field(default_factory=list)
+    build_targets: list[BuildTarget] = field(default_factory=list)
+    economy: EconomyPlan = field(default_factory=EconomyPlan)
+    greening: GreeningPlan = field(default_factory=GreeningPlan)
+    endgame: EndgamePlan = field(default_factory=EndgamePlan)
+    trash: TrashPlan = field(default_factory=TrashPlan)
+    action_order: list[str] = field(default_factory=list)
+    treasure_order: list[str] = field(default_factory=list)
+
+    def compile_into(self, strategy: BaseStrategy, info) -> BaseStrategy:
+        """Replace phenotype rule lists while preserving identity and Ways."""
+
+        gain: list[PriorityRule] = []
+
+        # A pile-out rule must precede normal green: its purpose is to take a
+        # cheaper card even when Province is affordable.
+        if self.endgame.estate_pileout:
+            gain.append(
+                PriorityRule(
+                    "Estate",
+                    PriorityRule.and_(
+                        PriorityRule.empty_piles(">=", 2),
+                        PriorityRule.pile_count(
+                            "Estate", "<=", self.endgame.pileout_max_remaining
+                        ),
+                        PriorityRule.score_diff(">=", self.endgame.pileout_min_score_diff),
+                    ),
+                )
+            )
+
+        # Explicit opening rules sit above green/build rules.  The max-in-deck
+        # condition makes "one Chapel on turns 1-2" a single reachable edit.
+        for opening in self.openings:
+            gain.append(
+                PriorityRule(
+                    opening.card,
+                    PriorityRule.and_(
+                        PriorityRule.max_in_deck(opening.card, opening.copies),
+                        PriorityRule.turn_number("<=", opening.through_turn),
+                    ),
+                )
+            )
+
+        def compile_target(target: BuildTarget) -> PriorityRule:
+            conditions = [PriorityRule.max_in_deck(target.card, target.copies)]
+            if target.through_turn is not None:
+                conditions.append(PriorityRule.turn_number("<=", target.through_turn))
+            if target.while_provinces_above is not None:
+                conditions.append(
+                    PriorityRule.provinces_left(">", target.while_provinces_above)
+                )
+            if target.requires_card is not None:
+                conditions.append(PriorityRule.has_cards([target.requires_card], 1))
+            return PriorityRule(target.card, PriorityRule.and_(*conditions))
+
+        gain.extend(
+            compile_target(target)
+            for target in self.build_targets
+            if target.priority_band == "before_province"
+        )
+
+        if info.has_colony:
+            gain.append(PriorityRule("Colony"))
+
+        if self.greening.province_mode == "always":
+            gain.append(PriorityRule("Province"))
+        else:
+            gain.append(
+                PriorityRule(
+                    "Province",
+                    PriorityRule.provinces_left("<=", self.greening.province_threshold),
+                )
+            )
+
+        gain.extend(
+            compile_target(target)
+            for target in self.build_targets
+            if target.priority_band == "before_duchy"
+        )
+
+        if self.greening.duchy_mode == "always":
+            gain.append(PriorityRule("Duchy"))
+        elif self.greening.duchy_mode == "threshold":
+            gain.append(
+                PriorityRule(
+                    "Duchy",
+                    PriorityRule.provinces_left("<=", self.greening.duchy_threshold),
+                )
+            )
+
+        if self.greening.estate_mode == "threshold":
+            gain.append(
+                PriorityRule(
+                    "Estate",
+                    PriorityRule.provinces_left("<=", self.greening.estate_threshold),
+                )
+            )
+
+        gain.extend(
+            compile_target(target)
+            for target in self.build_targets
+            if target.priority_band == "build"
+        )
+
+        if info.has_platinum and self.economy.prefer_platinum:
+            gain.append(PriorityRule("Platinum"))
+        gold_condition = (
+            PriorityRule.max_in_deck("Gold", self.economy.gold_cap)
+            if self.economy.gold_cap is not None
+            else None
+        )
+        if self.economy.buy_gold:
+            gain.append(PriorityRule("Gold", gold_condition))
+
+        silver_conditions = []
+        if self.economy.silver_cap is not None:
+            silver_conditions.append(
+                PriorityRule.max_in_deck("Silver", self.economy.silver_cap)
+            )
+        if self.economy.silver_through_turn is not None:
+            silver_conditions.append(
+                PriorityRule.turn_number("<=", self.economy.silver_through_turn)
+            )
+        if self.economy.buy_silver:
+            gain.append(
+                PriorityRule(
+                    "Silver",
+                    PriorityRule.and_(*silver_conditions) if silver_conditions else None,
+                )
+            )
+        strategy.gain_priority = gain
+        strategy.action_priority = [PriorityRule(card) for card in self.action_order]
+        strategy.treasure_priority = [PriorityRule(card) for card in self.treasure_order]
+
+        trash: list[PriorityRule] = []
+        if self.trash.trash_curse:
+            trash.append(PriorityRule("Curse"))
+        if self.trash.estate_until_provinces is not None:
+            trash.append(
+                PriorityRule(
+                    "Estate",
+                    PriorityRule.provinces_left(">", self.trash.estate_until_provinces),
+                )
+            )
+        if self.trash.copper_after_treasures is not None:
+            trash.append(
+                PriorityRule(
+                    "Copper",
+                    PriorityRule.has_cards(
+                        ["Silver", "Gold"], self.trash.copper_after_treasures
+                    ),
+                )
+            )
+        strategy.trash_priority = trash
+        strategy._strategic_genome = deepcopy(self)
+        return strategy
+
+
+def _default_action_order(info, rng) -> list[str]:
+    ordered: list[str] = []
+    for source in (info.villages, info.cantrips, info.terminal_draw, info.other_terminals):
+        group = list(source)
+        rng.shuffle(group)
+        ordered.extend(group)
+    return ordered
+
+
+def random_strategic_genome(info, rng=_random_module) -> StrategicGenome:
+    """Create a coherent but diverse phase-aware strategic hypothesis."""
+
+    openings: list[OpeningTarget] = []
+    opening_candidates = [
+        card for card in info.gainable if infer_card_roles(card).has("trasher")
+    ]
+    if opening_candidates and rng.random() < 0.45:
+        openings.append(OpeningTarget(rng.choice(opening_candidates), 1, rng.randint(2, 4)))
+
+    picks = list(info.gainable)
+    rng.shuffle(picks)
+    picks = picks[: rng.randint(min(2, len(picks)), min(6, len(picks)))] if picks else []
+    targets = [
+        BuildTarget(
+            card=card,
+            copies=info.default_cap(card, rng),
+            through_turn=rng.randint(8, 16) if rng.random() < 0.2 else None,
+            while_provinces_above=rng.randint(2, 4) if rng.random() < 0.2 else None,
+            priority_band=rng.choices(
+                ["build", "before_duchy", "before_province"],
+                weights=[0.75, 0.2, 0.05],
+                k=1,
+            )[0],
+        )
+        for card in picks
+    ]
+    targets.sort(key=lambda target: info.costs.get(target.card, 0), reverse=True)
+
+    province_mode = "always" if rng.random() < 0.8 else "threshold"
+    duchy_roll = rng.random()
+    duchy_mode: Literal["never", "threshold", "always"]
+    if duchy_roll < 0.1:
+        duchy_mode = "never"
+    elif duchy_roll < 0.22:
+        duchy_mode = "always"
+    else:
+        duchy_mode = "threshold"
+
+    treasures = (
+        (["Platinum"] if info.has_platinum else [])
+        + ["Gold"]
+        + sorted(info.treasure_cards, key=lambda c: -info.costs.get(c, 0))
+        + ["Silver", "Copper"]
+    )
+    return StrategicGenome(
+        openings=openings,
+        build_targets=targets,
+        economy=EconomyPlan(
+            buy_gold=rng.random() >= 0.1,
+            silver_cap=rng.randint(3, 6) if rng.random() < 0.35 else None,
+            silver_through_turn=rng.randint(7, 13) if rng.random() < 0.25 else None,
+            gold_cap=rng.randint(2, 6) if rng.random() < 0.15 else None,
+        ),
+        greening=GreeningPlan(
+            province_mode=province_mode,
+            province_threshold=rng.randint(4, 8),
+            duchy_mode=duchy_mode,
+            duchy_threshold=rng.randint(3, 6),
+            estate_mode="threshold" if rng.random() < 0.4 else "never",
+            estate_threshold=rng.randint(1, 3),
+        ),
+        endgame=EndgamePlan(
+            estate_pileout=rng.random() < 0.12,
+            pileout_max_remaining=1,
+            pileout_min_score_diff=rng.choice([-3, 0, 3]),
+        ),
+        action_order=_default_action_order(info, rng),
+        treasure_order=treasures,
+    )
+
+
+def random_strategic_strategy(info, rng=_random_module) -> BaseStrategy:
+    strategy = BaseStrategy()
+    return random_strategic_genome(info, rng).compile_into(strategy, info)
+
+
+def mutate_strategic_strategy(strategy: BaseStrategy, info, rate: float, rng=_random_module) -> bool:
+    """Apply semantic edits and recompile. Return False for legacy phenotypes."""
+
+    genome = getattr(strategy, "_strategic_genome", None)
+    if genome is None:
+        return False
+    genome = deepcopy(genome)
+
+    if rng.random() < rate:
+        modes = ["never", "threshold", "always"]
+        genome.greening.duchy_mode = rng.choice(modes)
+    if rng.random() < rate:
+        genome.greening.duchy_threshold = rng.randint(2, 8)
+    if rng.random() < rate * 0.5:
+        genome.greening.province_mode = rng.choice(["always", "threshold"])
+        genome.greening.province_threshold = rng.randint(3, 8)
+    if rng.random() < rate * 0.5:
+        genome.greening.estate_mode = rng.choice(["never", "threshold"])
+        genome.greening.estate_threshold = rng.randint(1, 5)
+    if rng.random() < rate * 0.5:
+        genome.endgame.estate_pileout = not genome.endgame.estate_pileout
+        genome.endgame.pileout_min_score_diff = rng.choice([-6, -3, 0, 3, 6])
+
+    if rng.random() < rate and genome.build_targets:
+        target = rng.choice(genome.build_targets)
+        target.copies = max(1, min(10, target.copies + rng.choice([-1, 1])))
+    if rng.random() < rate * 0.5 and genome.build_targets:
+        target = rng.choice(genome.build_targets)
+        target.priority_band = rng.choice(
+            ["before_province", "before_duchy", "build"]
+        )
+    if rng.random() < rate and len(genome.build_targets) >= 2:
+        i = rng.randint(0, len(genome.build_targets) - 2)
+        genome.build_targets[i], genome.build_targets[i + 1] = (
+            genome.build_targets[i + 1], genome.build_targets[i]
+        )
+    if rng.random() < rate * 0.4:
+        existing = {target.card for target in genome.build_targets}
+        missing = [card for card in info.gainable if card not in existing]
+        if missing:
+            card = rng.choice(missing)
+            genome.build_targets.append(BuildTarget(card, info.default_cap(card, rng)))
+    if rng.random() < rate * 0.25 and len(genome.build_targets) > 2:
+        genome.build_targets.pop(rng.randrange(len(genome.build_targets)))
+
+    if rng.random() < rate * 0.35:
+        if genome.openings and rng.random() < 0.5:
+            opening = rng.choice(genome.openings)
+            opening.through_turn = rng.randint(2, 5)
+            opening.copies = rng.randint(1, 2)
+        else:
+            candidates = [
+                card for card in info.gainable
+                if all(opening.card != card for opening in genome.openings)
+            ]
+            if candidates:
+                genome.openings.append(OpeningTarget(rng.choice(candidates), 1, rng.randint(2, 4)))
+    if rng.random() < rate * 0.15 and genome.openings:
+        genome.openings.pop(rng.randrange(len(genome.openings)))
+
+    if rng.random() < rate and len(genome.action_order) >= 2:
+        i = rng.randint(0, len(genome.action_order) - 2)
+        genome.action_order[i], genome.action_order[i + 1] = (
+            genome.action_order[i + 1], genome.action_order[i]
+        )
+    if rng.random() < rate * 0.5:
+        genome.economy.silver_cap = rng.choice([None, 2, 3, 4, 5, 6])
+    if rng.random() < rate * 0.25:
+        genome.economy.buy_gold = not genome.economy.buy_gold
+    if rng.random() < rate * 0.5:
+        genome.trash.estate_until_provinces = rng.choice([None, 3, 4, 5, 6])
+
+    way_policy = deepcopy(getattr(strategy, "way_policy", []))
+    name = strategy.name
+    genome.compile_into(strategy, info)
+    strategy.name = name
+    strategy.way_policy = way_policy
+    return True
+
+
+def crossover_strategic_strategies(parent1: BaseStrategy, parent2: BaseStrategy, info, rng=_random_module) -> BaseStrategy | None:
+    """Combine whole strategic modules, avoiding positional rule crossover."""
+
+    first = getattr(parent1, "_strategic_genome", None)
+    second = getattr(parent2, "_strategic_genome", None)
+    if first is None or second is None:
+        return None
+
+    child_genome = deepcopy(first)
+    for field_name in (
+        "openings", "build_targets", "economy", "greening", "endgame",
+        "trash", "action_order", "treasure_order",
+    ):
+        if rng.random() < 0.5:
+            setattr(child_genome, field_name, deepcopy(getattr(second, field_name)))
+
+    child = deepcopy(parent1)
+    child_genome.compile_into(child, info)
+    if rng.random() < 0.5:
+        child.way_policy = deepcopy(getattr(parent2, "way_policy", []))
+    return child

--- a/dominion/simulation/strategic_genome.py
+++ b/dominion/simulation/strategic_genome.py
@@ -321,6 +321,9 @@ def synchronize_strategic_genome(strategy: BaseStrategy, info) -> bool:
         genome.endgame.estate_pileout = False
     genome.economy.buy_gold = any(card == "Gold" for card, _ in gain_signatures)
     genome.economy.buy_silver = any(card == "Silver" for card, _ in gain_signatures)
+    genome.economy.prefer_platinum = any(
+        card == "Platinum" for card, _ in gain_signatures
+    )
 
     genome.action_order = [card for card in action_names if card in genome.action_order]
     genome.treasure_order = [card for card in treasure_names if card in genome.treasure_order]

--- a/dominion/simulation/strategic_genome.py
+++ b/dominion/simulation/strategic_genome.py
@@ -307,22 +307,76 @@ def synchronize_strategic_genome(strategy: BaseStrategy, info) -> bool:
             kept_targets.append(target)
     genome.build_targets = kept_targets
 
-    if not any(card == "Duchy" for card, _condition in gain_signatures):
+    def compiled_rule_survives(probe_genome: StrategicGenome, card: str) -> bool:
+        """Whether this isolated module's exact compiled rule survived."""
+        probe = probe_genome.compile_into(BaseStrategy(), info)
+        return any(
+            _rule_signature(rule) in gain_signatures
+            for rule in probe.gain_priority
+            if rule.card_name == card
+        )
+
+    duchy_probe = StrategicGenome(
+        greening=GreeningPlan(
+            duchy_mode=genome.greening.duchy_mode,
+            duchy_threshold=genome.greening.duchy_threshold,
+            estate_mode="never",
+        ),
+        economy=EconomyPlan(buy_gold=False, buy_silver=False),
+    )
+    if not compiled_rule_survives(duchy_probe, "Duchy"):
         genome.greening.duchy_mode = "never"
-    if not any(
-        card == "Estate" and "empty_piles" not in (condition or "")
-        for card, condition in gain_signatures
-    ):
+
+    estate_probe = StrategicGenome(
+        greening=GreeningPlan(
+            duchy_mode="never",
+            estate_mode=genome.greening.estate_mode,
+            estate_threshold=genome.greening.estate_threshold,
+        ),
+        economy=EconomyPlan(buy_gold=False, buy_silver=False),
+    )
+    if not compiled_rule_survives(estate_probe, "Estate"):
         genome.greening.estate_mode = "never"
-    if not any(
-        card == "Estate" and "empty_piles" in (condition or "")
-        for card, condition in gain_signatures
-    ):
+
+    endgame_probe = StrategicGenome(
+        greening=GreeningPlan(duchy_mode="never", estate_mode="never"),
+        endgame=deepcopy(genome.endgame),
+        economy=EconomyPlan(buy_gold=False, buy_silver=False),
+    )
+    if not compiled_rule_survives(endgame_probe, "Estate"):
         genome.endgame.estate_pileout = False
-    genome.economy.buy_gold = any(card == "Gold" for card, _ in gain_signatures)
-    genome.economy.buy_silver = any(card == "Silver" for card, _ in gain_signatures)
-    genome.economy.prefer_platinum = any(
-        card == "Platinum" for card, _ in gain_signatures
+
+    gold_probe = StrategicGenome(
+        greening=GreeningPlan(duchy_mode="never"),
+        economy=EconomyPlan(
+            buy_gold=genome.economy.buy_gold,
+            buy_silver=False,
+            gold_cap=genome.economy.gold_cap,
+            prefer_platinum=False,
+        ),
+    )
+    genome.economy.buy_gold = compiled_rule_survives(gold_probe, "Gold")
+    silver_probe = StrategicGenome(
+        greening=GreeningPlan(duchy_mode="never"),
+        economy=EconomyPlan(
+            buy_gold=False,
+            buy_silver=genome.economy.buy_silver,
+            silver_cap=genome.economy.silver_cap,
+            silver_through_turn=genome.economy.silver_through_turn,
+            prefer_platinum=False,
+        ),
+    )
+    genome.economy.buy_silver = compiled_rule_survives(silver_probe, "Silver")
+    platinum_probe = StrategicGenome(
+        greening=GreeningPlan(duchy_mode="never"),
+        economy=EconomyPlan(
+            buy_gold=False,
+            buy_silver=False,
+            prefer_platinum=genome.economy.prefer_platinum,
+        ),
+    )
+    genome.economy.prefer_platinum = compiled_rule_survives(
+        platinum_probe, "Platinum"
     )
 
     genome.action_order = [card for card in action_names if card in genome.action_order]

--- a/dominion/simulation/structured_genome.py
+++ b/dominion/simulation/structured_genome.py
@@ -167,65 +167,15 @@ def _gate_for(card: str, info: KingdomInfo, rng):
 
 
 def random_menu_strategy(info: KingdomInfo, rng=_random_module) -> BaseStrategy:
-    """Build a random but *coherent* strategy: greening block on top, an
-    economy backbone, and a few capped kingdom picks ordered roughly by cost."""
-    strategy = BaseStrategy()
+    """Build a coherent strategy from the typed strategic genome.
 
-    gain: list[PriorityRule] = []
-    if info.has_colony:
-        gain.append(PriorityRule("Colony"))
-    gain.append(PriorityRule("Province"))
-    if rng.random() < 0.9:
-        gain.append(PriorityRule("Duchy", _greening_gate("Duchy", rng)))
-    if rng.random() < 0.4:
-        gain.append(PriorityRule("Estate", _greening_gate("Estate", rng)))
+    The public function name is retained for compatibility with callers and
+    tests; new random individuals now carry semantic phase blocks in
+    ``_strategic_genome`` in addition to their compiled priority lists.
+    """
+    from dominion.simulation.strategic_genome import random_strategic_strategy
 
-    picks: list[str] = []
-    if info.gainable:
-        hi = min(6, len(info.gainable))
-        n_picks = rng.randint(min(2, hi), hi)
-        picks = rng.sample(info.gainable, n_picks)
-
-    # Merge picks with the treasure backbone, ordered by cost with jitter so
-    # adjacent-cost cards can swap order between individuals.
-    entries: list[tuple[float, PriorityRule]] = [
-        (info.costs.get(card, 0) + rng.uniform(-1.5, 1.5), PriorityRule(card, _pick_gate(card, info, rng)))
-        for card in picks
-    ]
-    if info.has_platinum:
-        entries.append((9 + rng.uniform(-1.5, 1.5), PriorityRule("Platinum")))
-    entries.append((6 + rng.uniform(-1.5, 1.5), PriorityRule("Gold")))
-    entries.append((3 + rng.uniform(-1.5, 1.5), PriorityRule("Silver", _silver_gate(rng))))
-    entries.sort(key=lambda pair: pair[0], reverse=True)
-    gain.extend(rule for _, rule in entries)
-    strategy.gain_priority = gain
-
-    # Action play order: villages first, then cantrips, then terminal draw,
-    # then remaining terminals. Within each role group the order is shuffled.
-    action: list[PriorityRule] = []
-    for group in (info.villages, info.cantrips, info.terminal_draw, info.other_terminals):
-        group = list(group)
-        rng.shuffle(group)
-        action.extend(PriorityRule(card) for card in group)
-    strategy.action_priority = action
-
-    # Treasures: Platinum, Gold, kingdom treasures (cost order), Silver, Copper.
-    kingdom_treasures = sorted(info.treasure_cards, key=lambda c: -info.costs.get(c, 0))
-    strategy.treasure_priority = (
-        ([PriorityRule("Platinum")] if info.has_platinum else [])
-        + [PriorityRule("Gold")]
-        + [PriorityRule(c) for c in kingdom_treasures]
-        + [PriorityRule("Silver"), PriorityRule("Copper")]
-    )
-
-    strategy.trash_priority = [
-        PriorityRule("Curse"),
-        PriorityRule("Estate", PriorityRule.provinces_left(">", rng.randint(2, 6))),
-        PriorityRule("Copper", PriorityRule.has_cards(["Silver", "Gold"], rng.randint(2, 4))),
-    ]
-
-    strategy.way_policy = []
-    return strategy
+    return random_strategic_strategy(info, rng)
 
 
 # ---------------------------------------------------------------------------
@@ -253,6 +203,11 @@ def _adjust_cap(rule: PriorityRule, rng) -> bool:
 
 def mutate_menu(strategy: BaseStrategy, info: KingdomInfo, rate: float, rng=_random_module) -> BaseStrategy:
     """Apply menu-edit mutations in place and return the strategy."""
+    from dominion.simulation.strategic_genome import mutate_strategic_strategy
+
+    if mutate_strategic_strategy(strategy, info, rate, rng):
+        return strategy
+
     gain = strategy.gain_priority
 
     # Reorder: swap adjacent entries.

--- a/dominion/strategy/enhanced_strategy.py
+++ b/dominion/strategy/enhanced_strategy.py
@@ -228,8 +228,8 @@ class PriorityRule:
         Estate only when it is the final card in the third pile.
         """
         cmp = PriorityRule._OP_MAP[op]
-        fn = lambda s, _me, _card=card_name, _amount=amount, _cmp=cmp: _cmp(
-            s.supply.get(_card, 0), _amount
+        fn = lambda s, _me, _card=card_name, _amount=amount, _cmp=cmp: (
+            _card in s.supply and _cmp(s.supply[_card], _amount)
         )
         return PriorityRule._tag_source(
             fn,

--- a/dominion/strategy/enhanced_strategy.py
+++ b/dominion/strategy/enhanced_strategy.py
@@ -220,6 +220,23 @@ class PriorityRule:
         return PriorityRule._tag_source(fn, f"PriorityRule.empty_piles({op!r}, {amount!r})")
 
     @staticmethod
+    def pile_count(card_name: str, op: str, amount: int) -> Callable[["GameState", "PlayerState"], bool]:
+        """True when a named Supply pile's remaining count matches ``op``.
+
+        Unlike ``provinces_left`` this is usable for any pile, which makes
+        explicit pile-control policies representable: for example, buy an
+        Estate only when it is the final card in the third pile.
+        """
+        cmp = PriorityRule._OP_MAP[op]
+        fn = lambda s, _me, _card=card_name, _amount=amount, _cmp=cmp: _cmp(
+            s.supply.get(_card, 0), _amount
+        )
+        return PriorityRule._tag_source(
+            fn,
+            f"PriorityRule.pile_count({card_name!r}, {op!r}, {amount!r})",
+        )
+
+    @staticmethod
     def deck_size(op: str, amount: int) -> Callable[["GameState", "PlayerState"], bool]:
         """True when the player's total deck size (all zones) satisfies the comparison."""
         cmp = PriorityRule._OP_MAP[op]

--- a/tests/test_structured_genome.py
+++ b/tests/test_structured_genome.py
@@ -299,6 +299,36 @@ class TestStrategicGenomeRepresentability:
         )
         assert all(rule.card_name != "Smithy" for rule in child.gain_priority)
 
+    def test_pruned_platinum_is_not_resurrected_by_semantic_crossover(self):
+        from dominion.strategy.rule_pruning import prune_unfired_rules
+
+        parent = StrategicGenome(
+            greening=GreeningPlan(duchy_mode="never"),
+            economy=EconomyPlan(prefer_platinum=True),
+            treasure_order=["Platinum", "Gold", "Silver", "Copper"],
+        ).compile_into(BaseStrategy(), _colony_info())
+        for rules in (
+            parent.gain_priority,
+            parent.action_priority,
+            parent.treasure_priority,
+            parent.trash_priority,
+        ):
+            for rule in rules:
+                rule._fired = not (
+                    rule.card_name == "Platinum"
+                    and rules is parent.gain_priority
+                )
+
+        prune_unfired_rules(parent, min_rules=0)
+        synchronize_strategic_genome(parent, _colony_info())
+        child = crossover_strategic_strategies(
+            parent, parent, _colony_info()
+        )
+
+        assert child is not None
+        assert child._strategic_genome.economy.prefer_platinum is False
+        assert all(rule.card_name != "Platinum" for rule in child.gain_priority)
+
 
 class TestMutateMenu:
     def test_invariants_survive_heavy_mutation(self):

--- a/tests/test_structured_genome.py
+++ b/tests/test_structured_genome.py
@@ -29,6 +29,7 @@ from dominion.simulation.strategic_genome import (
     StrategicGenome,
     crossover_strategic_strategies,
     mutate_strategic_strategy,
+    synchronize_strategic_genome,
 )
 from dominion.strategy.enhanced_strategy import PriorityRule
 from dominion.strategy.strategies.base_strategy import BaseStrategy
@@ -267,6 +268,36 @@ class TestStrategicGenomeRepresentability:
         assert child is not None
         assert hasattr(child, "_strategic_genome")
         assert any(rule.card_name == "Province" for rule in child.gain_priority)
+
+    def test_pruned_target_is_not_resurrected_by_semantic_crossover(self):
+        from dominion.strategy.rule_pruning import prune_unfired_rules
+
+        genome = StrategicGenome(
+            build_targets=[BuildTarget("Smithy", 2)],
+            greening=GreeningPlan(duchy_mode="never"),
+            action_order=["Smithy"],
+            treasure_order=["Gold", "Silver", "Copper"],
+        )
+        parent = genome.compile_into(BaseStrategy(), _info())
+        for rules in (
+            parent.gain_priority,
+            parent.action_priority,
+            parent.treasure_priority,
+            parent.trash_priority,
+        ):
+            for rule in rules:
+                rule._fired = rule.card_name != "Smithy"
+
+        prune_unfired_rules(parent, min_rules=0)
+        synchronize_strategic_genome(parent, _info())
+        child = crossover_strategic_strategies(parent, parent, _info())
+
+        assert child is not None
+        assert all(
+            target.card != "Smithy"
+            for target in child._strategic_genome.build_targets
+        )
+        assert all(rule.card_name != "Smithy" for rule in child.gain_priority)
 
 
 class TestMutateMenu:

--- a/tests/test_structured_genome.py
+++ b/tests/test_structured_genome.py
@@ -20,6 +20,16 @@ from dominion.simulation.structured_genome import (
     normalize_menu,
     random_menu_strategy,
 )
+from dominion.simulation.strategic_genome import (
+    BuildTarget,
+    EconomyPlan,
+    EndgamePlan,
+    GreeningPlan,
+    OpeningTarget,
+    StrategicGenome,
+    crossover_strategic_strategies,
+    mutate_strategic_strategy,
+)
 from dominion.strategy.enhanced_strategy import PriorityRule
 from dominion.strategy.strategies.base_strategy import BaseStrategy
 
@@ -98,10 +108,13 @@ class TestRandomMenuStrategy:
         for _ in range(30):
             s = random_menu_strategy(info)
             names = [r.card_name for r in s.gain_priority]
-            # Province exists and leads the menu.
-            assert names[0] == "Province"
-            # The economy backbone is present.
-            assert "Gold" in names and "Silver" in names
+            # Province exists near the front; explicit opening/endgame rules
+            # are allowed to precede it in the phase-aware genome.
+            assert "Province" in names
+            assert names.index("Province") <= 3
+            # Silver remains the fallback economy. Gold may be deliberately
+            # omitted for rushes such as Rebuild/Duchy.
+            assert "Silver" in names
             # No junk buys.
             assert "Copper" not in names and "Curse" not in names
             # Picks are kingdom cards.
@@ -153,12 +166,15 @@ class TestRandomMenuStrategy:
         for _ in range(30):
             s = random_menu_strategy(info)
             names = [r.card_name for r in s.gain_priority]
-            # Colony leads the greening block, unconditionally; Province follows.
-            assert names[0] == "Colony"
-            assert s.gain_priority[0].condition is None
+            # Colony leads the normal greening block. Explicit opening/endgame
+            # rules may precede it, but Colony itself remains unconditional.
+            colony_rule = next(rule for rule in s.gain_priority if rule.card_name == "Colony")
+            assert colony_rule.condition is None
             assert "Province" in names
-            # Platinum joins the backbone above Gold, never as a capped pick.
-            assert names.index("Platinum") < names.index("Gold")
+            # Platinum joins the backbone and is never a capped pick. Gold may
+            # be deliberately omitted by a typed rush plan.
+            if "Gold" in names:
+                assert names.index("Platinum") < names.index("Gold")
             for rule in s.gain_priority:
                 if rule.card_name in ("Colony", "Platinum"):
                     source = getattr(rule.condition, "_source", "") if rule.condition else ""
@@ -166,6 +182,91 @@ class TestRandomMenuStrategy:
             # Platinum is played before Gold.
             treasures = [r.card_name for r in s.treasure_priority]
             assert treasures.index("Platinum") < treasures.index("Gold")
+
+
+class TestStrategicGenomeRepresentability:
+    def test_exact_early_single_card_opening_is_one_semantic_block(self):
+        genome = StrategicGenome(
+            openings=[OpeningTarget("Chapel", copies=1, through_turn=2)],
+            greening=GreeningPlan(duchy_mode="never"),
+            action_order=["Chapel"],
+            treasure_order=["Gold", "Silver", "Copper"],
+        )
+        strategy = genome.compile_into(BaseStrategy(), _info())
+
+        chapel = strategy.gain_priority[0]
+        assert chapel.card_name == "Chapel"
+        source = chapel.condition._source
+        assert "max_in_deck('Chapel', 1)" in source
+        assert "turn_number('<=', 2)" in source
+
+    def test_rebuild_rush_is_representable_without_custom_hooks(self):
+        info = KingdomInfo.from_kingdom(["Rebuild", "Cellar", "Moat"])
+        genome = StrategicGenome(
+            build_targets=[
+                BuildTarget(
+                    "Rebuild", copies=2, priority_band="before_duchy"
+                )
+            ],
+            economy=EconomyPlan(buy_gold=False, buy_silver=True),
+            greening=GreeningPlan(
+                province_mode="always",
+                duchy_mode="always",
+                estate_mode="threshold",
+                estate_threshold=2,
+            ),
+            action_order=["Rebuild"],
+            treasure_order=["Gold", "Silver", "Copper"],
+        )
+        strategy = genome.compile_into(BaseStrategy(), info)
+
+        assert [rule.card_name for rule in strategy.gain_priority] == [
+            "Province", "Rebuild", "Duchy", "Estate", "Silver"
+        ]
+        assert "max_in_deck('Rebuild', 2)" in strategy.gain_priority[1].condition._source
+
+    def test_pileout_policy_can_override_normal_province_buy(self):
+        genome = StrategicGenome(
+            greening=GreeningPlan(duchy_mode="never"),
+            endgame=EndgamePlan(
+                estate_pileout=True,
+                pileout_max_remaining=1,
+                pileout_min_score_diff=0,
+            ),
+            treasure_order=["Gold", "Silver", "Copper"],
+        )
+        strategy = genome.compile_into(BaseStrategy(), _info())
+        estate = strategy.gain_priority[0]
+        assert estate.card_name == "Estate"
+
+        state = _mock_state()
+        state.empty_piles = 2
+        state.supply["Estate"] = 1
+        player = _mock_player()
+        state.players = [player]
+        assert estate.condition(state, player) is True
+
+        state.supply["Estate"] = 2
+        assert estate.condition(state, player) is False
+
+    def test_semantic_mutation_recompiles_from_typed_genome(self):
+        random.seed(41)
+        strategy = random_menu_strategy(_info())
+        assert hasattr(strategy, "_strategic_genome")
+
+        assert mutate_strategic_strategy(strategy, _info(), rate=1.0) is True
+        assert strategy._strategic_genome is not None
+        assert any(rule.card_name == "Province" for rule in strategy.gain_priority)
+
+    def test_crossover_swaps_whole_modules(self):
+        random.seed(42)
+        first = random_menu_strategy(_info())
+        second = random_menu_strategy(_info())
+        child = crossover_strategic_strategies(first, second, _info())
+
+        assert child is not None
+        assert hasattr(child, "_strategic_genome")
+        assert any(rule.card_name == "Province" for rule in child.gain_priority)
 
 
 class TestMutateMenu:
@@ -1012,7 +1113,9 @@ class TestTrainerIntegration:
         random.seed(11)
         s = trainer.create_random_strategy()
         names = [r.card_name for r in s.gain_priority]
-        assert names[0] == "Province"
+        assert "Province" in names
+        assert names.index("Province") <= 3
+        assert hasattr(s, "_strategic_genome")
         assert "Copper" not in names
 
     def test_legacy_flag_restores_freeform_init(self):
@@ -1028,6 +1131,19 @@ class TestTrainerIntegration:
             for _ in range(20)
         )
         assert seen_copper
+
+    def test_mixed_parent_crossover_drops_stale_typed_metadata(self):
+        trainer = GeneticTrainer(KINGDOM, population_size=1, generations=1)
+        typed = trainer.create_random_strategy()
+        legacy = BaseStrategy()
+        legacy.gain_priority = [PriorityRule("Province"), PriorityRule("Gold")]
+        legacy.treasure_priority = [
+            PriorityRule("Gold"), PriorityRule("Silver"), PriorityRule("Copper")
+        ]
+
+        child = trainer._crossover(typed, legacy)
+
+        assert not hasattr(child, "_strategic_genome")
 
     def test_structured_mutation_preserves_invariants(self):
         trainer = GeneticTrainer(KINGDOM, population_size=1, generations=1, mutation_rate=1.0)

--- a/tests/test_structured_genome.py
+++ b/tests/test_structured_genome.py
@@ -70,6 +70,22 @@ def _mock_player():
     return player
 
 
+class _DeterministicRng:
+    """Small RNG stub for asserting exact semantic operator outcomes."""
+
+    def random(self):
+        return 0.0
+
+    def choice(self, values):
+        return values[-1]
+
+    def randint(self, _low, high):
+        return high
+
+    def randrange(self, _stop):
+        return 0
+
+
 class TestKingdomInfo:
     def test_role_classification(self):
         info = _info()
@@ -242,32 +258,57 @@ class TestStrategicGenomeRepresentability:
 
         state = _mock_state()
         state.empty_piles = 2
-        state.supply["Estate"] = 1
         player = _mock_player()
         state.players = [player]
+
+        assert estate.condition(state, player) is False
+        state.supply["Estate"] = 1
         assert estate.condition(state, player) is True
 
         state.supply["Estate"] = 2
         assert estate.condition(state, player) is False
 
     def test_semantic_mutation_recompiles_from_typed_genome(self):
-        random.seed(41)
-        strategy = random_menu_strategy(_info())
-        assert hasattr(strategy, "_strategic_genome")
+        strategy = StrategicGenome(
+            build_targets=[BuildTarget("Smithy", 2)],
+            economy=EconomyPlan(buy_gold=True),
+            action_order=["Smithy"],
+            treasure_order=["Gold", "Silver", "Copper"],
+        ).compile_into(BaseStrategy(), _info())
 
-        assert mutate_strategic_strategy(strategy, _info(), rate=1.0) is True
-        assert strategy._strategic_genome is not None
-        assert any(rule.card_name == "Province" for rule in strategy.gain_priority)
+        assert mutate_strategic_strategy(
+            strategy, _info(), rate=1.0, rng=_DeterministicRng()
+        ) is True
+        assert strategy._strategic_genome.economy.buy_gold is False
+        assert strategy._strategic_genome.build_targets[0].copies == 3
+        assert all(rule.card_name != "Gold" for rule in strategy.gain_priority)
+        smithy = next(
+            rule for rule in strategy.gain_priority if rule.card_name == "Smithy"
+        )
+        assert "max_in_deck('Smithy', 3)" in smithy.condition._source
 
     def test_crossover_swaps_whole_modules(self):
-        random.seed(42)
-        first = random_menu_strategy(_info())
-        second = random_menu_strategy(_info())
-        child = crossover_strategic_strategies(first, second, _info())
+        first = StrategicGenome(
+            build_targets=[BuildTarget("Smithy", 2)],
+            action_order=["Smithy"],
+            treasure_order=["Gold", "Silver", "Copper"],
+        ).compile_into(BaseStrategy(), _info())
+        second = StrategicGenome(
+            build_targets=[BuildTarget("Witch", 1)],
+            action_order=["Witch"],
+            treasure_order=["Gold", "Silver", "Copper"],
+        ).compile_into(BaseStrategy(), _info())
+        child = crossover_strategic_strategies(
+            first, second, _info(), rng=_DeterministicRng()
+        )
 
         assert child is not None
-        assert hasattr(child, "_strategic_genome")
-        assert any(rule.card_name == "Province" for rule in child.gain_priority)
+        assert [
+            target.card for target in child._strategic_genome.build_targets
+        ] == ["Witch"]
+        assert child._strategic_genome.action_order == ["Witch"]
+        assert any(rule.card_name == "Witch" for rule in child.gain_priority)
+        assert all(rule.card_name != "Smithy" for rule in child.gain_priority)
 
     def test_pruned_target_is_not_resurrected_by_semantic_crossover(self):
         from dominion.strategy.rule_pruning import prune_unfired_rules
@@ -328,6 +369,38 @@ class TestStrategicGenomeRepresentability:
         assert child is not None
         assert child._strategic_genome.economy.prefer_platinum is False
         assert all(rule.card_name != "Platinum" for rule in child.gain_priority)
+
+    def test_surviving_pileout_does_not_mask_pruned_estate_greening(self):
+        genome = StrategicGenome(
+            greening=GreeningPlan(
+                duchy_mode="never", estate_mode="threshold", estate_threshold=2
+            ),
+            endgame=EndgamePlan(estate_pileout=True),
+            treasure_order=["Gold", "Silver", "Copper"],
+        )
+        parent = genome.compile_into(BaseStrategy(), _info())
+        parent.gain_priority = [
+            rule
+            for rule in parent.gain_priority
+            if not (
+                rule.card_name == "Estate"
+                and "provinces_left" in getattr(rule.condition, "_source", "")
+            )
+        ]
+
+        synchronize_strategic_genome(parent, _info())
+        child = crossover_strategic_strategies(parent, parent, _info())
+
+        assert child is not None
+        assert child._strategic_genome.greening.estate_mode == "never"
+        assert child._strategic_genome.endgame.estate_pileout is True
+        estate_sources = [
+            getattr(rule.condition, "_source", "")
+            for rule in child.gain_priority
+            if rule.card_name == "Estate"
+        ]
+        assert len(estate_sources) == 1
+        assert "empty_piles" in estate_sources[0]
 
 
 class TestMutateMenu:


### PR DESCRIPTION
## Summary
Introduces a typed, phase-aware strategy genome covering openings, build targets, economy, greening, trashing, action order, and score-aware pile endings. Semantic mutation and crossover now exchange complete strategy modules while preserving compatibility with hand-written and previously generated strategies. Adds general Supply-pile conditions, representability coverage for Chapel, Rebuild, and pile-out plans, and documents the search architecture and calibration standard.

## Validation
- `pytest -q` — 1,831 passed
- `git diff --check origin/main...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added phase-aware strategic planning for openings, builds, economy, trashing, greening, and endgame decisions.
  * Improved strategy evolution with semantic mutation and crossover of strategic plans.
  * Added supply-pile count conditions for more precise strategy rules.
  * Added synchronization to keep evolved plans aligned with their compiled strategies.

* **Documentation**
  * Expanded calibration guidance, results interpretation, and strategy-search architecture documentation.

* **Tests**
  * Added coverage for strategic plan compilation, mutation, crossover, ordering, and metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->