### PR TITLE
Widen the greening-gate vocabulary: ungated Duchy, pile-pressure Estate, opener picks

### DIFF
--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -112,6 +112,29 @@ exactly the categories the suite was designed to separate:
   saved genome. The known-best label stays as a reference, but the community
   answer is not the best strategy on this exact board in this simulator.
 
+## Widened greening-gate vocabulary (2026-07-05)
+
+First measured pipeline change: the structured genome's gate vocabulary
+gained an ungated-Duchy option (25%), a pile-pressure Estate gate
+(`empty_piles >= 1-2`, 25%), and an opener shape for kingdom picks
+(`max_in_deck 1 AND turn <= 2-4`, 15%). Same run settings as the baseline;
+full table in `reports/calibration/evolve_v2_widened_gates.md`.
+
+- **Both representability targets closed**: rebuild_duchy 32.8% → 46.2%
+  (gap 17.2 → 3.8pp) and chapel_witch 44.0% → 64.2% (gap 6.0 → 0; the
+  champion beats the reference with triple-Witch money and clean greening).
+  Attribution is partial — the rebuild champion used the widest Duchy gate
+  plus a Rebuild cap of 6 rather than the fully ungated rule — but the rush
+  shapes are now inside the search space either way.
+- **BM+X money boards wobbled** (smithy_bm 41.8% → 25.0%, wharf_bm 46.5%
+  → 40.8%): partly wider-vocabulary noise, mostly single-run GA variance —
+  a smithy_bm re-run on identical settings scored 39.0%, a 14pp swing
+  between seeds. Per-board single-run numbers are ±8pp; treat mean gap
+  across all 10 boards as the signal, and re-run anomalies before reacting.
+- These wobble boards are all in the objective-failure class (fixed Big
+  Money panel gives no gradient toward mirror-optimal BM+X), which is the
+  next work item — a coevolution/champion-pool outer loop.
+
 ## Caveats
 
 - The known-best strategies are strong reference points, not proofs of

--- a/dominion/simulation/structured_genome.py
+++ b/dominion/simulation/structured_genome.py
@@ -109,8 +109,18 @@ class KingdomInfo:
 
 def _greening_gate(card: str, rng):
     if card == "Duchy":
+        # Usually endgame-gated, sometimes ungated: rush archetypes
+        # (Rebuild/Duchy, Gardens slogs) buy Duchy over Gold from turn 1,
+        # and the calibration suite showed that plan was unsearchable while
+        # the pile gate was mandatory (rebuild_duchy gap: 17pp).
+        if rng.random() < 0.25:
+            return None
         return PriorityRule.provinces_left("<=", rng.randint(3, 6))
     if card == "Estate":
+        # Endgame count gate, or pile pressure: start grabbing Estates once
+        # piles empty to force or win the three-pile ending.
+        if rng.random() < 0.25:
+            return PriorityRule.empty_piles(">=", rng.randint(1, 2))
         return PriorityRule.provinces_left("<=", rng.randint(1, 3))
     # Province: usually unconditional; occasionally an endgame-only gate.
     if rng.random() < 0.85:
@@ -129,6 +139,14 @@ def _silver_gate(rng):
 
 def _pick_gate(card: str, info: KingdomInfo, rng):
     """Cap + optional extra gate for a kingdom menu pick."""
+    if rng.random() < 0.15:
+        # Opener shape: exactly one copy, bought in the opening turns.
+        # Chapel-style enablers need cap 1 + early turn jointly — the pieces
+        # existed separately in the vocabulary but the combination did not.
+        return PriorityRule.and_(
+            PriorityRule.max_in_deck(card, 1),
+            PriorityRule.turn_number("<=", rng.randint(2, 4)),
+        )
     cap = PriorityRule.max_in_deck(card, info.default_cap(card, rng))
     if rng.random() >= 0.3:
         return cap

--- a/reports/calibration/evolve_parts_v2/chapel_witch/champion_chapel_witch.py
+++ b/reports/calibration/evolve_parts_v2/chapel_witch/champion_chapel_witch.py
@@ -1,0 +1,39 @@
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class ChampionChapelWitch(EnhancedStrategy):
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = 'gen27-5423024400'
+        self.description = "Auto-generated strategy from genetic training"
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule('Province'),
+            PriorityRule('Duchy', PriorityRule.provinces_left('<=', 4)),
+            PriorityRule('Estate', PriorityRule.provinces_left('<=', 2)),
+            PriorityRule('Gold'),
+            PriorityRule('Witch', PriorityRule.max_in_deck('Witch', 3)),
+            PriorityRule('Silver'),
+        ]
+
+        self.action_priority = [
+            PriorityRule('Cellar'),
+            PriorityRule('Moat'),
+            PriorityRule('Witch'),
+        ]
+
+        self.treasure_priority = [
+            PriorityRule('Gold'),
+            PriorityRule('Silver'),
+            PriorityRule('Copper'),
+        ]
+
+        self.trash_priority = [
+            PriorityRule('Curse'),
+            PriorityRule('Estate', PriorityRule.provinces_left('>', 2)),
+            PriorityRule('Copper', PriorityRule.has_cards(['Silver', 'Gold'], 2)),
+        ]
+
+def create_championchapelwitch() -> EnhancedStrategy:
+    return ChampionChapelWitch()

--- a/reports/calibration/evolve_parts_v2/rebuild_duchy/champion_rebuild_duchy.py
+++ b/reports/calibration/evolve_parts_v2/rebuild_duchy/champion_rebuild_duchy.py
@@ -1,0 +1,39 @@
+from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule
+
+
+class ChampionRebuildDuchy(EnhancedStrategy):
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = 'gen20-5224853616'
+        self.description = "Auto-generated strategy from genetic training"
+        self.version = "1.0"
+
+        self.gain_priority = [
+            PriorityRule('Province'),
+            PriorityRule('Duchy', PriorityRule.provinces_left('<=', 6)),
+            PriorityRule('Gold'),
+            PriorityRule('Rebuild', PriorityRule.max_in_deck('Rebuild', 6)),
+            PriorityRule('Silver'),
+            PriorityRule('Moat', PriorityRule.max_in_deck('Moat', 3)),
+        ]
+
+        self.action_priority = [
+            PriorityRule('Cellar'),
+            PriorityRule('Mine'),
+            PriorityRule('Feast'),
+        ]
+
+        self.treasure_priority = [
+            PriorityRule('Gold'),
+            PriorityRule('Silver'),
+            PriorityRule('Copper'),
+        ]
+
+        self.trash_priority = [
+            PriorityRule('Curse'),
+            PriorityRule('Estate', PriorityRule.provinces_left('>', 5)),
+            PriorityRule('Copper', PriorityRule.has_cards(['Silver', 'Gold'], 3)),
+        ]
+
+def create_championrebuildduchy() -> EnhancedStrategy:
+    return ChampionRebuildDuchy()

--- a/reports/calibration/evolve_v2_widened_gates.json
+++ b/reports/calibration/evolve_v2_widened_gates.json
@@ -1,0 +1,122 @@
+[
+  {
+    "board": "smithy_bm",
+    "strategy_a": "Champion smithy_bm",
+    "strategy_b": "Double Smithy",
+    "wins_a": 100,
+    "games": 400,
+    "winrate_a": 25.0,
+    "ci_a": [
+      21.01,
+      29.47
+    ]
+  },
+  {
+    "board": "witch_bm",
+    "strategy_a": "Champion witch_bm",
+    "strategy_b": "Double Witch",
+    "wins_a": 150,
+    "games": 400,
+    "winrate_a": 37.5,
+    "ci_a": [
+      32.9,
+      42.34
+    ]
+  },
+  {
+    "board": "chapel_witch",
+    "strategy_a": "Champion chapel_witch",
+    "strategy_b": "Chapel Witch Classic",
+    "wins_a": 257,
+    "games": 400,
+    "winrate_a": 64.25,
+    "ci_a": [
+      59.44,
+      68.79
+    ]
+  },
+  {
+    "board": "gardens_workshop",
+    "strategy_a": "Champion gardens_workshop",
+    "strategy_b": "Gardens Workshop Rush",
+    "wins_a": 391,
+    "games": 400,
+    "winrate_a": 97.75,
+    "ci_a": [
+      95.78,
+      98.81
+    ]
+  },
+  {
+    "board": "wharf_bm",
+    "strategy_a": "Champion wharf_bm",
+    "strategy_b": "Big Money Wharf",
+    "wins_a": 163,
+    "games": 400,
+    "winrate_a": 40.75,
+    "ci_a": [
+      36.04,
+      45.63
+    ]
+  },
+  {
+    "board": "rebuild_duchy",
+    "strategy_a": "Champion rebuild_duchy",
+    "strategy_b": "Rebuild Rush",
+    "wins_a": 185,
+    "games": 400,
+    "winrate_a": 46.25,
+    "ci_a": [
+      41.42,
+      51.15
+    ]
+  },
+  {
+    "board": "jack_bm",
+    "strategy_a": "Champion jack_bm",
+    "strategy_b": "Double Jack",
+    "wins_a": 187,
+    "games": 400,
+    "winrate_a": 46.75,
+    "ci_a": [
+      41.91,
+      51.65
+    ]
+  },
+  {
+    "board": "mountebank_bm",
+    "strategy_a": "Champion mountebank_bm",
+    "strategy_b": "Mountebank Money",
+    "wins_a": 193,
+    "games": 400,
+    "winrate_a": 48.25,
+    "ci_a": [
+      43.39,
+      53.14
+    ]
+  },
+  {
+    "board": "courtyard_bm",
+    "strategy_a": "Champion courtyard_bm",
+    "strategy_b": "Courtyard Money",
+    "wins_a": 223,
+    "games": 400,
+    "winrate_a": 55.75,
+    "ci_a": [
+      50.85,
+      60.54
+    ]
+  },
+  {
+    "board": "first_game",
+    "strategy_a": "Champion first_game",
+    "strategy_b": "First Game Smithy Militia",
+    "wins_a": 206,
+    "games": 400,
+    "winrate_a": 51.5,
+    "ci_a": [
+      46.61,
+      56.36
+    ]
+  }
+]

--- a/reports/calibration/evolve_v2_widened_gates.md
+++ b/reports/calibration/evolve_v2_widened_gates.md
@@ -1,0 +1,16 @@
+# Calibration: evolved champion vs known-best
+
+| Board | Known best | Games | Champion win rate | 95% CI | Gap (pp) | Verdict |
+|---|---|---|---|---|---|---|
+| smithy_bm | Double Smithy | 400 | 25.0% | [21.0%, 29.5%] | 25.0 | BEHIND |
+| witch_bm | Double Witch | 400 | 37.5% | [32.9%, 42.3%] | 12.5 | BEHIND |
+| chapel_witch | Chapel Witch Classic | 400 | 64.2% | [59.4%, 68.8%] | 0.0 | BEATS KNOWN BEST |
+| gardens_workshop | Gardens Workshop Rush | 400 | 97.8% | [95.8%, 98.8%] | 0.0 | BEATS KNOWN BEST |
+| wharf_bm | Big Money Wharf | 400 | 40.8% | [36.0%, 45.6%] | 9.2 | BEHIND |
+| rebuild_duchy | Rebuild Rush | 400 | 46.2% | [41.4%, 51.1%] | 3.8 | TIED |
+| jack_bm | Double Jack | 400 | 46.8% | [41.9%, 51.6%] | 3.2 | TIED |
+| mountebank_bm | Mountebank Money | 400 | 48.2% | [43.4%, 53.1%] | 1.8 | TIED |
+| courtyard_bm | Courtyard Money | 400 | 55.8% | [50.9%, 60.5%] | 0.0 | BEATS KNOWN BEST |
+| first_game | First Game Smithy Militia | 400 | 51.5% | [46.6%, 56.4%] | 0.0 | TIED |
+
+**Mean gap: 5.5 percentage points** (0 = champions match or beat every known-best)

--- a/tests/test_structured_genome.py
+++ b/tests/test_structured_genome.py
@@ -1052,3 +1052,61 @@ class TestTrainerIntegration:
             ]
             assert len(keys) == len(set(keys)), f"duplicate rules survived: {keys}"
             assert any(r.card_name == "Province" for r in s.gain_priority)
+
+
+class TestWidenedGreeningVocabulary:
+    """The greening-gate vocabulary must include the shapes that classic
+    archetypes need: an ungated Duchy (Rebuild-style "Duchy over Gold"),
+    pile-pressure Estates, and a cap-1 early-turn opener gate for picks
+    (Chapel-style openings). See docs/calibration.md — the rebuild_duchy
+    board exposed that these were unrepresentable."""
+
+    def test_duchy_gate_can_be_ungated_but_usually_is_not(self):
+        from dominion.simulation.structured_genome import _greening_gate
+
+        rng = random.Random(0)
+        gates = [_greening_gate("Duchy", rng) for _ in range(400)]
+        ungated = sum(1 for gate in gates if gate is None)
+        assert ungated > 0, "ungated Duchy never offered — Rebuild-style rushes stay unsearchable"
+        assert ungated < 200, "ungated Duchy should stay a minority option"
+        for gate in gates:
+            if gate is not None:
+                assert "provinces_left" in gate._source
+
+    def test_estate_gate_includes_pile_pressure_option(self):
+        from dominion.simulation.structured_genome import _greening_gate
+
+        rng = random.Random(1)
+        sources = [_greening_gate("Estate", rng)._source for _ in range(400)]
+        assert any("empty_piles" in s for s in sources), "no pile-pressure Estate gate offered"
+        assert any("provinces_left" in s for s in sources)
+
+    def test_pick_gate_includes_opening_buy_shape(self):
+        import re as _re
+
+        from dominion.simulation.structured_genome import _pick_gate
+
+        rng = random.Random(2)
+        info = _info()
+        opener = _re.compile(r"max_in_deck\('Chapel', 1\).*turn_number\('<=', ([2-4])\)")
+        sources = [_pick_gate("Chapel", info, rng)._source for _ in range(400)]
+        assert any(opener.search(s) for s in sources), (
+            "no opener-shaped gate (cap 1 + turn <= 2-4) in 400 draws"
+        )
+
+    def test_mutation_can_discover_ungated_duchy(self):
+        random.seed(7)
+        info = _info()
+        strategy = random_menu_strategy(info)
+        found = False
+        for _ in range(300):
+            if not any(r.card_name == "Duchy" for r in strategy.gain_priority):
+                strategy.gain_priority.insert(
+                    1, PriorityRule("Duchy", PriorityRule.provinces_left("<=", 4))
+                )
+            strategy = normalize_menu(mutate_menu(strategy, info, rate=0.9), info)
+            duchy = next((r for r in strategy.gain_priority if r.card_name == "Duchy"), None)
+            if duchy is not None and duchy.condition is None:
+                found = True
+                break
+        assert found, "re-gate mutation never produced an ungated Duchy"


### PR DESCRIPTION
## What this is

First pipeline change measured by the calibration suite (#304). The baseline exposed a representability ceiling: the structured genome's greening block always gated Duchy behind `provinces_left <= 3..6` (at init and in the re-gate mutation), so "buy Duchy over Gold from turn 1" — the Rebuild rush — was outside the search space entirely, and no opener shape (exactly one copy, bought turns 1–3) existed for Chapel-style enablers.

Three additions to `structured_genome.py`, all reachable from both random init and the re-gate mutation:

- **Duchy**: 25% chance of no gate (rush/slog shape)
- **Estate**: 25% chance of `empty_piles >= 1-2` (three-pile pressure) instead of the count gate
- **Kingdom picks**: 15% chance of an opener gate — `max_in_deck 1 AND turn_number <= 2-4`

## Measured effect (same settings as baseline: pop 30 / gens 30 / 15 games per eval / 400 confirm games)

| Board | Baseline | Widened | Gap change |
|---|---|---|---|
| **rebuild_duchy** | 32.8% | **46.2%** | 17.2 → 3.8pp |
| **chapel_witch** | 44.0% | **64.2%** | 6.0 → 0 (beats known-best) |
| smithy_bm | 41.8% | 25.0% (re-run: 39.0%) | see below |
| witch_bm | 40.5% | 37.5% | — |
| wharf_bm | 46.5% | 40.8% | — |
| jack_bm / mountebank / courtyard / first_game / gardens | ~unchanged | ~unchanged | — |

Both representability targets closed. Attribution is partial — the rebuild champion converged on the widest Duchy gate (`provinces_left <= 6`) plus a Rebuild cap of 6 rather than the fully ungated rule, and the chapel champion won with triple-Witch money — but the rush/opener shapes are now inside the search space either way (champion genomes committed under `reports/calibration/evolve_parts_v2/`).

The BM+X money-board dips are dominated by single-run GA variance: a smithy_bm re-run on identical settings scored 39.0% vs 25.0% — a 14pp seed-to-seed swing, documented in `docs/calibration.md`. Those boards are all in the objective-failure class from #304 (fixed Big Money panel gives no gradient toward mirror-optimal BM+X); the coevolution/champion-pool outer loop is the next work item and targets them directly.

## Tests

- 4 new vocabulary tests (ungated-Duchy frequency bounds, pile-pressure Estate, opener shape, mutation-reachability of ungated Duchy)
- Full suite: 1825 passed, 5 deselected (slow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)