### PR TITLE
Add strategy HTML report pages

### DIFF
--- a/dominion/reporting/html_report.py
+++ b/dominion/reporting/html_report.py
@@ -35,9 +35,19 @@ def _strategy_loader_for_links() -> StrategyLoader:
     return StrategyLoader()
 
 
-def _strategy_report_href(name: str, *, prefix: str) -> str:
-    display_name = _strategy_loader_for_links().get_display_name(name) or name
+def _strategy_report_href(name: str, *, prefix: str) -> str | None:
+    display_name = _strategy_loader_for_links().get_display_name(name)
+    if display_name is None:
+        return None
     return strategy_page_href(display_name, prefix=prefix)
+
+
+def _strategy_anchor(name: str, *, prefix: str) -> str:
+    label = escape(name)
+    href = _strategy_report_href(name, prefix=prefix)
+    if href is None:
+        return label
+    return f'<a href="{escape(href)}">{label}</a>'
 
 
 def _decision_firings_section(results: dict, *, strategy_link_prefix: str = "strategies") -> str:
@@ -49,8 +59,7 @@ def _decision_firings_section(results: dict, *, strategy_link_prefix: str = "str
     for role in ("strategy1", "strategy2"):
         stats = decision_firings.get(role) or {}
         raw_strategy_name = str(stats.get("strategy_name", role))
-        strategy_name = escape(raw_strategy_name)
-        strategy_link = escape(_strategy_report_href(raw_strategy_name, prefix=strategy_link_prefix))
+        strategy_name = _strategy_anchor(raw_strategy_name, prefix=strategy_link_prefix)
         rows = []
 
         for list_name, firings in sorted((stats.get("priority_rules") or {}).items()):
@@ -100,7 +109,7 @@ def _decision_firings_section(results: dict, *, strategy_link_prefix: str = "str
         total_gain_overrides = gain_stats.get("total", 0)
         sections.append(
             f"""
-            <h3><a href="{strategy_link}">{strategy_name}</a></h3>
+            <h3>{strategy_name}</h3>
             <p>choose_gain special cases: {total_gain_overrides}</p>
             <table>
                 <tr><th>Decision</th><th>Card / Baseline</th><th>Selected</th><th>Count</th></tr>
@@ -205,10 +214,8 @@ def generate_html_report(results: dict, output_path: Path, *, verbose: bool = Fa
 
     title = f"{strat1} vs {strat2}"
     strategy_link_prefix = _strategy_link_prefix(output_path)
-    strat1_link = escape(_strategy_report_href(strat1, prefix=strategy_link_prefix))
-    strat2_link = escape(_strategy_report_href(strat2, prefix=strategy_link_prefix))
-    strat1_label = escape(strat1)
-    strat2_label = escape(strat2)
+    strat1_label = _strategy_anchor(strat1, prefix=strategy_link_prefix)
+    strat2_label = _strategy_anchor(strat2, prefix=strategy_link_prefix)
     decision_firings_section = _decision_firings_section(
         results,
         strategy_link_prefix=strategy_link_prefix,
@@ -229,7 +236,7 @@ def generate_html_report(results: dict, output_path: Path, *, verbose: bool = Fa
         </style>
     </head>
     <body>
-    <h1><a href="{strat1_link}">{strat1_label}</a> vs <a href="{strat2_link}">{strat2_label}</a> Comparison</h1>
+    <h1>{strat1_label} vs {strat2_label} Comparison</h1>
     <p>Games played: {results['games_played']}</p>
     <p>Confidence the win-rate difference is real: {confidence:.1%} (p={win_p:.4f})</p>
     <h2>Win Counts</h2>
@@ -427,10 +434,9 @@ def generate_leaderboard_html(
         cards = stats.get("cards", [])
         cards_str = escape(", ".join(cards)) if cards else "-"
         desc = escape(str(stats.get("description", "")))
-        name_label = escape(name)
-        strategy_link = escape(_strategy_report_href(name, prefix=strategy_link_prefix))
+        name_label = _strategy_anchor(name, prefix=strategy_link_prefix)
         rows += (
-            f"<tr><td>{rank}</td><td><a href=\"{strategy_link}\">{name_label}</a></td><td class='desc'>{desc}</td>"
+            f"<tr><td>{rank}</td><td>{name_label}</td><td class='desc'>{desc}</td>"
             f"<td>{stats['wins']}</td>"
             f"<td>{stats['losses']}</td><td>{stats['win_rate']:.1f}%</td>"
             f"<td class='cards'>{cards_str}</td></tr>\n"

--- a/dominion/reporting/html_report.py
+++ b/dominion/reporting/html_report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from functools import lru_cache
 from html import escape
 import io
 import os
@@ -14,6 +15,7 @@ from matplotlib.ticker import MaxNLocator
 from scipy.stats import binomtest
 
 from dominion.reporting.strategy_links import strategy_page_href
+from dominion.strategy.strategy_loader import StrategyLoader
 
 
 def fig_to_base64(fig: plt.Figure) -> str:
@@ -28,6 +30,16 @@ def _strategy_link_prefix(output_path: Path) -> str:
     return os.path.relpath(Path("reports") / "strategies", output_path.parent)
 
 
+@lru_cache(maxsize=1)
+def _strategy_loader_for_links() -> StrategyLoader:
+    return StrategyLoader()
+
+
+def _strategy_report_href(name: str, *, prefix: str) -> str:
+    display_name = _strategy_loader_for_links().get_display_name(name) or name
+    return strategy_page_href(display_name, prefix=prefix)
+
+
 def _decision_firings_section(results: dict, *, strategy_link_prefix: str = "strategies") -> str:
     decision_firings = results.get("decision_firings") or {}
     if not decision_firings:
@@ -38,7 +50,7 @@ def _decision_firings_section(results: dict, *, strategy_link_prefix: str = "str
         stats = decision_firings.get(role) or {}
         raw_strategy_name = str(stats.get("strategy_name", role))
         strategy_name = escape(raw_strategy_name)
-        strategy_link = escape(strategy_page_href(raw_strategy_name, prefix=strategy_link_prefix))
+        strategy_link = escape(_strategy_report_href(raw_strategy_name, prefix=strategy_link_prefix))
         rows = []
 
         for list_name, firings in sorted((stats.get("priority_rules") or {}).items()):
@@ -193,8 +205,8 @@ def generate_html_report(results: dict, output_path: Path, *, verbose: bool = Fa
 
     title = f"{strat1} vs {strat2}"
     strategy_link_prefix = _strategy_link_prefix(output_path)
-    strat1_link = escape(strategy_page_href(strat1, prefix=strategy_link_prefix))
-    strat2_link = escape(strategy_page_href(strat2, prefix=strategy_link_prefix))
+    strat1_link = escape(_strategy_report_href(strat1, prefix=strategy_link_prefix))
+    strat2_link = escape(_strategy_report_href(strat2, prefix=strategy_link_prefix))
     strat1_label = escape(strat1)
     strat2_label = escape(strat2)
     decision_firings_section = _decision_firings_section(
@@ -416,7 +428,7 @@ def generate_leaderboard_html(
         cards_str = escape(", ".join(cards)) if cards else "-"
         desc = escape(str(stats.get("description", "")))
         name_label = escape(name)
-        strategy_link = escape(strategy_page_href(name, prefix=strategy_link_prefix))
+        strategy_link = escape(_strategy_report_href(name, prefix=strategy_link_prefix))
         rows += (
             f"<tr><td>{rank}</td><td><a href=\"{strategy_link}\">{name_label}</a></td><td class='desc'>{desc}</td>"
             f"<td>{stats['wins']}</td>"

--- a/dominion/reporting/html_report.py
+++ b/dominion/reporting/html_report.py
@@ -13,6 +13,8 @@ import seaborn as sns
 from matplotlib.ticker import MaxNLocator
 from scipy.stats import binomtest
 
+from dominion.reporting.strategy_links import strategy_page_href
+
 
 def fig_to_base64(fig: plt.Figure) -> str:
     """Convert a matplotlib figure to a base64 encoded PNG."""
@@ -22,7 +24,11 @@ def fig_to_base64(fig: plt.Figure) -> str:
     return base64.b64encode(buf.read()).decode("ascii")
 
 
-def _decision_firings_section(results: dict) -> str:
+def _strategy_link_prefix(output_path: Path) -> str:
+    return os.path.relpath(Path("reports") / "strategies", output_path.parent)
+
+
+def _decision_firings_section(results: dict, *, strategy_link_prefix: str = "strategies") -> str:
     decision_firings = results.get("decision_firings") or {}
     if not decision_firings:
         return ""
@@ -30,7 +36,9 @@ def _decision_firings_section(results: dict) -> str:
     sections = []
     for role in ("strategy1", "strategy2"):
         stats = decision_firings.get(role) or {}
-        strategy_name = escape(str(stats.get("strategy_name", role)))
+        raw_strategy_name = str(stats.get("strategy_name", role))
+        strategy_name = escape(raw_strategy_name)
+        strategy_link = escape(strategy_page_href(raw_strategy_name, prefix=strategy_link_prefix))
         rows = []
 
         for list_name, firings in sorted((stats.get("priority_rules") or {}).items()):
@@ -80,7 +88,7 @@ def _decision_firings_section(results: dict) -> str:
         total_gain_overrides = gain_stats.get("total", 0)
         sections.append(
             f"""
-            <h3>{strategy_name}</h3>
+            <h3><a href="{strategy_link}">{strategy_name}</a></h3>
             <p>choose_gain special cases: {total_gain_overrides}</p>
             <table>
                 <tr><th>Decision</th><th>Card / Baseline</th><th>Selected</th><th>Count</th></tr>
@@ -184,7 +192,15 @@ def generate_html_report(results: dict, output_path: Path, *, verbose: bool = Fa
             log_items += f'<li>Game {game["game_number"]}: No log available</li>'
 
     title = f"{strat1} vs {strat2}"
-    decision_firings_section = _decision_firings_section(results)
+    strategy_link_prefix = _strategy_link_prefix(output_path)
+    strat1_link = escape(strategy_page_href(strat1, prefix=strategy_link_prefix))
+    strat2_link = escape(strategy_page_href(strat2, prefix=strategy_link_prefix))
+    strat1_label = escape(strat1)
+    strat2_label = escape(strat2)
+    decision_firings_section = _decision_firings_section(
+        results,
+        strategy_link_prefix=strategy_link_prefix,
+    )
 
     html = f"""
     <html>
@@ -201,7 +217,7 @@ def generate_html_report(results: dict, output_path: Path, *, verbose: bool = Fa
         </style>
     </head>
     <body>
-    <h1>{title} Comparison</h1>
+    <h1><a href="{strat1_link}">{strat1_label}</a> vs <a href="{strat2_link}">{strat2_label}</a> Comparison</h1>
     <p>Games played: {results['games_played']}</p>
     <p>Confidence the win-rate difference is real: {confidence:.1%} (p={win_p:.4f})</p>
     <h2>Win Counts</h2>
@@ -394,12 +410,15 @@ def generate_leaderboard_html(
     plt.close(fig)
 
     rows = ""
+    strategy_link_prefix = _strategy_link_prefix(output_path)
     for rank, (name, stats) in enumerate(sorted_items, 1):
         cards = stats.get("cards", [])
-        cards_str = ", ".join(cards) if cards else "-"
-        desc = stats.get("description", "")
+        cards_str = escape(", ".join(cards)) if cards else "-"
+        desc = escape(str(stats.get("description", "")))
+        name_label = escape(name)
+        strategy_link = escape(strategy_page_href(name, prefix=strategy_link_prefix))
         rows += (
-            f"<tr><td>{rank}</td><td>{name}</td><td class='desc'>{desc}</td>"
+            f"<tr><td>{rank}</td><td><a href=\"{strategy_link}\">{name_label}</a></td><td class='desc'>{desc}</td>"
             f"<td>{stats['wins']}</td>"
             f"<td>{stats['losses']}</td><td>{stats['win_rate']:.1f}%</td>"
             f"<td class='cards'>{cards_str}</td></tr>\n"

--- a/dominion/reporting/strategy_links.py
+++ b/dominion/reporting/strategy_links.py
@@ -1,0 +1,19 @@
+"""Shared links for generated strategy reports."""
+
+from __future__ import annotations
+
+import re
+
+
+def strategy_slug(name: str) -> str:
+    """Return a stable filename slug for a strategy display name."""
+
+    slug = name.replace("-", " ").replace("_", " ").lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug).strip("-")
+    return slug or "strategy"
+
+
+def strategy_page_href(name: str, *, prefix: str = "strategies") -> str:
+    """Return the conventional relative href for a strategy page."""
+
+    return f"{prefix}/{strategy_slug(name)}.html"

--- a/dominion/reporting/strategy_pages.py
+++ b/dominion/reporting/strategy_pages.py
@@ -99,12 +99,13 @@ def collect_rendered_strategies(
         if strategy is None:
             raise ValueError(f"Unknown strategy: {display_name}")
 
+        resolved_name = loader.get_display_name(display_name) or display_name
         refs = battle._split_board_references(battle._extract_cards_from_strategy(strategy))
-        source_path, factory_name = _strategy_source(loader, display_name)
+        source_path, factory_name = _strategy_source(loader, resolved_name)
         rendered.append(
             RenderedStrategy(
-                display_name=display_name,
-                slug=strategy_slug(display_name),
+                display_name=resolved_name,
+                slug=strategy_slug(resolved_name),
                 strategy=strategy,
                 source_path=source_path,
                 factory_name=factory_name,

--- a/dominion/reporting/strategy_pages.py
+++ b/dominion/reporting/strategy_pages.py
@@ -1,0 +1,302 @@
+"""Render registered strategies as static HTML pages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html import escape
+import inspect
+from pathlib import Path
+from typing import Iterable
+
+from dominion.simulation.strategy_battle import StrategyBattle
+from dominion.reporting.strategy_links import strategy_page_href, strategy_slug
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
+from dominion.strategy.strategy_loader import StrategyLoader
+
+
+@dataclass(frozen=True)
+class RenderedStrategy:
+    display_name: str
+    slug: str
+    strategy: EnhancedStrategy
+    source_path: str
+    factory_name: str
+    references: dict[str, list[str]]
+
+
+def _condition_label(condition) -> str:
+    if condition is None:
+        return "always"
+    return str(getattr(condition, "_source", "custom condition"))
+
+
+def _priority_rows(rules: Iterable[PriorityRule]) -> str:
+    rows = []
+    for index, rule in enumerate(rules, 1):
+        rows.append(
+            "<tr>"
+            f"<td>{index}</td>"
+            f"<td>{escape(rule.card_name)}</td>"
+            f"<td>{escape(_condition_label(rule.condition))}</td>"
+            "</tr>"
+        )
+    if not rows:
+        return "<tr><td colspan=\"3\" class=\"empty\">None</td></tr>"
+    return "\n".join(rows)
+
+
+def _way_rows(rules: Iterable[WayRule]) -> str:
+    rows = []
+    for index, rule in enumerate(rules, 1):
+        rows.append(
+            "<tr>"
+            f"<td>{index}</td>"
+            f"<td>{escape(rule.card_name)}</td>"
+            f"<td>{escape(rule.way_name)}</td>"
+            f"<td>{escape(_condition_label(rule.condition))}</td>"
+            "</tr>"
+        )
+    if not rows:
+        return "<tr><td colspan=\"4\" class=\"empty\">None</td></tr>"
+    return "\n".join(rows)
+
+
+def _reference_list(values: list[str]) -> str:
+    if not values:
+        return "<span class=\"empty\">None</span>"
+    return ", ".join(escape(value) for value in values)
+
+
+def _strategy_source(loader: StrategyLoader, display_name: str) -> tuple[str, str]:
+    factory = loader.strategies.get(display_name)
+    if factory is None:
+        factory = loader.strategies.get(display_name.lower())
+    if factory is None:
+        return "", ""
+
+    source = inspect.getsourcefile(factory) or ""
+    try:
+        source = str(Path(source).resolve().relative_to(Path.cwd()))
+    except ValueError:
+        source = str(Path(source).resolve()) if source else ""
+    return source, getattr(factory, "__name__", "")
+
+
+def collect_rendered_strategies(
+    loader: StrategyLoader | None = None,
+    *,
+    names: Iterable[str] | None = None,
+) -> list[RenderedStrategy]:
+    """Instantiate registered strategies and collect metadata for rendering."""
+
+    loader = loader or StrategyLoader()
+    battle = StrategyBattle(log_frequency=0)
+    display_names = list(names) if names is not None else loader.list_strategies()
+    rendered = []
+
+    for display_name in sorted(display_names):
+        strategy = loader.get_strategy(display_name)
+        if strategy is None:
+            raise ValueError(f"Unknown strategy: {display_name}")
+
+        refs = battle._split_board_references(battle._extract_cards_from_strategy(strategy))
+        source_path, factory_name = _strategy_source(loader, display_name)
+        rendered.append(
+            RenderedStrategy(
+                display_name=display_name,
+                slug=strategy_slug(display_name),
+                strategy=strategy,
+                source_path=source_path,
+                factory_name=factory_name,
+                references={
+                    "Kingdom Cards": refs.kingdom_cards,
+                    "Events": refs.events,
+                    "Projects": refs.projects,
+                    "Ways": refs.ways,
+                    "Landmarks": refs.landmarks,
+                    "Allies": refs.allies,
+                },
+            )
+        )
+
+    return rendered
+
+
+def _page_shell(title: str, body: str) -> str:
+    return f"""<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>{escape(title)}</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      --border: #d8dde6;
+      --text: #1f2937;
+      --muted: #667085;
+      --header: #f3f5f8;
+      --row: #fbfcfe;
+      --accent: #255e8f;
+    }}
+    body {{
+      color: var(--text);
+      font-family: Arial, sans-serif;
+      line-height: 1.4;
+      margin: 32px auto;
+      max-width: 1120px;
+      padding: 0 24px;
+    }}
+    a {{ color: var(--accent); }}
+    h1 {{ margin-bottom: 4px; }}
+    h2 {{ border-bottom: 1px solid var(--border); margin-top: 32px; padding-bottom: 6px; }}
+    .muted, .empty {{ color: var(--muted); }}
+    .meta {{
+      display: grid;
+      gap: 8px 20px;
+      grid-template-columns: max-content 1fr;
+      margin: 20px 0;
+    }}
+    .meta dt {{ color: var(--muted); font-weight: bold; }}
+    .meta dd {{ margin: 0; }}
+    table {{
+      border-collapse: collapse;
+      margin: 12px 0 24px;
+      width: 100%;
+    }}
+    th, td {{
+      border: 1px solid var(--border);
+      padding: 7px 10px;
+      text-align: left;
+      vertical-align: top;
+    }}
+    th {{ background: var(--header); }}
+    tr:nth-child(even) td {{ background: var(--row); }}
+    td:first-child {{ width: 54px; }}
+    .search {{
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-size: 16px;
+      margin: 18px 0;
+      padding: 9px 11px;
+      width: min(460px, 100%);
+    }}
+  </style>
+</head>
+<body>
+{body}
+</body>
+</html>
+"""
+
+
+def render_strategy_page(item: RenderedStrategy, *, index_href: str = "index.html") -> str:
+    strategy = item.strategy
+    references = "".join(
+        f"<dt>{escape(label)}</dt><dd>{_reference_list(values)}</dd>"
+        for label, values in item.references.items()
+    )
+    body = f"""
+<p><a href="{escape(index_href)}">Strategy index</a></p>
+<h1>{escape(item.display_name)}</h1>
+<p class="muted">{escape(getattr(strategy, "description", "") or "No description.")}</p>
+
+<dl class="meta">
+  <dt>Internal Name</dt><dd>{escape(getattr(strategy, "name", ""))}</dd>
+  <dt>Version</dt><dd>{escape(getattr(strategy, "version", ""))}</dd>
+  <dt>Source</dt><dd>{escape(item.source_path or "Unknown")}</dd>
+  <dt>Factory</dt><dd>{escape(item.factory_name or "Unknown")}</dd>
+  {references}
+</dl>
+
+<h2>Gain Priority</h2>
+<table>
+  <tr><th>#</th><th>Card or Event</th><th>Condition</th></tr>
+  {_priority_rows(getattr(strategy, "gain_priority", []))}
+</table>
+
+<h2>Action Priority</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Condition</th></tr>
+  {_priority_rows(getattr(strategy, "action_priority", []))}
+</table>
+
+<h2>Trash Priority</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Condition</th></tr>
+  {_priority_rows(getattr(strategy, "trash_priority", []))}
+</table>
+
+<h2>Treasure Priority</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Condition</th></tr>
+  {_priority_rows(getattr(strategy, "treasure_priority", []))}
+</table>
+
+<h2>Way Policy</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Way</th><th>Condition</th></tr>
+  {_way_rows(getattr(strategy, "way_policy", []) or [])}
+</table>
+"""
+    return _page_shell(f"{item.display_name} Strategy", body)
+
+
+def render_strategy_index(items: list[RenderedStrategy]) -> str:
+    rows = []
+    for item in items:
+        strategy = item.strategy
+        refs = item.references["Kingdom Cards"]
+        rows.append(
+            "<tr class=\"strategy-row\">"
+            f"<td><a href=\"{escape(item.slug)}.html\">{escape(item.display_name)}</a></td>"
+            f"<td>{escape(getattr(strategy, 'name', ''))}</td>"
+            f"<td>{escape(getattr(strategy, 'description', '') or '')}</td>"
+            f"<td>{_reference_list(refs)}</td>"
+            f"<td>{escape(item.source_path or 'Unknown')}</td>"
+            "</tr>"
+        )
+
+    body = f"""
+<h1>Strategy Index</h1>
+<p class="muted">Generated from registered strategy objects. Regenerate this directory after changing strategy code.</p>
+<input class="search" id="strategy-search" type="search" placeholder="Search strategies">
+<table id="strategy-table">
+  <tr><th>Strategy</th><th>Internal Name</th><th>Description</th><th>Kingdom Cards Used</th><th>Source</th></tr>
+  {''.join(rows)}
+</table>
+<script>
+const search = document.getElementById('strategy-search');
+const rows = Array.from(document.querySelectorAll('.strategy-row'));
+search.addEventListener('input', () => {{
+  const query = search.value.toLowerCase();
+  for (const row of rows) {{
+    row.style.display = row.innerText.toLowerCase().includes(query) ? '' : 'none';
+  }}
+}});
+</script>
+"""
+    return _page_shell("Strategy Index", body)
+
+
+def render_strategy_pages(
+    output_dir: Path,
+    *,
+    names: Iterable[str] | None = None,
+    loader: StrategyLoader | None = None,
+) -> list[Path]:
+    """Write strategy HTML pages and return created paths."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    items = collect_rendered_strategies(loader, names=names)
+    written = []
+
+    index_path = output_dir / "index.html"
+    index_path.write_text(render_strategy_index(items), encoding="utf-8")
+    written.append(index_path)
+
+    for item in items:
+        path = output_dir / f"{item.slug}.html"
+        path.write_text(render_strategy_page(item), encoding="utf-8")
+        written.append(path)
+
+    return written

--- a/dominion/strategy/strategy_loader.py
+++ b/dominion/strategy/strategy_loader.py
@@ -131,6 +131,21 @@ class StrategyLoader:
             return None
         return strategy_factory()
 
+    def get_display_name(self, name: str) -> Optional[str]:
+        """Return the registered display name for a strategy name or alias."""
+        strategy_factory = self.strategies.get(name)
+        if strategy_factory is None:
+            strategy_factory = self.strategies.get(name.lower())
+        if strategy_factory is None:
+            strategy_factory = self.strategies.get(self._slugify(name))
+        if strategy_factory is None:
+            return None
+
+        for display_name in self.list_strategies():
+            if self.strategies.get(display_name) is strategy_factory:
+                return display_name
+        return None
+
     def list_strategies(self) -> list[str]:
         """Return display names only (deduplicated, sorted)."""
         return sorted(self._display_names)

--- a/scripts/render_strategies.py
+++ b/scripts/render_strategies.py
@@ -1,0 +1,38 @@
+"""Render registered Dominion strategies as static HTML pages.
+
+Usage:
+    PYTHONPATH=. python scripts/render_strategies.py
+    PYTHONPATH=. python scripts/render_strategies.py --strategy "Big Money"
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from dominion.reporting.strategy_pages import render_strategy_pages
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render registered strategies as HTML")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("reports/strategies"),
+        help="Directory for generated HTML pages (default: reports/strategies)",
+    )
+    parser.add_argument(
+        "--strategy",
+        action="append",
+        dest="strategies",
+        help="Strategy display name to render. May be passed multiple times. Defaults to all strategies.",
+    )
+    args = parser.parse_args()
+
+    written = render_strategy_pages(args.output_dir, names=args.strategies)
+    print(f"Wrote {len(written)} files to {args.output_dir}")
+    print(f"Index: {args.output_dir / 'index.html'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_strategy_loader.py
+++ b/tests/test_strategy_loader.py
@@ -15,6 +15,14 @@ def test_strategy_loader_unknown_returns_none():
     assert loader.get_strategy('No Such Strategy') is None
 
 
+def test_strategy_loader_display_name_for_aliases():
+    loader = StrategyLoader()
+    assert loader.get_display_name("BigMoney") == "Big Money"
+    assert loader.get_display_name("bigmoney") == "Big Money"
+    assert loader.get_display_name("ChapelWitch") == "Chapel Witch"
+    assert loader.get_display_name("No Such Strategy") is None
+
+
 def test_inspiring_festival_engine_prioritizes_horse_and_necropolis():
     loader = StrategyLoader()
     strategy = loader.get_strategy("Inspiring Festival Engine")

--- a/tests/test_strategy_pages.py
+++ b/tests/test_strategy_pages.py
@@ -1,0 +1,23 @@
+from dominion.reporting.strategy_links import strategy_page_href, strategy_slug
+from dominion.reporting.strategy_pages import render_strategy_pages
+
+
+def test_strategy_slug_is_stable_for_display_names():
+    assert strategy_slug("Big Money Smithy") == "big-money-smithy"
+    assert strategy_page_href("Big Money Smithy") == "strategies/big-money-smithy.html"
+
+
+def test_render_strategy_pages_writes_index_and_strategy_page(tmp_path):
+    written = render_strategy_pages(tmp_path, names=["Big Money"])
+
+    paths = {path.name for path in written}
+    assert paths == {"index.html", "big-money.html"}
+
+    index = (tmp_path / "index.html").read_text(encoding="utf-8")
+    page = (tmp_path / "big-money.html").read_text(encoding="utf-8")
+
+    assert "Strategy Index" in index
+    assert 'href="big-money.html"' in index
+    assert "Gain Priority" in page
+    assert "Province" in page
+    assert "dominion/strategy/strategies/big_money.py" in page

--- a/tests/test_strategy_pages.py
+++ b/tests/test_strategy_pages.py
@@ -1,10 +1,16 @@
 from dominion.reporting.strategy_links import strategy_page_href, strategy_slug
 from dominion.reporting.strategy_pages import render_strategy_pages
+from dominion.reporting.html_report import _strategy_report_href
 
 
 def test_strategy_slug_is_stable_for_display_names():
     assert strategy_slug("Big Money Smithy") == "big-money-smithy"
     assert strategy_page_href("Big Money Smithy") == "strategies/big-money-smithy.html"
+
+
+def test_strategy_report_href_resolves_aliases_to_rendered_pages():
+    assert _strategy_report_href("BigMoney", prefix="strategies") == "strategies/big-money.html"
+    assert _strategy_report_href("ChapelWitch", prefix="strategies") == "strategies/chapel-witch.html"
 
 
 def test_render_strategy_pages_writes_index_and_strategy_page(tmp_path):

--- a/tests/test_strategy_pages.py
+++ b/tests/test_strategy_pages.py
@@ -27,3 +27,14 @@ def test_render_strategy_pages_writes_index_and_strategy_page(tmp_path):
     assert "Gain Priority" in page
     assert "Province" in page
     assert "dominion/strategy/strategies/big_money.py" in page
+
+
+def test_render_strategy_pages_resolves_alias_names(tmp_path):
+    written = render_strategy_pages(tmp_path, names=["BigMoney"])
+
+    paths = {path.name for path in written}
+    assert paths == {"index.html", "big-money.html"}
+
+    page = (tmp_path / "big-money.html").read_text(encoding="utf-8")
+    assert "Big Money" in page
+    assert "dominion/strategy/strategies/big_money.py" in page

--- a/tests/test_strategy_pages.py
+++ b/tests/test_strategy_pages.py
@@ -1,6 +1,6 @@
 from dominion.reporting.strategy_links import strategy_page_href, strategy_slug
 from dominion.reporting.strategy_pages import render_strategy_pages
-from dominion.reporting.html_report import _strategy_report_href
+from dominion.reporting.html_report import _strategy_report_href, generate_leaderboard_html
 
 
 def test_strategy_slug_is_stable_for_display_names():
@@ -11,6 +11,35 @@ def test_strategy_slug_is_stable_for_display_names():
 def test_strategy_report_href_resolves_aliases_to_rendered_pages():
     assert _strategy_report_href("BigMoney", prefix="strategies") == "strategies/big-money.html"
     assert _strategy_report_href("ChapelWitch", prefix="strategies") == "strategies/chapel-witch.html"
+    assert _strategy_report_href("strategy_20260212_094841", prefix="strategies") is None
+
+
+def test_leaderboard_html_does_not_link_unresolved_strategy_names(tmp_path):
+    output = tmp_path / "leaderboard.html"
+    generate_leaderboard_html(
+        {
+            "Big Money": {
+                "wins": 1,
+                "losses": 0,
+                "win_rate": 100.0,
+                "description": "",
+                "cards": [],
+            },
+            "strategy_20260212_094841": {
+                "wins": 0,
+                "losses": 1,
+                "win_rate": 0.0,
+                "description": "",
+                "cards": [],
+            },
+        },
+        output,
+    )
+
+    html = output.read_text(encoding="utf-8")
+    assert "big-money.html" in html
+    assert "strategy_20260212_094841.html" not in html
+    assert "<td>strategy_20260212_094841</td>" in html
 
 
 def test_render_strategy_pages_writes_index_and_strategy_page(tmp_path):


### PR DESCRIPTION
## Summary
- Add a static strategy page renderer with an index and one HTML page per registered strategy.
- Add a CLI for regenerating the pages under reports/strategies and link matchup and leaderboard reports to those pages.
- Cover stable slugs and page rendering with focused tests.

## Validation
- PYTHONPATH=. pytest tests/test_strategy_pages.py tests/test_strategy_loader.py -q
- PYTHONPATH=. python -m py_compile dominion/reporting/strategy_links.py dominion/reporting/strategy_pages.py scripts/render_strategies.py dominion/reporting/html_report.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added static HTML strategy reports with an index, searchable strategy list, detailed strategy pages, metadata, references, priorities, and policy information.
  * Added clickable links between strategy reports, leaderboards, and decision-firing sections.
  * Added a command-line tool to generate reports for all strategies or selected strategies.
  * Strategy names are safely formatted for consistent report URLs.

* **Bug Fixes**
  * Improved HTML escaping for strategy names and descriptions.

* **Tests**
  * Added coverage for strategy aliases, report links, slugs, and generated pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->