### PR TITLE
Add Taskmaster workforce board strategy

### DIFF
--- a/boards/taskmaster_workforce.txt
+++ b/boards/taskmaster_workforce.txt
@@ -1,0 +1,18 @@
+# Taskmaster Workforce.
+#
+# Built to make buying many Taskmasters the central plan. Supplies registers
+# the Horse pile, cheap gainers can stockpile Taskmasters early, and
+# Wharf/Market/Festival supply enough buys to keep adding them. The six $5
+# Actions give the deck reliable ways to turn Taskmasters back on every turn,
+# so a stack of Taskmasters becomes sustained actions and money instead of
+# dead duration clutter.
+Taskmaster
+Supplies
+Groom
+Ironworks
+Sculptor
+Wharf
+Market
+Festival
+Laboratory
+Lost City

--- a/generated_strategies/taskmaster_workforce_best.py
+++ b/generated_strategies/taskmaster_workforce_best.py
@@ -1,0 +1,57 @@
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class TaskmasterWorkforceBest(EnhancedStrategy):
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Taskmaster Workforce Best"
+        self.description = "Evolved strategy for boards/taskmaster_workforce.txt"
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule("Province"),
+            PriorityRule("Duchy", PriorityRule.provinces_left("<=", 5)),
+            PriorityRule("Estate", PriorityRule.provinces_left("<=", 3)),
+            PriorityRule("Wharf", PriorityRule.max_in_deck("Wharf", 1)),
+            PriorityRule(
+                "Sculptor",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Sculptor", 1),
+                    PriorityRule.provinces_left(">", 4),
+                ),
+            ),
+            PriorityRule("Gold"),
+            PriorityRule("Festival", PriorityRule.max_in_deck("Festival", 3)),
+            PriorityRule("Silver", PriorityRule.turn_number("<=", 11)),
+            PriorityRule("Supplies", PriorityRule.max_in_deck("Supplies", 1)),
+            PriorityRule("Groom", PriorityRule.max_in_deck("Groom", 2)),
+        ]
+
+        self.action_priority = [
+            PriorityRule("Lost City"),
+            PriorityRule("Festival"),
+            PriorityRule("Market"),
+            PriorityRule("Laboratory"),
+            PriorityRule("Taskmaster"),
+            PriorityRule("Wharf"),
+            PriorityRule("Ironworks"),
+            PriorityRule("Groom"),
+            PriorityRule("Sculptor"),
+        ]
+
+        self.treasure_priority = [
+            PriorityRule("Gold"),
+            PriorityRule("Supplies"),
+            PriorityRule("Silver"),
+            PriorityRule("Copper"),
+        ]
+
+        self.trash_priority = [
+            PriorityRule("Curse"),
+            PriorityRule("Estate", PriorityRule.provinces_left(">", 2)),
+            PriorityRule("Copper", PriorityRule.has_cards(["Silver", "Gold"], 2)),
+        ]
+
+
+def create_taskmaster_workforce_best() -> EnhancedStrategy:
+    return TaskmasterWorkforceBest()

--- a/generated_strategies/taskmaster_workforce_best.py
+++ b/generated_strategies/taskmaster_workforce_best.py
@@ -22,6 +22,14 @@ class TaskmasterWorkforceBest(EnhancedStrategy):
             ),
             PriorityRule("Gold"),
             PriorityRule("Festival", PriorityRule.max_in_deck("Festival", 3)),
+            PriorityRule(
+                "Taskmaster",
+                PriorityRule.and_(
+                    PriorityRule.max_in_deck("Taskmaster", 4),
+                    PriorityRule.turn_number(">=", 5),
+                    PriorityRule.provinces_left(">", 4),
+                ),
+            ),
             PriorityRule("Silver", PriorityRule.turn_number("<=", 11)),
             PriorityRule("Supplies", PriorityRule.max_in_deck("Supplies", 1)),
             PriorityRule("Groom", PriorityRule.max_in_deck("Groom", 2)),

--- a/tests/test_taskmaster_board.py
+++ b/tests/test_taskmaster_board.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from dominion.boards.loader import load_board
+from dominion.cards.registry import get_card
+from dominion.game.game_state import GameState
+from tests.utils import DummyAI
+
+
+def test_taskmaster_workforce_board_loads():
+    board = load_board(Path("boards/taskmaster_workforce.txt"))
+
+    assert board.kingdom_cards == [
+        "Taskmaster",
+        "Supplies",
+        "Groom",
+        "Ironworks",
+        "Sculptor",
+        "Wharf",
+        "Market",
+        "Festival",
+        "Laboratory",
+        "Lost City",
+    ]
+    assert [get_card(name).name for name in board.kingdom_cards] == board.kingdom_cards
+
+    state = GameState(players=[])
+    state.initialize_game(
+        [DummyAI(), DummyAI()],
+        [get_card(name) for name in board.kingdom_cards],
+    )
+
+    assert state.supply["Horse"] == 30
+    assert "Horse" in state.non_supply_pile_names


### PR DESCRIPTION
Adds a Taskmaster Workforce board designed around repeated exact-$5 gains and sustained Taskmaster value. Includes a named evolved strategy for the board plus a focused test that verifies the board loads, resolves all card names, and registers the Horse pile through Supplies. Validation run: pytest tests/test_taskmaster_board.py tests/test_taskmaster.py, plus a 20-game smoke battle of taskmaster_workforce_best against BigMoney.