### PR TITLE
Add linked board and strategy HTML catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ python -m dominion.simulation.strategy_battle "Chapel Witch" "Big Money" --games
 If `--output` is omitted, reports are written to the `reports` directory with
 an auto-generated filename.
 
+## Board and strategy catalog
+
+Generate linked HTML pages for every board and registered strategy:
+
+```
+PYTHONPATH=. python scripts/render_catalog.py
+```
+
+The indexes are written to `reports/boards/index.html` and
+`reports/strategies/index.html`. Each strategy links to every board that
+contains all of its referenced cards and landscapes, and each board links
+back to those compatible strategies.
+
 ## Calibration suite
 
 `boards/calibration/` pairs boards with community-known best strategies so
@@ -45,4 +58,3 @@ PYTHONPATH=. python scripts/calibration_suite.py --mode evolve --games 400
 
 See `docs/calibration.md` for the board list, sources, and how to read the
 gap score.
-

--- a/dominion/reporting/board_pages.py
+++ b/dominion/reporting/board_pages.py
@@ -1,0 +1,121 @@
+"""Render Dominion board definitions as static HTML pages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from html import escape
+from pathlib import Path
+from typing import Iterable
+
+from dominion.boards.loader import BoardConfig, load_board
+from dominion.reporting.strategy_links import PageLink, board_display_name, board_page_path
+from dominion.reporting.strategy_pages import _page_shell
+
+
+@dataclass(frozen=True)
+class RenderedBoard:
+    display_name: str
+    page_path: Path
+    source_path: Path
+    config: BoardConfig
+    compatible_strategies: tuple[PageLink, ...] = field(default_factory=tuple)
+
+
+def collect_rendered_boards(
+    boards_root: Path = Path("boards"),
+    *,
+    paths: Iterable[Path] | None = None,
+) -> list[RenderedBoard]:
+    """Load board definitions and collect their page metadata."""
+
+    board_paths = list(paths) if paths is not None else sorted(boards_root.rglob("*.txt"))
+    return [
+        RenderedBoard(
+            display_name=board_display_name(path),
+            page_path=board_page_path(path, boards_root=boards_root),
+            source_path=path,
+            config=load_board(path),
+        )
+        for path in board_paths
+    ]
+
+
+def _value_list(values: Iterable[str]) -> str:
+    items = list(values)
+    if not items:
+        return '<span class="empty">None</span>'
+    return ", ".join(escape(item) for item in items)
+
+
+def _link_list(links: Iterable[PageLink]) -> str:
+    items = list(links)
+    if not items:
+        return '<span class="empty">None</span>'
+    return ", ".join(
+        f'<a href="{escape(link.href)}">{escape(link.label)}</a>' for link in items
+    )
+
+
+def render_board_page(item: RenderedBoard, *, index_href: str) -> str:
+    """Render a board definition and its compatible strategies."""
+
+    config = item.config
+    traits = [f"{trait} ({card})" for card, trait in sorted(config.traits.items())]
+    body = f"""
+<nav><a href="{escape(index_href)}">Board index</a></nav>
+<h1>{escape(item.display_name)}</h1>
+<p class="muted">Source: {escape(str(item.source_path))}</p>
+
+<h2>Kingdom Cards</h2>
+<ol>{''.join(f'<li>{escape(card)}</li>' for card in config.kingdom_cards)}</ol>
+
+<h2>Landscapes and Setup</h2>
+<dl class="meta">
+  <dt>Events</dt><dd>{_value_list(config.events)}</dd>
+  <dt>Projects</dt><dd>{_value_list(config.projects)}</dd>
+  <dt>Ways</dt><dd>{_value_list(config.ways)}</dd>
+  <dt>Landmarks</dt><dd>{_value_list(config.landmarks)}</dd>
+  <dt>Allies</dt><dd>{_value_list(config.allies)}</dd>
+  <dt>Traits</dt><dd>{_value_list(traits)}</dd>
+  <dt>Prophecy</dt><dd>{escape(config.prophecy) if config.prophecy else '<span class="empty">None</span>'}</dd>
+</dl>
+
+<h2>Compatible Strategies</h2>
+<p>{_link_list(item.compatible_strategies)}</p>
+"""
+    return _page_shell(f"{item.display_name} Board", body)
+
+
+def render_board_index(items: list[RenderedBoard], *, strategy_index_href: str) -> str:
+    rows = []
+    for item in items:
+        rows.append(
+            '<tr class="board-row">'
+            f'<td><a href="{escape(item.page_path.as_posix())}">{escape(item.display_name)}</a></td>'
+            f"<td>{_value_list(item.config.kingdom_cards)}</td>"
+            f"<td>{len(item.compatible_strategies)}</td>"
+            f"<td>{escape(str(item.source_path))}</td>"
+            "</tr>"
+        )
+
+    body = f"""
+<nav><a href="{escape(strategy_index_href)}">Strategy index</a></nav>
+<h1>Board Index</h1>
+<p class="muted">Generated from board definition files. Regenerate this catalog after changing a board.</p>
+<input class="search" id="board-search" type="search" placeholder="Search boards">
+<table id="board-table">
+  <tr><th>Board</th><th>Kingdom Cards</th><th>Compatible Strategies</th><th>Source</th></tr>
+  {''.join(rows)}
+</table>
+<script>
+const search = document.getElementById('board-search');
+const rows = Array.from(document.querySelectorAll('.board-row'));
+search.addEventListener('input', () => {{
+  const query = search.value.toLowerCase();
+  for (const row of rows) {{
+    row.style.display = row.innerText.toLowerCase().includes(query) ? '' : 'none';
+  }}
+}});
+</script>
+"""
+    return _page_shell("Board Index", body)

--- a/dominion/reporting/catalog_pages.py
+++ b/dominion/reporting/catalog_pages.py
@@ -47,6 +47,8 @@ def _available_board_cards(board: RenderedBoard) -> set[str]:
         additions.update(card.get_additional_non_supply_piles())
         additions.update(getattr(card, "nocturne_piles", {}))
         additions.update(getattr(card, "nocturne_trash_piles", {}))
+        if getattr(card, "uses_boons", False):
+            additions.add("Will-o'-Wisp")
 
         if isinstance(card, SplitPileMixin):
             additions.add(card.partner_card_name)

--- a/dominion/reporting/catalog_pages.py
+++ b/dominion/reporting/catalog_pages.py
@@ -35,6 +35,15 @@ def _relative_href(target: Path, source: Path) -> str:
     return Path(os.path.relpath(target, source.parent)).as_posix()
 
 
+def _canonical_card_name(name: str) -> str:
+    """Resolve a registered card alias while preserving unknown references."""
+
+    try:
+        return get_card(name).name
+    except ValueError:
+        return name
+
+
 def _available_board_cards(board: RenderedBoard) -> set[str]:
     """Expand literal board entries with deterministic setup-created cards."""
 
@@ -67,7 +76,9 @@ def _available_board_cards(board: RenderedBoard) -> set[str]:
         available.update(RUIN_VARIANT_NAMES)
     if "Knights" in available:
         available.update(KNIGHT_NAMES)
-    if any(get_card(name).cost.potions for name in board.config.kingdom_cards):
+    if "Black Market" in available or any(
+        get_card(name).cost.potions for name in board.config.kingdom_cards
+    ):
         available.add("Potion")
 
     return available
@@ -88,6 +99,9 @@ def strategy_is_compatible(strategy: RenderedStrategy, board: RenderedBoard) -> 
     }
     references = {
         **strategy.references,
+        "Kingdom Cards": [
+            _canonical_card_name(name) for name in strategy.references["Kingdom Cards"]
+        ],
         "Ways": [canonical_way_name(name) for name in strategy.references["Ways"]],
         "Landmarks": [
             canonical_landmark_name(name) for name in strategy.references["Landmarks"]

--- a/dominion/reporting/catalog_pages.py
+++ b/dominion/reporting/catalog_pages.py
@@ -1,0 +1,121 @@
+"""Build linked static pages for all registered strategies and boards."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import os
+from pathlib import Path
+from typing import Iterable
+
+from dominion.reporting.board_pages import (
+    RenderedBoard,
+    collect_rendered_boards,
+    render_board_index,
+    render_board_page,
+)
+from dominion.reporting.strategy_links import PageLink
+from dominion.reporting.strategy_pages import (
+    RenderedStrategy,
+    collect_rendered_strategies,
+    render_strategy_index,
+    render_strategy_page,
+)
+from dominion.strategy.strategy_loader import StrategyLoader
+
+
+def _relative_href(target: Path, source: Path) -> str:
+    return Path(os.path.relpath(target, source.parent)).as_posix()
+
+
+def strategy_is_compatible(strategy: RenderedStrategy, board: RenderedBoard) -> bool:
+    """Return whether all of a strategy's board references exist on a board."""
+
+    available = {
+        "Kingdom Cards": set(board.config.kingdom_cards),
+        "Events": set(board.config.events),
+        "Projects": set(board.config.projects),
+        "Ways": set(board.config.ways),
+        "Landmarks": set(board.config.landmarks),
+        "Allies": set(board.config.allies),
+    }
+    return all(set(strategy.references[label]).issubset(values) for label, values in available.items())
+
+
+def _link_catalog(
+    strategies: list[RenderedStrategy],
+    boards: list[RenderedBoard],
+) -> tuple[list[RenderedStrategy], list[RenderedBoard]]:
+    linked_strategies = []
+    for strategy in strategies:
+        source = Path("strategies") / f"{strategy.slug}.html"
+        links = tuple(
+            PageLink(
+                board.display_name,
+                _relative_href(Path("boards") / board.page_path, source),
+            )
+            for board in boards
+            if strategy_is_compatible(strategy, board)
+        )
+        linked_strategies.append(replace(strategy, compatible_boards=links))
+
+    linked_boards = []
+    for board in boards:
+        source = Path("boards") / board.page_path
+        links = tuple(
+            PageLink(
+                strategy.display_name,
+                _relative_href(Path("strategies") / f"{strategy.slug}.html", source),
+            )
+            for strategy in strategies
+            if strategy_is_compatible(strategy, board)
+        )
+        linked_boards.append(replace(board, compatible_strategies=links))
+
+    return linked_strategies, linked_boards
+
+
+def render_catalog_pages(
+    output_dir: Path = Path("reports"),
+    *,
+    boards_root: Path = Path("boards"),
+    board_paths: Iterable[Path] | None = None,
+    strategy_names: Iterable[str] | None = None,
+    loader: StrategyLoader | None = None,
+) -> list[Path]:
+    """Write reciprocal board and strategy pages and return created paths."""
+
+    strategies = collect_rendered_strategies(loader, names=strategy_names)
+    boards = collect_rendered_boards(boards_root, paths=board_paths)
+    strategies, boards = _link_catalog(strategies, boards)
+    written: list[Path] = []
+
+    strategy_dir = output_dir / "strategies"
+    board_dir = output_dir / "boards"
+    strategy_dir.mkdir(parents=True, exist_ok=True)
+    board_dir.mkdir(parents=True, exist_ok=True)
+
+    strategy_index = strategy_dir / "index.html"
+    strategy_index.write_text(
+        render_strategy_index(strategies, board_index_href="../boards/index.html"),
+        encoding="utf-8",
+    )
+    written.append(strategy_index)
+    for strategy in strategies:
+        path = strategy_dir / f"{strategy.slug}.html"
+        path.write_text(render_strategy_page(strategy), encoding="utf-8")
+        written.append(path)
+
+    board_index = board_dir / "index.html"
+    board_index.write_text(
+        render_board_index(boards, strategy_index_href="../strategies/index.html"),
+        encoding="utf-8",
+    )
+    written.append(board_index)
+    for board in boards:
+        path = board_dir / board.page_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        index_href = _relative_href(board_index.relative_to(output_dir), path.relative_to(output_dir))
+        path.write_text(render_board_page(board, index_href=index_href), encoding="utf-8")
+        written.append(path)
+
+    return written

--- a/dominion/reporting/catalog_pages.py
+++ b/dominion/reporting/catalog_pages.py
@@ -27,6 +27,7 @@ from dominion.reporting.strategy_pages import (
     render_strategy_index,
     render_strategy_page,
 )
+from dominion.simulation.strategy_battle import canonical_landmark_name, canonical_way_name
 from dominion.strategy.strategy_loader import StrategyLoader
 
 
@@ -42,7 +43,7 @@ def _available_board_cards(board: RenderedBoard) -> set[str]:
     while pending:
         name = pending.pop()
         card = get_card(name)
-        additions = set(card.get_additional_piles())
+        additions = {card.name, *card.get_additional_piles()}
         additions.update(card.get_additional_non_supply_piles())
         additions.update(getattr(card, "nocturne_piles", {}))
         additions.update(getattr(card, "nocturne_trash_piles", {}))
@@ -77,11 +78,20 @@ def strategy_is_compatible(strategy: RenderedStrategy, board: RenderedBoard) -> 
         "Kingdom Cards": _available_board_cards(board),
         "Events": set(board.config.events),
         "Projects": set(board.config.projects),
-        "Ways": set(board.config.ways),
-        "Landmarks": set(board.config.landmarks),
+        "Ways": {canonical_way_name(name) for name in board.config.ways},
+        "Landmarks": {
+            canonical_landmark_name(name) for name in board.config.landmarks
+        },
         "Allies": set(board.config.allies),
     }
-    return all(set(strategy.references[label]).issubset(values) for label, values in available.items())
+    references = {
+        **strategy.references,
+        "Ways": [canonical_way_name(name) for name in strategy.references["Ways"]],
+        "Landmarks": [
+            canonical_landmark_name(name) for name in strategy.references["Landmarks"]
+        ],
+    }
+    return all(set(references[label]).issubset(values) for label, values in available.items())
 
 
 def _link_catalog(

--- a/dominion/reporting/catalog_pages.py
+++ b/dominion/reporting/catalog_pages.py
@@ -7,6 +7,13 @@ import os
 from pathlib import Path
 from typing import Iterable
 
+from dominion.cards.allies._split_base import AlliesSplitCard
+from dominion.cards.allies.wizards import WIZARDS_PILE_ORDER, WizardsSplitCard
+from dominion.cards.dark_ages.knights import KNIGHT_NAMES
+from dominion.cards.dark_ages.ruins import RUIN_VARIANT_NAMES
+from dominion.cards.empires.castles import CASTLE_ORDER
+from dominion.cards.registry import get_card
+from dominion.cards.split_pile import SplitPileMixin
 from dominion.reporting.board_pages import (
     RenderedBoard,
     collect_rendered_boards,
@@ -27,11 +34,47 @@ def _relative_href(target: Path, source: Path) -> str:
     return Path(os.path.relpath(target, source.parent)).as_posix()
 
 
+def _available_board_cards(board: RenderedBoard) -> set[str]:
+    """Expand literal board entries with deterministic setup-created cards."""
+
+    available = set(board.config.kingdom_cards)
+    pending = list(available)
+    while pending:
+        name = pending.pop()
+        card = get_card(name)
+        additions = set(card.get_additional_piles())
+        additions.update(card.get_additional_non_supply_piles())
+        additions.update(getattr(card, "nocturne_piles", {}))
+        additions.update(getattr(card, "nocturne_trash_piles", {}))
+
+        if isinstance(card, SplitPileMixin):
+            additions.add(card.partner_card_name)
+        if isinstance(card, WizardsSplitCard):
+            additions.update(WIZARDS_PILE_ORDER)
+        if isinstance(card, AlliesSplitCard):
+            additions.update(card.pile_order)
+
+        new_names = additions - available
+        available.update(new_names)
+        pending.extend(new_names)
+
+    if available.intersection(CASTLE_ORDER):
+        available.update(CASTLE_ORDER)
+    if "Ruins" in available:
+        available.update(RUIN_VARIANT_NAMES)
+    if "Knights" in available:
+        available.update(KNIGHT_NAMES)
+    if any(get_card(name).cost.potions for name in board.config.kingdom_cards):
+        available.add("Potion")
+
+    return available
+
+
 def strategy_is_compatible(strategy: RenderedStrategy, board: RenderedBoard) -> bool:
     """Return whether all of a strategy's board references exist on a board."""
 
     available = {
-        "Kingdom Cards": set(board.config.kingdom_cards),
+        "Kingdom Cards": _available_board_cards(board),
         "Events": set(board.config.events),
         "Projects": set(board.config.projects),
         "Ways": set(board.config.ways),

--- a/dominion/reporting/strategy_links.py
+++ b/dominion/reporting/strategy_links.py
@@ -1,8 +1,18 @@
-"""Shared links for generated strategy reports."""
+"""Shared links for generated board and strategy pages."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
 import re
+
+
+@dataclass(frozen=True)
+class PageLink:
+    """A label and relative URL for another generated catalog page."""
+
+    label: str
+    href: str
 
 
 def strategy_slug(name: str) -> str:
@@ -17,3 +27,23 @@ def strategy_page_href(name: str, *, prefix: str = "strategies") -> str:
     """Return the conventional relative href for a strategy page."""
 
     return f"{prefix}/{strategy_slug(name)}.html"
+
+
+def board_display_name(path: Path) -> str:
+    """Return an audience-facing name for a board definition path."""
+
+    words = path.stem.replace("-", "_").split("_")
+    labels = ["Big Money" if word.lower() == "bm" else word.title() for word in words]
+    return " ".join(labels)
+
+
+def board_page_path(path: Path, *, boards_root: Path = Path("boards")) -> Path:
+    """Return the board page path relative to the generated board directory."""
+
+    try:
+        relative = path.relative_to(boards_root)
+    except ValueError:
+        relative = Path(path.name)
+
+    filename = strategy_slug(board_display_name(relative)) + ".html"
+    return relative.parent / filename

--- a/dominion/reporting/strategy_pages.py
+++ b/dominion/reporting/strategy_pages.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from html import escape
 import inspect
 from pathlib import Path
 from typing import Iterable
 
 from dominion.simulation.strategy_battle import StrategyBattle
-from dominion.reporting.strategy_links import strategy_page_href, strategy_slug
+from dominion.reporting.strategy_links import PageLink, strategy_slug
 from dominion.strategy.enhanced_strategy import EnhancedStrategy, PriorityRule, WayRule
 from dominion.strategy.strategy_loader import StrategyLoader
 
@@ -22,6 +22,7 @@ class RenderedStrategy:
     source_path: str
     factory_name: str
     references: dict[str, list[str]]
+    compatible_boards: tuple[PageLink, ...] = field(default_factory=tuple)
 
 
 def _condition_label(condition) -> str:
@@ -65,6 +66,15 @@ def _reference_list(values: list[str]) -> str:
     if not values:
         return "<span class=\"empty\">None</span>"
     return ", ".join(escape(value) for value in values)
+
+
+def _page_link_list(values: Iterable[PageLink]) -> str:
+    links = list(values)
+    if not links:
+        return '<span class="empty">None</span>'
+    return ", ".join(
+        f'<a href="{escape(link.href)}">{escape(link.label)}</a>' for link in links
+    )
 
 
 def _strategy_source(loader: StrategyLoader, display_name: str) -> tuple[str, str]:
@@ -201,6 +211,9 @@ def render_strategy_page(item: RenderedStrategy, *, index_href: str = "index.htm
 <h1>{escape(item.display_name)}</h1>
 <p class="muted">{escape(getattr(strategy, "description", "") or "No description.")}</p>
 
+<h2>Compatible Boards</h2>
+<p>{_page_link_list(item.compatible_boards)}</p>
+
 <dl class="meta">
   <dt>Internal Name</dt><dd>{escape(getattr(strategy, "name", ""))}</dd>
   <dt>Version</dt><dd>{escape(getattr(strategy, "version", ""))}</dd>
@@ -242,7 +255,11 @@ def render_strategy_page(item: RenderedStrategy, *, index_href: str = "index.htm
     return _page_shell(f"{item.display_name} Strategy", body)
 
 
-def render_strategy_index(items: list[RenderedStrategy]) -> str:
+def render_strategy_index(
+    items: list[RenderedStrategy],
+    *,
+    board_index_href: str | None = None,
+) -> str:
     rows = []
     for item in items:
         strategy = item.strategy
@@ -257,7 +274,13 @@ def render_strategy_index(items: list[RenderedStrategy]) -> str:
             "</tr>"
         )
 
+    board_nav = (
+        f'<nav><a href="{escape(board_index_href)}">Board index</a></nav>'
+        if board_index_href
+        else ""
+    )
     body = f"""
+{board_nav}
 <h1>Strategy Index</h1>
 <p class="muted">Generated from registered strategy objects. Regenerate this directory after changing strategy code.</p>
 <input class="search" id="strategy-search" type="search" placeholder="Search strategies">

--- a/scripts/render_catalog.py
+++ b/scripts/render_catalog.py
@@ -1,0 +1,28 @@
+"""Render linked Dominion board and strategy catalogs as static HTML."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from dominion.reporting.catalog_pages import render_catalog_pages
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render linked board and strategy HTML pages")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("reports"),
+        help="Parent directory for generated boards/ and strategies/ pages (default: reports)",
+    )
+    args = parser.parse_args()
+
+    written = render_catalog_pages(args.output_dir)
+    print(f"Wrote {len(written)} files to {args.output_dir}")
+    print(f"Board index: {args.output_dir / 'boards' / 'index.html'}")
+    print(f"Strategy index: {args.output_dir / 'strategies' / 'index.html'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_catalog_pages.py
+++ b/tests/test_catalog_pages.py
@@ -64,7 +64,7 @@ def test_compatibility_canonicalizes_card_aliases_and_parametric_landscapes():
         strategy,
         references={
             **strategy.references,
-            "Kingdom Cards": ["City Quarter", "Small Castle"],
+            "Kingdom Cards": ["City Quarter", "Council room", "Potion", "Small Castle"],
             "Ways": ["Way of the Mouse"],
             "Landmarks": ["Obelisk"],
         },
@@ -74,7 +74,7 @@ def test_compatibility_canonicalizes_card_aliases_and_parametric_landscapes():
         page_path=Path("canonical-names.html"),
         source_path=Path("boards/canonical_names.txt"),
         config=BoardConfig(
-            ["City quarter", "Castles"],
+            ["Black Market", "City quarter", "Castles", "Council Room"],
             ways=["Way of the Mouse (Native Village)"],
             landmarks=["Obelisk (Temple)"],
         ),

--- a/tests/test_catalog_pages.py
+++ b/tests/test_catalog_pages.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+from dataclasses import replace
+
+from dominion.boards.loader import BoardConfig
+from dominion.reporting.board_pages import RenderedBoard
+from dominion.reporting.catalog_pages import render_catalog_pages, strategy_is_compatible
+from dominion.reporting.strategy_links import board_display_name, board_page_path
+from dominion.reporting.strategy_pages import collect_rendered_strategies
+
+
+def _write_board(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_board_names_expand_big_money_shorthand():
+    path = Path("boards/calibration/smithy_bm.txt")
+
+    assert board_display_name(path) == "Smithy Big Money"
+    assert board_page_path(path) == Path("calibration/smithy-big-money.html")
+
+
+def test_compatibility_requires_referenced_landscapes():
+    strategy = collect_rendered_strategies(names=["Big Money"])[0]
+    strategy = replace(
+        strategy,
+        references={**strategy.references, "Events": ["Continue"]},
+    )
+    board = RenderedBoard(
+        display_name="Sample",
+        page_path=Path("sample.html"),
+        source_path=Path("boards/sample.txt"),
+        config=BoardConfig(["Village"]),
+    )
+
+    assert not strategy_is_compatible(strategy, board)
+    board.config.events.append("Continue")
+    assert strategy_is_compatible(strategy, board)
+
+
+def test_catalog_pages_link_compatible_boards_and_strategies_both_ways(tmp_path):
+    boards_root = tmp_path / "source_boards"
+    compatible = _write_board(
+        boards_root / "sample_board.txt",
+        "Village\nSmithy\nMarket\nFestival\nLaboratory\nMine\nWitch\nMoat\nWorkshop\nChapel\n",
+    )
+    incompatible = _write_board(
+        boards_root / "nested" / "other_board.txt",
+        "Cellar\nMarket\nMerchant\nMilitia\nMine\nMoat\nRemodel\nSmithy\nVillage\nWorkshop\n",
+    )
+    output = tmp_path / "site"
+
+    written = render_catalog_pages(
+        output,
+        boards_root=boards_root,
+        board_paths=[compatible, incompatible],
+        strategy_names=["Big Money", "Village Smithy Lab"],
+    )
+
+    assert {path.relative_to(output).as_posix() for path in written} == {
+        "boards/index.html",
+        "boards/nested/other-board.html",
+        "boards/sample-board.html",
+        "strategies/big-money.html",
+        "strategies/index.html",
+        "strategies/village-smithy-lab.html",
+    }
+
+    strategy = (output / "strategies" / "village-smithy-lab.html").read_text()
+    compatible_board = (output / "boards" / "sample-board.html").read_text()
+    incompatible_board = (output / "boards" / "nested" / "other-board.html").read_text()
+
+    assert 'href="../boards/sample-board.html">Sample Board</a>' in strategy
+    assert "Other Board" not in strategy
+    assert 'href="../strategies/village-smithy-lab.html">Village Smithy Lab</a>' in compatible_board
+    assert "Village Smithy Lab" not in incompatible_board
+    assert 'href="../../strategies/big-money.html">Big Money</a>' in incompatible_board
+
+
+def test_catalog_indexes_link_to_each_other(tmp_path):
+    boards_root = tmp_path / "boards"
+    board = _write_board(boards_root / "simple.txt", "Village\n")
+    output = tmp_path / "site"
+
+    render_catalog_pages(
+        output,
+        boards_root=boards_root,
+        board_paths=[board],
+        strategy_names=["Big Money"],
+    )
+
+    strategy_index = (output / "strategies" / "index.html").read_text()
+    board_index = (output / "boards" / "index.html").read_text()
+    assert 'href="../boards/index.html">Board index</a>' in strategy_index
+    assert 'href="../strategies/index.html">Strategy index</a>' in board_index

--- a/tests/test_catalog_pages.py
+++ b/tests/test_catalog_pages.py
@@ -58,6 +58,31 @@ def test_compatibility_includes_setup_created_piles():
     assert strategy_is_compatible(strategy, board)
 
 
+def test_compatibility_canonicalizes_card_aliases_and_parametric_landscapes():
+    strategy = collect_rendered_strategies(names=["Big Money"])[0]
+    strategy = replace(
+        strategy,
+        references={
+            **strategy.references,
+            "Kingdom Cards": ["City Quarter", "Small Castle"],
+            "Ways": ["Way of the Mouse"],
+            "Landmarks": ["Obelisk"],
+        },
+    )
+    board = RenderedBoard(
+        display_name="Canonical Names",
+        page_path=Path("canonical-names.html"),
+        source_path=Path("boards/canonical_names.txt"),
+        config=BoardConfig(
+            ["City quarter", "Castles"],
+            ways=["Way of the Mouse (Native Village)"],
+            landmarks=["Obelisk (Temple)"],
+        ),
+    )
+
+    assert strategy_is_compatible(strategy, board)
+
+
 def test_catalog_pages_link_compatible_boards_and_strategies_both_ways(tmp_path):
     boards_root = tmp_path / "source_boards"
     compatible = _write_board(

--- a/tests/test_catalog_pages.py
+++ b/tests/test_catalog_pages.py
@@ -45,14 +45,14 @@ def test_compatibility_includes_setup_created_piles():
         strategy,
         references={
             **strategy.references,
-            "Kingdom Cards": ["Bustling Village", "Horse", "Lich"],
+            "Kingdom Cards": ["Bustling Village", "Horse", "Lich", "Will-o'-Wisp"],
         },
     )
     board = RenderedBoard(
         display_name="Setup Piles",
         page_path=Path("setup-piles.html"),
         source_path=Path("boards/setup_piles.txt"),
-        config=BoardConfig(["Settlers", "Student", "Supplies"]),
+        config=BoardConfig(["Settlers", "Student", "Supplies", "Tracker"]),
     )
 
     assert strategy_is_compatible(strategy, board)

--- a/tests/test_catalog_pages.py
+++ b/tests/test_catalog_pages.py
@@ -39,6 +39,25 @@ def test_compatibility_requires_referenced_landscapes():
     assert strategy_is_compatible(strategy, board)
 
 
+def test_compatibility_includes_setup_created_piles():
+    strategy = collect_rendered_strategies(names=["Big Money"])[0]
+    strategy = replace(
+        strategy,
+        references={
+            **strategy.references,
+            "Kingdom Cards": ["Bustling Village", "Horse", "Lich"],
+        },
+    )
+    board = RenderedBoard(
+        display_name="Setup Piles",
+        page_path=Path("setup-piles.html"),
+        source_path=Path("boards/setup_piles.txt"),
+        config=BoardConfig(["Settlers", "Student", "Supplies"]),
+    )
+
+    assert strategy_is_compatible(strategy, board)
+
+
 def test_catalog_pages_link_compatible_boards_and_strategies_both_ways(tmp_path):
     boards_root = tmp_path / "source_boards"
     compatible = _write_board(


### PR DESCRIPTION
## Summary

Adds a static HTML catalog that discovers every board and registered strategy, computes compatibility across kingdom cards and landscapes, and creates reciprocal links between their pages.
Board and strategy indexes now link to each other, including descriptive board filenames and support for nested board directories.
The README documents the new `scripts/render_catalog.py` command.

## Validation

`python -m ruff check dominion/reporting/board_pages.py dominion/reporting/catalog_pages.py dominion/reporting/strategy_links.py dominion/reporting/strategy_pages.py scripts/render_catalog.py tests/test_catalog_pages.py` and `pytest -q` (1,836 tests) passed; the added catalog tests also pass after the final test update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable HTML catalogs for Dominion boards and registered strategies.
  * Added individual board pages displaying cards, board metadata, and compatible strategies.
  * Strategy pages now show compatible boards, with reciprocal links between catalogs.
  * Added a command-line tool to generate catalog files under `reports/`.

* **Documentation**
  * Documented catalog generation and clarified calibration-suite guidance, including gap-score interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->