### PR TITLE
Add best strategy HTML cards

### DIFF
--- a/generated_strategies/taskmaster_workforce_best.py
+++ b/generated_strategies/taskmaster_workforce_best.py
@@ -5,7 +5,10 @@ class TaskmasterWorkforceBest(EnhancedStrategy):
     def __init__(self) -> None:
         super().__init__()
         self.name = "Taskmaster Workforce Best"
-        self.description = "Evolved strategy for boards/taskmaster_workforce.txt"
+        self.description = (
+            "Best-found Taskmaster Workforce board policy: Taskmaster payload "
+            "with Wharf draw, Festival buys, and fast greening."
+        )
         self.version = "1.0"
 
         self.gain_priority = [

--- a/reports/strategies/hyderabad-best-found.html
+++ b/reports/strategies/hyderabad-best-found.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Hyderabad Best Found Strategy</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --border: #d8dde6;
+      --text: #1f2937;
+      --muted: #667085;
+      --header: #f3f5f8;
+      --row: #fbfcfe;
+      --accent: #255e8f;
+    }
+    body {
+      color: var(--text);
+      font-family: Arial, sans-serif;
+      line-height: 1.4;
+      margin: 32px auto;
+      max-width: 1120px;
+      padding: 0 24px;
+    }
+    a { color: var(--accent); }
+    h1 { margin-bottom: 4px; }
+    h2 { border-bottom: 1px solid var(--border); margin-top: 32px; padding-bottom: 6px; }
+    .muted, .empty { color: var(--muted); }
+    .meta {
+      display: grid;
+      gap: 8px 20px;
+      grid-template-columns: max-content 1fr;
+      margin: 20px 0;
+    }
+    .meta dt { color: var(--muted); font-weight: bold; }
+    .meta dd { margin: 0; }
+    table {
+      border-collapse: collapse;
+      margin: 12px 0 24px;
+      width: 100%;
+    }
+    th, td {
+      border: 1px solid var(--border);
+      padding: 7px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: var(--header); }
+    tr:nth-child(even) td { background: var(--row); }
+    td:first-child { width: 54px; }
+    .search {
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-size: 16px;
+      margin: 18px 0;
+      padding: 9px 11px;
+      width: min(460px, 100%);
+    }
+  </style>
+</head>
+<body>
+
+<p><a href="index.html">Strategy index</a></p>
+<h1>Hyderabad Best Found</h1>
+<p class="muted">Best-found Hyderabad board policy: Stockpile-battery money with one Scholar, late Duchies, and three-pile Estate closing.</p>
+
+<dl class="meta">
+  <dt>Internal Name</dt><dd>Hyderabad Best Found</dd>
+  <dt>Version</dt><dd>1.0</dd>
+  <dt>Source</dt><dd>generated_strategies/hyderabad_best_found.py</dd>
+  <dt>Factory</dt><dd>create_hyderabad_best_found</dd>
+  <dt>Kingdom Cards</dt><dd>Ducat, Scholar, Stockpile</dd><dt>Events</dt><dd><span class="empty">None</span></dd><dt>Projects</dt><dd><span class="empty">None</span></dd><dt>Ways</dt><dd><span class="empty">None</span></dd><dt>Landmarks</dt><dd><span class="empty">None</span></dd><dt>Allies</dt><dd><span class="empty">None</span></dd>
+</dl>
+
+<h2>Gain Priority</h2>
+<table>
+  <tr><th>#</th><th>Card or Event</th><th>Condition</th></tr>
+  <tr><td>1</td><td>Province</td><td>always</td></tr>
+<tr><td>2</td><td>Duchy</td><td>PriorityRule.provinces_left(&#x27;&lt;=&#x27;, 3)</td></tr>
+<tr><td>3</td><td>Estate</td><td>PriorityRule.empty_piles(&#x27;&gt;=&#x27;, 2)</td></tr>
+<tr><td>4</td><td>Gold</td><td>always</td></tr>
+<tr><td>5</td><td>Scholar</td><td>PriorityRule.and_(PriorityRule.max_in_deck(&#x27;Scholar&#x27;, 1), PriorityRule.turn_number(&#x27;&lt;=&#x27;, 12))</td></tr>
+<tr><td>6</td><td>Stockpile</td><td>PriorityRule.max_in_deck(&#x27;Stockpile&#x27;, 6)</td></tr>
+<tr><td>7</td><td>Ducat</td><td>PriorityRule.and_(PriorityRule.max_in_deck(&#x27;Ducat&#x27;, 1), PriorityRule.provinces_left(&#x27;&gt;&#x27;, 3))</td></tr>
+<tr><td>8</td><td>Silver</td><td>always</td></tr>
+</table>
+
+<h2>Action Priority</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Condition</th></tr>
+  <tr><td>1</td><td>Scholar</td><td>always</td></tr>
+</table>
+
+<h2>Trash Priority</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Condition</th></tr>
+  <tr><td colspan="3" class="empty">None</td></tr>
+</table>
+
+<h2>Treasure Priority</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Condition</th></tr>
+  <tr><td>1</td><td>Silver</td><td>always</td></tr>
+<tr><td>2</td><td>Gold</td><td>always</td></tr>
+<tr><td>3</td><td>Copper</td><td>always</td></tr>
+<tr><td>4</td><td>Stockpile</td><td>always</td></tr>
+<tr><td>5</td><td>Ducat</td><td>always</td></tr>
+</table>
+
+<h2>Way Policy</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Way</th><th>Condition</th></tr>
+  <tr><td colspan="4" class="empty">None</td></tr>
+</table>
+
+</body>
+</html>

--- a/reports/strategies/index.html
+++ b/reports/strategies/index.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Strategy Index</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --border: #d8dde6;
+      --text: #1f2937;
+      --muted: #667085;
+      --header: #f3f5f8;
+      --row: #fbfcfe;
+      --accent: #255e8f;
+    }
+    body {
+      color: var(--text);
+      font-family: Arial, sans-serif;
+      line-height: 1.4;
+      margin: 32px auto;
+      max-width: 1120px;
+      padding: 0 24px;
+    }
+    a { color: var(--accent); }
+    h1 { margin-bottom: 4px; }
+    h2 { border-bottom: 1px solid var(--border); margin-top: 32px; padding-bottom: 6px; }
+    .muted, .empty { color: var(--muted); }
+    .meta {
+      display: grid;
+      gap: 8px 20px;
+      grid-template-columns: max-content 1fr;
+      margin: 20px 0;
+    }
+    .meta dt { color: var(--muted); font-weight: bold; }
+    .meta dd { margin: 0; }
+    table {
+      border-collapse: collapse;
+      margin: 12px 0 24px;
+      width: 100%;
+    }
+    th, td {
+      border: 1px solid var(--border);
+      padding: 7px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: var(--header); }
+    tr:nth-child(even) td { background: var(--row); }
+    td:first-child { width: 54px; }
+    .search {
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-size: 16px;
+      margin: 18px 0;
+      padding: 9px 11px;
+      width: min(460px, 100%);
+    }
+  </style>
+</head>
+<body>
+
+<h1>Strategy Index</h1>
+<p class="muted">Generated from registered strategy objects. Regenerate this directory after changing strategy code.</p>
+<input class="search" id="strategy-search" type="search" placeholder="Search strategies">
+<table id="strategy-table">
+  <tr><th>Strategy</th><th>Internal Name</th><th>Description</th><th>Kingdom Cards Used</th><th>Source</th></tr>
+  <tr class="strategy-row"><td><a href="hyderabad-best-found.html">Hyderabad Best Found</a></td><td>Hyderabad Best Found</td><td>Best-found Hyderabad board policy: Stockpile-battery money with one Scholar, late Duchies, and three-pile Estate closing.</td><td>Ducat, Scholar, Stockpile</td><td>generated_strategies/hyderabad_best_found.py</td></tr><tr class="strategy-row"><td><a href="lisbon-best-found.html">Lisbon Best Found</a></td><td>Lisbon Best Found</td><td>Best-found Lisbon board policy: City-first pile pressure into Colony, Clerk, and a fast green pivot.</td><td>City, Clerk, Collection, Colony, Gardens, Investment, Peddler, Platinum</td><td>generated_strategies/lisbon_best_found.py</td></tr><tr class="strategy-row"><td><a href="taskmaster-workforce-best.html">Taskmaster Workforce Best</a></td><td>Taskmaster Workforce Best</td><td>Best-found Taskmaster Workforce board policy: Taskmaster payload with Wharf draw, Festival buys, and fast greening.</td><td>Festival, Groom, Ironworks, Laboratory, Lost City, Market, Sculptor, Supplies, Taskmaster, Wharf</td><td>generated_strategies/taskmaster_workforce_best.py</td></tr>
+</table>
+<script>
+const search = document.getElementById('strategy-search');
+const rows = Array.from(document.querySelectorAll('.strategy-row'));
+search.addEventListener('input', () => {
+  const query = search.value.toLowerCase();
+  for (const row of rows) {
+    row.style.display = row.innerText.toLowerCase().includes(query) ? '' : 'none';
+  }
+});
+</script>
+
+</body>
+</html>

--- a/reports/strategies/lisbon-best-found.html
+++ b/reports/strategies/lisbon-best-found.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Lisbon Best Found Strategy</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --border: #d8dde6;
+      --text: #1f2937;
+      --muted: #667085;
+      --header: #f3f5f8;
+      --row: #fbfcfe;
+      --accent: #255e8f;
+    }
+    body {
+      color: var(--text);
+      font-family: Arial, sans-serif;
+      line-height: 1.4;
+      margin: 32px auto;
+      max-width: 1120px;
+      padding: 0 24px;
+    }
+    a { color: var(--accent); }
+    h1 { margin-bottom: 4px; }
+    h2 { border-bottom: 1px solid var(--border); margin-top: 32px; padding-bottom: 6px; }
+    .muted, .empty { color: var(--muted); }
+    .meta {
+      display: grid;
+      gap: 8px 20px;
+      grid-template-columns: max-content 1fr;
+      margin: 20px 0;
+    }
+    .meta dt { color: var(--muted); font-weight: bold; }
+    .meta dd { margin: 0; }
+    table {
+      border-collapse: collapse;
+      margin: 12px 0 24px;
+      width: 100%;
+    }
+    th, td {
+      border: 1px solid var(--border);
+      padding: 7px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: var(--header); }
+    tr:nth-child(even) td { background: var(--row); }
+    td:first-child { width: 54px; }
+    .search {
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-size: 16px;
+      margin: 18px 0;
+      padding: 9px 11px;
+      width: min(460px, 100%);
+    }
+  </style>
+</head>
+<body>
+
+<p><a href="index.html">Strategy index</a></p>
+<h1>Lisbon Best Found</h1>
+<p class="muted">Best-found Lisbon board policy: City-first pile pressure into Colony, Clerk, and a fast green pivot.</p>
+
+<dl class="meta">
+  <dt>Internal Name</dt><dd>Lisbon Best Found</dd>
+  <dt>Version</dt><dd>1.0</dd>
+  <dt>Source</dt><dd>generated_strategies/lisbon_best_found.py</dd>
+  <dt>Factory</dt><dd>create_lisbon_best_found</dd>
+  <dt>Kingdom Cards</dt><dd>City, Clerk, Collection, Colony, Gardens, Investment, Peddler, Platinum</dd><dt>Events</dt><dd><span class="empty">None</span></dd><dt>Projects</dt><dd><span class="empty">None</span></dd><dt>Ways</dt><dd><span class="empty">None</span></dd><dt>Landmarks</dt><dd><span class="empty">None</span></dd><dt>Allies</dt><dd><span class="empty">None</span></dd>
+</dl>
+
+<h2>Gain Priority</h2>
+<table>
+  <tr><th>#</th><th>Card or Event</th><th>Condition</th></tr>
+  <tr><td>1</td><td>City</td><td>always</td></tr>
+<tr><td>2</td><td>Colony</td><td>always</td></tr>
+<tr><td>3</td><td>Clerk</td><td>always</td></tr>
+<tr><td>4</td><td>Province</td><td>always</td></tr>
+<tr><td>5</td><td>Duchy</td><td>always</td></tr>
+<tr><td>6</td><td>Gardens</td><td>always</td></tr>
+<tr><td>7</td><td>Peddler</td><td>always</td></tr>
+<tr><td>8</td><td>Silver</td><td>always</td></tr>
+</table>
+
+<h2>Action Priority</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Condition</th></tr>
+  <tr><td>1</td><td>City</td><td>always</td></tr>
+<tr><td>2</td><td>Peddler</td><td>always</td></tr>
+<tr><td>3</td><td>Clerk</td><td>always</td></tr>
+</table>
+
+<h2>Trash Priority</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Condition</th></tr>
+  <tr><td>1</td><td>Curse</td><td>always</td></tr>
+<tr><td>2</td><td>Estate</td><td>PriorityRule.provinces_left(&#x27;&gt;&#x27;, 2)</td></tr>
+<tr><td>3</td><td>Copper</td><td>PriorityRule.has_cards([&#x27;Silver&#x27;, &#x27;Gold&#x27;], 3)</td></tr>
+</table>
+
+<h2>Treasure Priority</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Condition</th></tr>
+  <tr><td>1</td><td>Collection</td><td>always</td></tr>
+<tr><td>2</td><td>Platinum</td><td>always</td></tr>
+<tr><td>3</td><td>Gold</td><td>always</td></tr>
+<tr><td>4</td><td>Investment</td><td>always</td></tr>
+<tr><td>5</td><td>Silver</td><td>always</td></tr>
+<tr><td>6</td><td>Copper</td><td>always</td></tr>
+</table>
+
+<h2>Way Policy</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Way</th><th>Condition</th></tr>
+  <tr><td colspan="4" class="empty">None</td></tr>
+</table>
+
+</body>
+</html>

--- a/reports/strategies/taskmaster-workforce-best.html
+++ b/reports/strategies/taskmaster-workforce-best.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Taskmaster Workforce Best Strategy</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --border: #d8dde6;
+      --text: #1f2937;
+      --muted: #667085;
+      --header: #f3f5f8;
+      --row: #fbfcfe;
+      --accent: #255e8f;
+    }
+    body {
+      color: var(--text);
+      font-family: Arial, sans-serif;
+      line-height: 1.4;
+      margin: 32px auto;
+      max-width: 1120px;
+      padding: 0 24px;
+    }
+    a { color: var(--accent); }
+    h1 { margin-bottom: 4px; }
+    h2 { border-bottom: 1px solid var(--border); margin-top: 32px; padding-bottom: 6px; }
+    .muted, .empty { color: var(--muted); }
+    .meta {
+      display: grid;
+      gap: 8px 20px;
+      grid-template-columns: max-content 1fr;
+      margin: 20px 0;
+    }
+    .meta dt { color: var(--muted); font-weight: bold; }
+    .meta dd { margin: 0; }
+    table {
+      border-collapse: collapse;
+      margin: 12px 0 24px;
+      width: 100%;
+    }
+    th, td {
+      border: 1px solid var(--border);
+      padding: 7px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: var(--header); }
+    tr:nth-child(even) td { background: var(--row); }
+    td:first-child { width: 54px; }
+    .search {
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-size: 16px;
+      margin: 18px 0;
+      padding: 9px 11px;
+      width: min(460px, 100%);
+    }
+  </style>
+</head>
+<body>
+
+<p><a href="index.html">Strategy index</a></p>
+<h1>Taskmaster Workforce Best</h1>
+<p class="muted">Best-found Taskmaster Workforce board policy: Taskmaster payload with Wharf draw, Festival buys, and fast greening.</p>
+
+<dl class="meta">
+  <dt>Internal Name</dt><dd>Taskmaster Workforce Best</dd>
+  <dt>Version</dt><dd>1.0</dd>
+  <dt>Source</dt><dd>generated_strategies/taskmaster_workforce_best.py</dd>
+  <dt>Factory</dt><dd>create_taskmaster_workforce_best</dd>
+  <dt>Kingdom Cards</dt><dd>Festival, Groom, Ironworks, Laboratory, Lost City, Market, Sculptor, Supplies, Taskmaster, Wharf</dd><dt>Events</dt><dd><span class="empty">None</span></dd><dt>Projects</dt><dd><span class="empty">None</span></dd><dt>Ways</dt><dd><span class="empty">None</span></dd><dt>Landmarks</dt><dd><span class="empty">None</span></dd><dt>Allies</dt><dd><span class="empty">None</span></dd>
+</dl>
+
+<h2>Gain Priority</h2>
+<table>
+  <tr><th>#</th><th>Card or Event</th><th>Condition</th></tr>
+  <tr><td>1</td><td>Province</td><td>always</td></tr>
+<tr><td>2</td><td>Duchy</td><td>PriorityRule.provinces_left(&#x27;&lt;=&#x27;, 5)</td></tr>
+<tr><td>3</td><td>Estate</td><td>PriorityRule.provinces_left(&#x27;&lt;=&#x27;, 3)</td></tr>
+<tr><td>4</td><td>Wharf</td><td>PriorityRule.max_in_deck(&#x27;Wharf&#x27;, 1)</td></tr>
+<tr><td>5</td><td>Sculptor</td><td>PriorityRule.and_(PriorityRule.max_in_deck(&#x27;Sculptor&#x27;, 1), PriorityRule.provinces_left(&#x27;&gt;&#x27;, 4))</td></tr>
+<tr><td>6</td><td>Gold</td><td>always</td></tr>
+<tr><td>7</td><td>Festival</td><td>PriorityRule.max_in_deck(&#x27;Festival&#x27;, 3)</td></tr>
+<tr><td>8</td><td>Taskmaster</td><td>PriorityRule.and_(PriorityRule.max_in_deck(&#x27;Taskmaster&#x27;, 4), PriorityRule.turn_number(&#x27;&gt;=&#x27;, 5), PriorityRule.provinces_left(&#x27;&gt;&#x27;, 4))</td></tr>
+<tr><td>9</td><td>Silver</td><td>PriorityRule.turn_number(&#x27;&lt;=&#x27;, 11)</td></tr>
+<tr><td>10</td><td>Supplies</td><td>PriorityRule.max_in_deck(&#x27;Supplies&#x27;, 1)</td></tr>
+<tr><td>11</td><td>Groom</td><td>PriorityRule.max_in_deck(&#x27;Groom&#x27;, 2)</td></tr>
+</table>
+
+<h2>Action Priority</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Condition</th></tr>
+  <tr><td>1</td><td>Lost City</td><td>always</td></tr>
+<tr><td>2</td><td>Festival</td><td>always</td></tr>
+<tr><td>3</td><td>Market</td><td>always</td></tr>
+<tr><td>4</td><td>Laboratory</td><td>always</td></tr>
+<tr><td>5</td><td>Taskmaster</td><td>always</td></tr>
+<tr><td>6</td><td>Wharf</td><td>always</td></tr>
+<tr><td>7</td><td>Ironworks</td><td>always</td></tr>
+<tr><td>8</td><td>Groom</td><td>always</td></tr>
+<tr><td>9</td><td>Sculptor</td><td>always</td></tr>
+</table>
+
+<h2>Trash Priority</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Condition</th></tr>
+  <tr><td>1</td><td>Curse</td><td>always</td></tr>
+<tr><td>2</td><td>Estate</td><td>PriorityRule.provinces_left(&#x27;&gt;&#x27;, 2)</td></tr>
+<tr><td>3</td><td>Copper</td><td>PriorityRule.has_cards([&#x27;Silver&#x27;, &#x27;Gold&#x27;], 2)</td></tr>
+</table>
+
+<h2>Treasure Priority</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Condition</th></tr>
+  <tr><td>1</td><td>Gold</td><td>always</td></tr>
+<tr><td>2</td><td>Supplies</td><td>always</td></tr>
+<tr><td>3</td><td>Silver</td><td>always</td></tr>
+<tr><td>4</td><td>Copper</td><td>always</td></tr>
+</table>
+
+<h2>Way Policy</h2>
+<table>
+  <tr><th>#</th><th>Card</th><th>Way</th><th>Condition</th></tr>
+  <tr><td colspan="4" class="empty">None</td></tr>
+</table>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds generated HTML strategy cards for the published best strategies: Hyderabad Best Found, Lisbon Best Found, and Taskmaster Workforce Best.
- Adds a generated index page that links those cards and summarizes their strategy descriptions, kingdom references, and source files.
- Updates the Taskmaster Workforce strategy description so the generated index uses a plain-English summary instead of a board file path.

## Validation

- `PYTHONPATH=. python scripts/render_strategies.py --strategy "Lisbon Best Found" --strategy "Hyderabad Best Found" --strategy "Taskmaster Workforce Best"`
- `PYTHONPATH=. pytest tests/test_strategy_pages.py`